### PR TITLE
fix(ci): resolve BUG-064 and BUG-065 broken community workflow actions

### DIFF
--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Welcome first-time contributors
         uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             👋 Welcome to AI Memory Module! Thanks for opening your first issue.
 
             A maintainer will review your issue soon. In the meantime:
@@ -31,7 +31,7 @@ jobs:
             - Star the repo if you find it useful ⭐
 
             Please ensure you've filled out the issue template completely to help us assist you faster.
-          pr-message: |
+          pr_message: |
             🎉 Thanks for your first pull request to AI Memory Module!
 
             A maintainer will review your PR soon. Here's what happens next:
@@ -93,7 +93,7 @@ jobs:
     if: github.event_name == 'pull_request_target'
     steps:
       - name: Verify issue link
-        uses: hattan/verify-linked-issue-action@v1.2.0
+        uses: hattan/verify-linked-issue-action@bea64a33e19f9de109c88aee8ef5c1657f09b049 # v1.1.5 pinned to SHA
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary
- **BUG-064**: Pin `hattan/verify-linked-issue-action` to commit SHA `bea64a33` (v1.1.5). The referenced `v1.2.0` tag never existed — latest upstream tag is v1.1.5. Pinned to SHA for supply chain security.
- **BUG-065**: Update `actions/first-interaction@v3` input names from kebab-case to snake_case (`issue-message` → `issue_message`, `pr-message` → `pr_message`) per v3 breaking change.

Both bugs were pre-existing (discovered during PR #31 CI runs, reported 2026-02-10). Neither blocked merging but caused cosmetic CI failures on every PR.

## Test plan
- [ ] Open a test PR and verify "Check Linked Issue" job no longer fails at setup
- [ ] Verify "Welcome New Contributors" job no longer fails on input name mismatch
- [ ] Confirm no other community workflow jobs are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)