### PR TITLE
fix(github-sync): normalize repo IDs and add legacy recovery tools

### DIFF
--- a/_ai-memory/skills/aim-github-sync/SKILL.md
+++ b/_ai-memory/skills/aim-github-sync/SKILL.md
@@ -8,9 +8,9 @@ allowed-tools: Bash
 
 Synchronize GitHub issues, pull requests, commits, and CI results from the configured repository into the AI Memory discussions collection.
 
-## Usage
+## Activation
 
-```bash
+```text
 # Incremental sync (default) - only fetch updated items
 /aim-github-sync
 
@@ -82,25 +82,11 @@ for k, v in d.items():
 
 ### Status Mode
 
-Reads `.audit/state/github_sync_state.json` and displays last sync timestamps per type:
+Uses the real CLI status path, which resolves canonical and legacy state-file
+locations for the configured repo:
 
 ```bash
-cd "$AI_MEMORY_INSTALL_DIR" || { echo "Error: AI_MEMORY_INSTALL_DIR is not set or directory does not exist"; exit 1; }
-python3 -c "
-import json
-from pathlib import Path
-state_file = Path('.audit/state/github_sync_state.json')
-if not state_file.exists():
-    print('No sync state found. Run /aim-github-sync first.')
-else:
-    state = json.loads(state_file.read_text())
-    print('## GitHub Sync Status')
-    print('')
-    for type_key, info in state.items():
-        last = info.get('last_synced', 'never')
-        count = info.get('last_count', 0)
-        print(f'  {type_key}: last synced {last} ({count} items)')
-"
+"${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh" "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/github_sync.py" --status
 ```
 
 ## Guard
@@ -118,7 +104,7 @@ Error: GitHub sync is not enabled. Set GITHUB_SYNC_ENABLED=true and configure GI
 - **Deduplication**: SHA256 content hashing prevents duplicate storage (SPEC-005)
 - **Versioning**: Changed content creates new version, marks old as superseded
 - **Collection**: discussions (shared with conversation data, filtered by source="github")
-- **Tenant Isolation**: group_id = owner/repo
+- **Tenant Isolation**: `group_id` uses normalized lowercase `owner/repo`
 - **Sync Priority**: PRs (+ reviews + diffs) -> Issues (+ comments) -> Commits -> CI Results
 
 ## Notes
@@ -126,6 +112,24 @@ Error: GitHub sync is not enabled. Set GITHUB_SYNC_ENABLED=true and configure GI
 - Requires GitHub personal access token (classic or fine-grained)
 - Sync logs written to `~/.ai-memory/logs/activity.log`
 - First full sync can take several minutes for large repositories
-- Incremental sync timestamps stored per type in `github_sync_state.json`
+- Incremental sync timestamps stored per repo in `~/.ai-memory/github-state/github_sync_state_<owner__repo>.json`
 - Reviews and diffs are synced as part of PR sync
 - Issue comments are synced as part of issue sync
+
+## Legacy ID Audit and Migration
+
+If GitHub data exists but status or project scoping looks inconsistent, audit for
+legacy mixed IDs first:
+
+```bash
+"${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh" audit_group_ids.py
+```
+
+If the report shows legacy aliases, review the plan and then apply the migration:
+
+```bash
+"${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh" migrate_group_ids.py
+"${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh" migrate_group_ids.py --apply
+```
+
+When the install still has a flattened legacy `AI_MEMORY_PROJECT_ID`, the apply step also updates that env entry to the canonical slash-form repo ID.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -477,10 +477,16 @@ services:
       # PLAN-009: Tell discover_projects() where the mounted projects.d lives.
       # Path.home() inside the container is not /config, so we must be explicit.
       - AI_MEMORY_PROJECTS_DIR=/config/projects.d
+      # Explicit install_dir so config.install_dir resolves to a writable path.
+      # Required because container HOME=/ makes ~/.ai-memory expand to /.ai-memory
+      # (read-only root fs). Matches other services (hook-capture, classifier-worker).
+      - AI_MEMORY_INSTALL_DIR=/app
     volumes:
-      # Persist sync state across container restarts
-      # Engine writes to Path.cwd()/.audit/state/ = /app/.audit/state/
-      - ${AI_MEMORY_INSTALL_DIR:-${HOME}/.ai-memory}/github-state:/app/.audit/state
+      # Persist sync state across container restarts.
+      # Engine (post-PR #111) writes to config.install_dir/github-state/ = /app/github-state/
+      # Legacy path /app/.audit/state/ is still checked by github_state_candidates() for
+      # auto-migration of pre-#111 state files.
+      - ${AI_MEMORY_INSTALL_DIR:-${HOME}/.ai-memory}/github-state:/app/github-state
       # Freshness scanner log directory (read_only: true blocks writes otherwise)
       - ${AI_MEMORY_INSTALL_DIR:-${HOME}/.ai-memory}/github-state/logs:/app/.audit/logs
       # Multi-project config directory (PLAN-009)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -491,6 +491,12 @@ services:
       - ${AI_MEMORY_INSTALL_DIR:-${HOME}/.ai-memory}/github-state/logs:/app/.audit/logs
       # Multi-project config directory (PLAN-009)
       - ${AI_MEMORY_INSTALL_DIR:-${HOME}/.ai-memory}/config/projects.d:/config/projects.d:ro
+      # Shared trace buffer for Langfuse span emission. github-sync writes
+      # storage-layer traces here; without this mount writes fail with
+      # read-only filesystem (container image fs at /app is not writable).
+      # Matches classifier-worker pattern (L387). Caught during Phase B
+      # live verification after the install_dir fix unmasked the issue.
+      - ${AI_MEMORY_INSTALL_DIR:-${HOME}/.ai-memory}/trace_buffer:/app/trace_buffer
     depends_on:
       qdrant:
         condition: service_healthy

--- a/docs/GITHUB-INTEGRATION.md
+++ b/docs/GITHUB-INTEGRATION.md
@@ -120,7 +120,7 @@ The installer validates the token against the GitHub API before proceeding. On s
 
 ### Incremental Sync (Default)
 
-After the first run, only new or updated items are fetched. The last-seen state is tracked per content type in `~/.ai-memory/.audit/state/github_sync_state.json`:
+After the first run, only new or updated items are fetched. The last-seen state is tracked per repo in `~/.ai-memory/github-state/github_sync_state_<owner__repo>.json`:
 
 ```json
 {
@@ -164,7 +164,7 @@ Qdrant (github collection for all GitHub-synced data)
     │   memory_type tag for filtering
     │
     ▼
-State Persistence (~/.ai-memory/.audit/state/github_sync_state.json)
+State Persistence (~/.ai-memory/github-state/github_sync_state_<owner__repo>.json)
 ```
 
 ### Rate Limiting
@@ -228,6 +228,28 @@ Manually trigger a sync outside the scheduled interval.
 # Check sync status
 /aim-github-sync --status
 ```
+
+### Legacy ID Audit and Migration
+
+Older installs could end up with mixed identifiers, most commonly:
+
+- GitHub data stored under mixed-case `owner/repo`
+- project-scoped data stored under flattened `owner-repo`
+
+Audit the current install before migrating:
+
+```bash
+"${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh" audit_group_ids.py
+```
+
+If legacy aliases are reported, review the dry run and then apply:
+
+```bash
+"${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh" migrate_group_ids.py
+"${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh" migrate_group_ids.py --apply
+```
+
+The migration rewrites detected legacy aliases to their canonical IDs, updates `AI_MEMORY_PROJECT_ID` in the installed `docker/.env` when it still matches a legacy flattened alias, and moves any legacy GitHub sync state file into the shared `github-state/` location when needed.
 
 ### Session Start Enrichment
 
@@ -293,8 +315,8 @@ tail -f ~/.ai-memory/logs/github_sync.log
 To force a full re-sync from scratch:
 
 ```bash
-# Remove state file and run full sync
-rm ~/.ai-memory/.audit/state/github_sync_state.json
+# Remove the canonical per-repo state file and run full sync
+rm ~/.ai-memory/github-state/github_sync_state_owner__repo.json
 /aim-github-sync --full
 ```
 

--- a/scripts/github_sync.py
+++ b/scripts/github_sync.py
@@ -39,7 +39,11 @@ def show_status(config):
         config.github_repo,
         cwd=Path.cwd(),
     )
-    state_dir = sync_state_file.parent if sync_state_file else Path(config.install_dir) / "github-state"
+    state_dir = (
+        sync_state_file.parent
+        if sync_state_file
+        else Path(config.install_dir) / "github-state"
+    )
 
     print("GitHub Sync Status")
     print("=" * 50)

--- a/scripts/github_sync.py
+++ b/scripts/github_sync.py
@@ -24,8 +24,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 from memory.config import get_config
 from memory.connectors.github.client import GitHubClient
 from memory.connectors.github.code_sync import CodeBlobSync
-from memory.connectors.github.sync import GitHubSyncEngine
 from memory.connectors.github.paths import resolve_github_state_file
+from memory.connectors.github.sync import GitHubSyncEngine
 
 
 def show_status(config):

--- a/scripts/github_sync.py
+++ b/scripts/github_sync.py
@@ -25,18 +25,21 @@ from memory.config import get_config
 from memory.connectors.github.client import GitHubClient
 from memory.connectors.github.code_sync import CodeBlobSync
 from memory.connectors.github.sync import GitHubSyncEngine
+from memory.connectors.github.paths import resolve_github_state_file
 
 
 def show_status(config):
     """Display sync status from state files.
 
-    State file location: Path.cwd() / ".audit" / "state" / "github_sync_state.json"
-    Note: config.project_path does NOT exist — engine uses Path.cwd() fallback.
-    CodeBlobSync does not maintain state files (stateless per run).
+    State file location: canonical install dir github-state, with legacy fallbacks.
+    CodeBlobSync does not maintain separate state files (stateless per run).
     """
-    # Mirror sync.py state resolution: Path.cwd() / ".audit" / "state"
-    state_dir = Path.cwd() / ".audit" / "state"
-    sync_state_file = state_dir / "github_sync_state.json"
+    sync_state_file = resolve_github_state_file(
+        config.install_dir,
+        config.github_repo,
+        cwd=Path.cwd(),
+    )
+    state_dir = sync_state_file.parent if sync_state_file else Path(config.install_dir) / "github-state"
 
     print("GitHub Sync Status")
     print("=" * 50)
@@ -47,7 +50,7 @@ def show_status(config):
     print(f"State directory: {state_dir}")
     print()
 
-    if sync_state_file.exists():
+    if sync_state_file and sync_state_file.exists():
         state = json.loads(sync_state_file.read_text())
         print("Last sync state (issues/PRs/commits/CI):")
         for key, val in state.items():

--- a/scripts/memory/audit_group_ids.py
+++ b/scripts/memory/audit_group_ids.py
@@ -14,6 +14,8 @@ INSTALL_DIR = os.environ.get(
 )
 sys.path.insert(0, os.path.join(INSTALL_DIR, "src"))
 
+from qdrant_client import models
+
 from memory.config import (
     COLLECTION_CODE_PATTERNS,
     COLLECTION_DISCUSSIONS,
@@ -24,7 +26,6 @@ from memory.connectors.github.paths import github_state_file, resolve_github_sta
 from memory.group_ids import build_group_id_plan
 from memory.project import normalize_project_name
 from memory.qdrant_client import get_qdrant_client
-from qdrant_client import models
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/memory/audit_group_ids.py
+++ b/scripts/memory/audit_group_ids.py
@@ -9,7 +9,9 @@ import os
 import sys
 from pathlib import Path
 
-INSTALL_DIR = os.environ.get("AI_MEMORY_INSTALL_DIR", os.path.expanduser("~/.ai-memory"))
+INSTALL_DIR = os.environ.get(
+    "AI_MEMORY_INSTALL_DIR", os.path.expanduser("~/.ai-memory")
+)
 sys.path.insert(0, os.path.join(INSTALL_DIR, "src"))
 
 from memory.config import (
@@ -44,7 +46,11 @@ def count_group_id(client, collection: str, group_id: str) -> int:
     result = client.count(
         collection_name=collection,
         count_filter=models.Filter(
-            must=[models.FieldCondition(key="group_id", match=models.MatchValue(value=group_id))]
+            must=[
+                models.FieldCondition(
+                    key="group_id", match=models.MatchValue(value=group_id)
+                )
+            ]
         ),
         exact=True,
     )
@@ -78,7 +84,9 @@ def main() -> int:
     ]:
         print(f"- {collection}: {count_group_id(client, collection, gid)}")
     if plan.github_group_id:
-        print(f"- {COLLECTION_GITHUB}: {count_group_id(client, COLLECTION_GITHUB, plan.github_group_id)}")
+        print(
+            f"- {COLLECTION_GITHUB}: {count_group_id(client, COLLECTION_GITHUB, plan.github_group_id)}"
+        )
     print("")
 
     legacy_rows: list[tuple[str, str, dict[str, int]]] = []
@@ -87,13 +95,17 @@ def main() -> int:
             COLLECTION_CODE_PATTERNS: count_group_id(
                 client, COLLECTION_CODE_PATTERNS, legacy_id
             ),
-            COLLECTION_DISCUSSIONS: count_group_id(client, COLLECTION_DISCUSSIONS, legacy_id),
+            COLLECTION_DISCUSSIONS: count_group_id(
+                client, COLLECTION_DISCUSSIONS, legacy_id
+            ),
         }
         if any(counts.values()):
             legacy_rows.append(("project", legacy_id, counts))
 
     for legacy_id in plan.legacy_github_ids:
-        counts = {COLLECTION_GITHUB: count_group_id(client, COLLECTION_GITHUB, legacy_id)}
+        counts = {
+            COLLECTION_GITHUB: count_group_id(client, COLLECTION_GITHUB, legacy_id)
+        }
         if any(counts.values()):
             legacy_rows.append(("github", legacy_id, counts))
 

--- a/scripts/memory/audit_group_ids.py
+++ b/scripts/memory/audit_group_ids.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# ruff: noqa: E402
+"""Audit canonical and legacy group IDs for the current project."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+INSTALL_DIR = os.environ.get("AI_MEMORY_INSTALL_DIR", os.path.expanduser("~/.ai-memory"))
+sys.path.insert(0, os.path.join(INSTALL_DIR, "src"))
+
+from memory.config import (
+    COLLECTION_CODE_PATTERNS,
+    COLLECTION_DISCUSSIONS,
+    COLLECTION_GITHUB,
+    get_config,
+)
+from memory.connectors.github.paths import github_state_file, resolve_github_state_file
+from memory.group_ids import build_group_id_plan
+from memory.project import normalize_project_name
+from memory.qdrant_client import get_qdrant_client
+from qdrant_client import models
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Audit legacy ai-memory group IDs")
+    parser.add_argument(
+        "--cwd",
+        default=os.getcwd(),
+        help="Project directory to audit (default: current working directory)",
+    )
+    parser.add_argument(
+        "--fail-on-legacy",
+        action="store_true",
+        help="Exit non-zero when legacy aliases are detected",
+    )
+    return parser.parse_args()
+
+
+def count_group_id(client, collection: str, group_id: str) -> int:
+    result = client.count(
+        collection_name=collection,
+        count_filter=models.Filter(
+            must=[models.FieldCondition(key="group_id", match=models.MatchValue(value=group_id))]
+        ),
+        exact=True,
+    )
+    return result.count
+
+
+def main() -> int:
+    args = parse_args()
+    config = get_config()
+    client = get_qdrant_client(config)
+
+    project_id = os.environ.get("AI_MEMORY_PROJECT_ID")
+    plan = build_group_id_plan(
+        project_id=project_id,
+        github_repo=config.github_repo,
+        cwd=args.cwd,
+    )
+
+    print("## Group ID Audit")
+    print("")
+    print(f"Project cwd: {Path(args.cwd).resolve()}")
+    print(f"Canonical project group_id: {plan.project_group_id}")
+    print(f"Canonical GitHub group_id: {plan.github_group_id or 'not configured'}")
+    print(f"Unified IDs: {'yes' if plan.unified else 'no'}")
+    print("")
+
+    print("### Canonical Counts")
+    for collection, gid in [
+        (COLLECTION_CODE_PATTERNS, plan.project_group_id),
+        (COLLECTION_DISCUSSIONS, plan.project_group_id),
+    ]:
+        print(f"- {collection}: {count_group_id(client, collection, gid)}")
+    if plan.github_group_id:
+        print(f"- {COLLECTION_GITHUB}: {count_group_id(client, COLLECTION_GITHUB, plan.github_group_id)}")
+    print("")
+
+    legacy_rows: list[tuple[str, str, dict[str, int]]] = []
+    for legacy_id in plan.legacy_project_ids:
+        counts = {
+            COLLECTION_CODE_PATTERNS: count_group_id(
+                client, COLLECTION_CODE_PATTERNS, legacy_id
+            ),
+            COLLECTION_DISCUSSIONS: count_group_id(client, COLLECTION_DISCUSSIONS, legacy_id),
+        }
+        if any(counts.values()):
+            legacy_rows.append(("project", legacy_id, counts))
+
+    for legacy_id in plan.legacy_github_ids:
+        counts = {COLLECTION_GITHUB: count_group_id(client, COLLECTION_GITHUB, legacy_id)}
+        if any(counts.values()):
+            legacy_rows.append(("github", legacy_id, counts))
+
+    legacy_found = bool(legacy_rows)
+    if legacy_rows:
+        print("### Legacy Aliases")
+        for kind, legacy_id, counts in legacy_rows:
+            print(f"- {kind} alias `{legacy_id}`")
+            for collection, count in counts.items():
+                print(f"  {collection}: {count}")
+        print("")
+
+    if (
+        project_id
+        and project_id.strip() != plan.project_group_id
+        and normalize_project_name(project_id) in plan.legacy_project_ids
+    ):
+        legacy_found = True
+        print("### Config Mismatch")
+        print(f"- AI_MEMORY_PROJECT_ID: {project_id} -> {plan.project_group_id}")
+        print("")
+
+    state_path = (
+        resolve_github_state_file(config.install_dir, config.github_repo, cwd=args.cwd)
+        if config.github_repo
+        else None
+    )
+    expected_state = (
+        github_state_file(config.install_dir, config.github_repo)
+        if config.github_repo
+        else None
+    )
+    print("### GitHub Sync State")
+    print(f"- canonical path: {expected_state or 'not configured'}")
+    print(f"- active path: {state_path or 'not found'}")
+
+    if state_path and expected_state and Path(state_path) != expected_state:
+        legacy_found = True
+
+    if legacy_found and args.fail_on_legacy:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/memory/migrate_group_ids.py
+++ b/scripts/memory/migrate_group_ids.py
@@ -9,7 +9,9 @@ import os
 import sys
 from pathlib import Path
 
-INSTALL_DIR = os.environ.get("AI_MEMORY_INSTALL_DIR", os.path.expanduser("~/.ai-memory"))
+INSTALL_DIR = os.environ.get(
+    "AI_MEMORY_INSTALL_DIR", os.path.expanduser("~/.ai-memory")
+)
 sys.path.insert(0, os.path.join(INSTALL_DIR, "src"))
 
 from memory.config import (
@@ -82,14 +84,20 @@ def count_group_id(client, collection: str, group_id: str) -> int:
     result = client.count(
         collection_name=collection,
         count_filter=models.Filter(
-            must=[models.FieldCondition(key="group_id", match=models.MatchValue(value=group_id))]
+            must=[
+                models.FieldCondition(
+                    key="group_id", match=models.MatchValue(value=group_id)
+                )
+            ]
         ),
         exact=True,
     )
     return result.count
 
 
-def migrate_state_file(config, github_repo: str | None, cwd: str) -> tuple[str, str] | None:
+def migrate_state_file(
+    config, github_repo: str | None, cwd: str
+) -> tuple[str, str] | None:
     if not github_repo:
         return None
 
@@ -104,7 +112,9 @@ def migrate_state_file(config, github_repo: str | None, cwd: str) -> tuple[str, 
     return None
 
 
-def planned_state_file_move(config, github_repo: str | None, cwd: str) -> tuple[str, str] | None:
+def planned_state_file_move(
+    config, github_repo: str | None, cwd: str
+) -> tuple[str, str] | None:
     if not github_repo:
         return None
 
@@ -178,7 +188,9 @@ def main() -> int:
         for legacy_id in plan.legacy_github_ids:
             count = count_group_id(client, COLLECTION_GITHUB, legacy_id)
             if count:
-                actions.append((COLLECTION_GITHUB, legacy_id, plan.github_group_id, count))
+                actions.append(
+                    (COLLECTION_GITHUB, legacy_id, plan.github_group_id, count)
+                )
 
     print("## Group ID Migration")
     print("")
@@ -195,10 +207,18 @@ def main() -> int:
             else planned_state_file_move(config, config.github_repo, args.cwd)
         )
         if project_id_update:
-            label = "Updated AI_MEMORY_PROJECT_ID" if args.apply else "Planned AI_MEMORY_PROJECT_ID update"
+            label = (
+                "Updated AI_MEMORY_PROJECT_ID"
+                if args.apply
+                else "Planned AI_MEMORY_PROJECT_ID update"
+            )
             if args.apply:
-                apply_project_id_update(env_file, project_id_update[1], project_id_update[2])
-            print(f"{label}: {project_id_update[1]} -> {project_id_update[2]} ({project_id_update[0]})")
+                apply_project_id_update(
+                    env_file, project_id_update[1], project_id_update[2]
+                )
+            print(
+                f"{label}: {project_id_update[1]} -> {project_id_update[2]} ({project_id_update[0]})"
+            )
         if state_move:
             label = "Moved state file" if args.apply else "Planned state file move"
             print(f"{label}: {state_move[0]} -> {state_move[1]}")
@@ -234,7 +254,9 @@ def main() -> int:
         print("State file: no move required")
 
     if project_id_update:
-        if apply_project_id_update(env_file, project_id_update[1], project_id_update[2]):
+        if apply_project_id_update(
+            env_file, project_id_update[1], project_id_update[2]
+        ):
             print(
                 f"Updated AI_MEMORY_PROJECT_ID: {project_id_update[1]} -> {project_id_update[2]} ({project_id_update[0]})"
             )

--- a/scripts/memory/migrate_group_ids.py
+++ b/scripts/memory/migrate_group_ids.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+# ruff: noqa: E402
+"""Migrate legacy ai-memory group IDs to canonical values."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+INSTALL_DIR = os.environ.get("AI_MEMORY_INSTALL_DIR", os.path.expanduser("~/.ai-memory"))
+sys.path.insert(0, os.path.join(INSTALL_DIR, "src"))
+
+from memory.config import (
+    COLLECTION_CODE_PATTERNS,
+    COLLECTION_DISCUSSIONS,
+    COLLECTION_GITHUB,
+    get_config,
+)
+from memory.connectors.github.paths import github_state_file, github_state_candidates
+from memory.group_ids import build_group_id_plan
+from memory.project import normalize_project_name
+from memory.qdrant_client import get_qdrant_client
+from qdrant_client import models
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Migrate legacy ai-memory group IDs")
+    parser.add_argument(
+        "--cwd",
+        default=os.getcwd(),
+        help="Project directory to migrate (default: current working directory)",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply the migration. Without this flag, only print the plan.",
+    )
+    return parser.parse_args()
+
+
+def migrate_collection(
+    client,
+    *,
+    collection: str,
+    old_group_id: str,
+    new_group_id: str,
+) -> int:
+    total = 0
+    offset = None
+    while True:
+        points, next_offset = client.scroll(
+            collection_name=collection,
+            scroll_filter=models.Filter(
+                must=[
+                    models.FieldCondition(
+                        key="group_id", match=models.MatchValue(value=old_group_id)
+                    )
+                ]
+            ),
+            limit=1000,
+            offset=offset,
+            with_payload=False,
+            with_vectors=False,
+        )
+        ids = [point.id for point in points]
+        if ids:
+            client.set_payload(
+                collection_name=collection,
+                payload={"group_id": new_group_id},
+                points=ids,
+                wait=True,
+            )
+            total += len(ids)
+        if next_offset is None:
+            return total
+        offset = next_offset
+
+
+def count_group_id(client, collection: str, group_id: str) -> int:
+    result = client.count(
+        collection_name=collection,
+        count_filter=models.Filter(
+            must=[models.FieldCondition(key="group_id", match=models.MatchValue(value=group_id))]
+        ),
+        exact=True,
+    )
+    return result.count
+
+
+def migrate_state_file(config, github_repo: str | None, cwd: str) -> tuple[str, str] | None:
+    if not github_repo:
+        return None
+
+    canonical_path = github_state_file(config.install_dir, github_repo)
+    for candidate in github_state_candidates(config.install_dir, github_repo, cwd=cwd):
+        if candidate == canonical_path or not candidate.exists():
+            continue
+        canonical_path.parent.mkdir(parents=True, exist_ok=True)
+        if not canonical_path.exists():
+            candidate.replace(canonical_path)
+            return (str(candidate), str(canonical_path))
+    return None
+
+
+def planned_state_file_move(config, github_repo: str | None, cwd: str) -> tuple[str, str] | None:
+    if not github_repo:
+        return None
+
+    canonical_path = github_state_file(config.install_dir, github_repo)
+    for candidate in github_state_candidates(config.install_dir, github_repo, cwd=cwd):
+        if candidate == canonical_path or not candidate.exists():
+            continue
+        if not canonical_path.exists():
+            return (str(candidate), str(canonical_path))
+    return None
+
+
+def configured_env_file(config) -> Path:
+    return Path(config.install_dir) / "docker" / ".env"
+
+
+def planned_project_id_update(
+    env_file: Path, project_id: str | None, plan
+) -> tuple[str, str, str] | None:
+    if (
+        not project_id
+        or project_id.strip() == plan.project_group_id
+        or normalize_project_name(project_id) not in plan.legacy_project_ids
+    ):
+        return None
+    if not env_file.exists():
+        return None
+    return (str(env_file), project_id, plan.project_group_id)
+
+
+def apply_project_id_update(env_file: Path, old_value: str, new_value: str) -> bool:
+    if not env_file.exists():
+        return False
+
+    lines = env_file.read_text().splitlines()
+    updated = False
+    for index, line in enumerate(lines):
+        if line.startswith("AI_MEMORY_PROJECT_ID="):
+            lines[index] = f"AI_MEMORY_PROJECT_ID={new_value}"
+            updated = True
+            break
+
+    if not updated:
+        return False
+
+    env_file.write_text("\n".join(lines) + "\n")
+    return True
+
+
+def main() -> int:
+    args = parse_args()
+    config = get_config()
+    client = get_qdrant_client(config)
+
+    project_id = os.environ.get("AI_MEMORY_PROJECT_ID")
+    plan = build_group_id_plan(
+        project_id=project_id,
+        github_repo=config.github_repo,
+        cwd=args.cwd,
+    )
+    env_file = configured_env_file(config)
+    project_id_update = planned_project_id_update(env_file, project_id, plan)
+
+    actions: list[tuple[str, str, str, int]] = []
+    for legacy_id in plan.legacy_project_ids:
+        for collection in (COLLECTION_CODE_PATTERNS, COLLECTION_DISCUSSIONS):
+            count = count_group_id(client, collection, legacy_id)
+            if count:
+                actions.append((collection, legacy_id, plan.project_group_id, count))
+    if plan.github_group_id:
+        for legacy_id in plan.legacy_github_ids:
+            count = count_group_id(client, COLLECTION_GITHUB, legacy_id)
+            if count:
+                actions.append((COLLECTION_GITHUB, legacy_id, plan.github_group_id, count))
+
+    print("## Group ID Migration")
+    print("")
+    print(f"Apply mode: {'yes' if args.apply else 'no (dry run)'}")
+    print(f"Project canonical group_id: {plan.project_group_id}")
+    print(f"GitHub canonical group_id: {plan.github_group_id or 'not configured'}")
+    print("")
+
+    if not actions:
+        print("No legacy Qdrant aliases detected.")
+        state_move = (
+            migrate_state_file(config, config.github_repo, args.cwd)
+            if args.apply
+            else planned_state_file_move(config, config.github_repo, args.cwd)
+        )
+        if project_id_update:
+            label = "Updated AI_MEMORY_PROJECT_ID" if args.apply else "Planned AI_MEMORY_PROJECT_ID update"
+            if args.apply:
+                apply_project_id_update(env_file, project_id_update[1], project_id_update[2])
+            print(f"{label}: {project_id_update[1]} -> {project_id_update[2]} ({project_id_update[0]})")
+        if state_move:
+            label = "Moved state file" if args.apply else "Planned state file move"
+            print(f"{label}: {state_move[0]} -> {state_move[1]}")
+        return 0
+
+    for collection, old_id, new_id, count in actions:
+        print(f"- {collection}: {old_id} -> {new_id} ({count} record(s))")
+
+    state_move = planned_state_file_move(config, config.github_repo, args.cwd)
+    if state_move:
+        print(f"- state file: {state_move[0]} -> {state_move[1]}")
+    if project_id_update:
+        print(
+            f"- AI_MEMORY_PROJECT_ID: {project_id_update[1]} -> {project_id_update[2]} ({project_id_update[0]})"
+        )
+
+    if not args.apply:
+        print("")
+        print("Re-run with --apply to execute the migration.")
+        return 0
+
+    print("")
+    for collection, old_id, new_id, _count in actions:
+        migrated = migrate_collection(
+            client, collection=collection, old_group_id=old_id, new_group_id=new_id
+        )
+        print(f"{collection}: migrated {migrated} record(s) from {old_id} to {new_id}")
+
+    state_move = migrate_state_file(config, config.github_repo, args.cwd)
+    if state_move:
+        print(f"Moved state file: {state_move[0]} -> {state_move[1]}")
+    else:
+        print("State file: no move required")
+
+    if project_id_update:
+        if apply_project_id_update(env_file, project_id_update[1], project_id_update[2]):
+            print(
+                f"Updated AI_MEMORY_PROJECT_ID: {project_id_update[1]} -> {project_id_update[2]} ({project_id_update[0]})"
+            )
+        else:
+            print("AI_MEMORY_PROJECT_ID: no update applied")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/memory/migrate_group_ids.py
+++ b/scripts/memory/migrate_group_ids.py
@@ -14,17 +14,18 @@ INSTALL_DIR = os.environ.get(
 )
 sys.path.insert(0, os.path.join(INSTALL_DIR, "src"))
 
+from qdrant_client import models
+
 from memory.config import (
     COLLECTION_CODE_PATTERNS,
     COLLECTION_DISCUSSIONS,
     COLLECTION_GITHUB,
     get_config,
 )
-from memory.connectors.github.paths import github_state_file, github_state_candidates
+from memory.connectors.github.paths import github_state_candidates, github_state_file
 from memory.group_ids import build_group_id_plan
 from memory.project import normalize_project_name
 from memory.qdrant_client import get_qdrant_client
-from qdrant_client import models
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/memory/run-with-env.sh
+++ b/scripts/memory/run-with-env.sh
@@ -1,23 +1,49 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run memory scripts with proper environment variables
 # Usage: ./scripts/memory/run-with-env.sh <script.py> [args...]
 #
 # This script loads QDRANT_API_KEY and other env vars from docker/.env
 # Required because scripts run on HOST need the same auth as Docker services
+# and must use the ai-memory virtualenv rather than the shell's default python3.
+
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-ENV_FILE="$PROJECT_ROOT/docker/.env"
+INSTALL_DIR="${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}"
+ENV_FILE="${AI_MEMORY_ENV_FILE:-$INSTALL_DIR/docker/.env}"
+PY_BIN="$INSTALL_DIR/.venv/bin/python"
+
+export QDRANT_HOST="${QDRANT_HOST:-localhost}"
+export QDRANT_PORT="${QDRANT_PORT:-26350}"
+export QDRANT_GRPC_PORT="${QDRANT_GRPC_PORT:-26351}"
+export EMBEDDING_HOST="${EMBEDDING_HOST:-127.0.0.1}"
+export QDRANT_USE_HTTPS="${QDRANT_USE_HTTPS:-false}"
+
+load_env_var() {
+    local name="$1"
+    local value
+    value="$(awk -F= -v key="$name" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' "$ENV_FILE")"
+    if [ -n "$value" ]; then
+        export "$name=$value"
+    fi
+}
 
 # Load environment variables from docker/.env
 if [ -f "$ENV_FILE" ]; then
-    # Export only specific variables needed by scripts (avoid polluting env)
-    export QDRANT_API_KEY=$(grep '^QDRANT_API_KEY=' "$ENV_FILE" | cut -d= -f2)
-    export QDRANT_HOST="${QDRANT_HOST:-localhost}"
-    export QDRANT_PORT="${QDRANT_PORT:-26350}"
-    export QDRANT_USE_HTTPS="${QDRANT_USE_HTTPS:-false}"
+    load_env_var "QDRANT_API_KEY"
+    load_env_var "AI_MEMORY_PROJECT_ID"
+    load_env_var "GITHUB_REPO"
+    load_env_var "GITHUB_BRANCH"
+    load_env_var "GITHUB_TOKEN"
+    load_env_var "GITHUB_SYNC_ENABLED"
 else
     echo "Warning: $ENV_FILE not found, running without API key"
+fi
+
+if [ ! -x "$PY_BIN" ]; then
+    echo "Error: ai-memory venv python not found: $PY_BIN"
+    echo "Run $INSTALL_DIR/scripts/install.sh or set AI_MEMORY_INSTALL_DIR correctly."
+    exit 1
 fi
 
 # Check if script argument provided
@@ -25,7 +51,10 @@ if [ -z "$1" ]; then
     echo "Usage: $0 <script.py> [args...]"
     echo ""
     echo "Available scripts:"
-    ls -1 "$SCRIPT_DIR"/*.py 2>/dev/null | xargs -n1 basename
+    for script_path in "$SCRIPT_DIR"/*.py; do
+        [ -e "$script_path" ] || continue
+        basename "$script_path"
+    done
     exit 1
 fi
 
@@ -43,4 +72,4 @@ if [ ! -f "$SCRIPT" ]; then
 fi
 
 # Run the script
-exec python3 "$SCRIPT" "$@"
+exec "$PY_BIN" "$SCRIPT" "$@"

--- a/scripts/memory/run-with-env.sh
+++ b/scripts/memory/run-with-env.sh
@@ -23,6 +23,9 @@ load_env_var() {
     local name="$1"
     local value
     value="$(awk -F= -v key="$name" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' "$ENV_FILE")"
+    # Strip surrounding double or single quotes (common in .env files)
+    value="${value%\"}"; value="${value#\"}"
+    value="${value%\'}"; value="${value#\'}"
     if [ -n "$value" ]; then
         export "$name=$value"
     fi

--- a/src/memory/config.py
+++ b/src/memory/config.py
@@ -910,9 +910,22 @@ class MemoryConfig(BaseSettings):
     )
     @classmethod
     def expand_user_paths(cls, v):
-        """Expand ~ and environment variables in paths."""
+        """Expand ~ and environment variables in paths.
+
+        Guard: if ``~/.ai-memory`` expansion produces ``/.ai-memory`` (HOME=/
+        edge case common in minimal Docker images), raise ValueError. Silent
+        fallback would mask runtime read-only-filesystem errors downstream.
+        Containers should set AI_MEMORY_INSTALL_DIR explicitly.
+        """
         if isinstance(v, str):
-            return Path(os.path.expanduser(os.path.expandvars(v)))
+            v = Path(os.path.expanduser(os.path.expandvars(v)))
+        if isinstance(v, Path) and str(v) == "/.ai-memory":
+            raise ValueError(
+                "install_dir resolved to '/.ai-memory' which indicates HOME=/ "
+                "(common in minimal Docker images where HOME is unset). Set "
+                "AI_MEMORY_INSTALL_DIR explicitly to a writable path "
+                "(e.g. '/app') in the container environment."
+            )
         return v
 
     @field_validator("queue_dir", mode="before")

--- a/src/memory/config.py
+++ b/src/memory/config.py
@@ -280,6 +280,7 @@ class MemoryConfig(BaseSettings):
     install_dir: Path = Field(
         default_factory=lambda: Path.home() / ".ai-memory",
         description="Installation directory",
+        validation_alias=AliasChoices("AI_MEMORY_INSTALL_DIR", "INSTALL_DIR"),
     )
 
     queue_path: Path = Field(

--- a/src/memory/connectors/github/code_sync.py
+++ b/src/memory/connectors/github/code_sync.py
@@ -70,6 +70,7 @@ from memory.connectors.github.client import (
     GitHubClient,
     GitHubClientError,
 )
+from memory.connectors.github.paths import normalize_github_repo_slug
 from memory.connectors.github.schema import (
     GITHUB_COLLECTION,
     SOURCE_AUTHORITY_MAP,
@@ -77,6 +78,7 @@ from memory.connectors.github.schema import (
 )
 from memory.extraction import detect_language as detect_language_from_path
 from memory.models import MemoryType
+from memory.project import normalize_org_repo_slug
 from memory.qdrant_client import get_qdrant_client
 from memory.storage import MemoryStorage
 
@@ -716,9 +718,11 @@ class CodeBlobSync:
         )
         self.storage = MemoryStorage(self.config)
         self.qdrant = get_qdrant_client(self.config)
-        self._group_id = repo or self.config.github_repo
-        if not self._group_id:
+        self._repo = repo or self.config.github_repo
+        if not self._repo:
             raise ValueError("No repo specified and GITHUB_REPO not configured")
+        self._repo = normalize_org_repo_slug(self._repo) or self._repo
+        self._group_id = normalize_github_repo_slug(self._repo)
         self._branch = branch or self.config.github_branch
         self._exclude_patterns = _parse_filter_patterns(
             getattr(self.config, "github_code_blob_exclude", "") or "",

--- a/src/memory/connectors/github/paths.py
+++ b/src/memory/connectors/github/paths.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 from memory.project import normalize_project_name

--- a/src/memory/connectors/github/paths.py
+++ b/src/memory/connectors/github/paths.py
@@ -1,0 +1,83 @@
+"""Helpers for GitHub repo normalization and sync state paths."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from memory.project import normalize_project_name
+
+
+def normalize_github_repo_slug(repo: str) -> str:
+    """Normalize a GitHub owner/repo slug for stable tenant IDs.
+
+    Examples:
+        "Axonify/thunderball" -> "axonify/thunderball"
+        "owner/repo" -> "owner/repo"
+        "owner repo" -> "owner-repo"
+    """
+    raw = (repo or "").strip()
+    if not raw:
+        return normalize_project_name(raw)
+
+    if "/" not in raw:
+        return normalize_project_name(raw)
+
+    owner, name = raw.split("/", 1)
+    owner_norm = normalize_project_name(owner)
+    repo_norm = normalize_project_name(name)
+    return f"{owner_norm}/{repo_norm}"
+
+
+def github_state_dir(install_dir: str | Path) -> Path:
+    """Canonical shared directory for GitHub sync state files."""
+    return Path(install_dir) / "github-state"
+
+
+def github_state_file(install_dir: str | Path, repo: str) -> Path:
+    """Canonical state file path for a GitHub repo."""
+    repo_safe = normalize_github_repo_slug(repo).replace("/", "__")
+    return github_state_dir(install_dir) / f"github_sync_state_{repo_safe}.json"
+
+
+def github_state_candidates(
+    install_dir: str | Path,
+    repo: str,
+    cwd: str | Path | None = None,
+) -> list[Path]:
+    """Return canonical and legacy candidate paths for GitHub sync state."""
+    candidates: list[Path] = []
+
+    def add(path: Path) -> None:
+        if path not in candidates:
+            candidates.append(path)
+
+    install_root = Path(install_dir)
+    cwd_path = Path(cwd) if cwd is not None else Path.cwd()
+
+    normalized_safe = normalize_github_repo_slug(repo).replace("/", "__")
+    raw_safe = (repo or "").replace("/", "__")
+
+    add(github_state_dir(install_root) / f"github_sync_state_{normalized_safe}.json")
+    if raw_safe and raw_safe != normalized_safe:
+        add(github_state_dir(install_root) / f"github_sync_state_{raw_safe}.json")
+
+    for base in [install_root / ".audit" / "state", cwd_path / ".audit" / "state"]:
+        add(base / f"github_sync_state_{normalized_safe}.json")
+        if raw_safe and raw_safe != normalized_safe:
+            add(base / f"github_sync_state_{raw_safe}.json")
+        add(base / "github_sync_state.json")
+
+    return candidates
+
+
+def resolve_github_state_file(
+    install_dir: str | Path,
+    repo: str,
+    cwd: str | Path | None = None,
+) -> Path | None:
+    """Return the first existing GitHub sync state file candidate."""
+    for candidate in github_state_candidates(install_dir, repo, cwd=cwd):
+        if candidate.exists():
+            return candidate
+    return None

--- a/src/memory/connectors/github/sync.py
+++ b/src/memory/connectors/github/sync.py
@@ -74,15 +74,15 @@ from memory.connectors.github.composer import (
     compose_pr_diff,
     compose_pr_review,
 )
-from memory.connectors.github.schema import (
-    GITHUB_COLLECTION,
-    SOURCE_AUTHORITY_MAP,
-    compute_content_hash,
-)
 from memory.connectors.github.paths import (
     github_state_candidates,
     github_state_file,
     normalize_github_repo_slug,
+)
+from memory.connectors.github.schema import (
+    GITHUB_COLLECTION,
+    SOURCE_AUTHORITY_MAP,
+    compute_content_hash,
 )
 from memory.models import MemoryType
 from memory.project import normalize_org_repo_slug

--- a/src/memory/connectors/github/sync.py
+++ b/src/memory/connectors/github/sync.py
@@ -79,7 +79,13 @@ from memory.connectors.github.schema import (
     SOURCE_AUTHORITY_MAP,
     compute_content_hash,
 )
+from memory.connectors.github.paths import (
+    github_state_candidates,
+    github_state_file,
+    normalize_github_repo_slug,
+)
 from memory.models import MemoryType
+from memory.project import normalize_org_repo_slug
 from memory.qdrant_client import get_qdrant_client
 from memory.storage import MemoryStorage
 
@@ -185,6 +191,7 @@ class GitHubSyncEngine:
         self.repo = repo or self.config.github_repo
         if not self.repo:
             raise ValueError("No repo specified and GITHUB_REPO not configured")
+        self.repo = normalize_org_repo_slug(self.repo) or self.repo
         self._branch = branch or self.config.github_branch
 
         # BUG-245: per-project token > global token
@@ -194,7 +201,7 @@ class GitHubSyncEngine:
             repo=self.repo,
         )
         self.storage = MemoryStorage(self.config)
-        self._group_id = self.repo  # owner/repo as tenant ID
+        self._group_id = normalize_github_repo_slug(self.repo)
         self.qdrant = get_qdrant_client(self.config)
 
         # SEC-2: Security scanner for GitHub content before storage
@@ -215,10 +222,8 @@ class GitHubSyncEngine:
             else Path.cwd()
         )
         self._project_root = project_root
-        self._state_dir = project_root / ".audit" / "state"
-        # Use __ for / to avoid collisions with - (which stays as-is)
-        repo_safe = self.repo.replace("/", "__")
-        self._state_file = self._state_dir / f"github_sync_state_{repo_safe}.json"
+        self._state_file = github_state_file(self.config.install_dir, self.repo)
+        self._state_dir = self._state_file.parent
 
     @observe(name="github_sync")
     async def sync(self, mode: str = "incremental") -> SyncResult:
@@ -1015,11 +1020,25 @@ class GitHubSyncEngine:
             State dict with per-type last_synced timestamps.
             Empty dict if file doesn't exist.
         """
-        if self._state_file.exists():
+        for candidate in github_state_candidates(
+            self.config.install_dir,
+            self.repo,
+            cwd=self._project_root,
+        ):
+            if not candidate.exists():
+                continue
             try:
-                return json.loads(self._state_file.read_text(encoding="utf-8"))
+                state = json.loads(candidate.read_text(encoding="utf-8"))
+                if candidate != self._state_file:
+                    logger.info(
+                        "Loaded GitHub sync state from legacy path %s; migrating to %s",
+                        candidate,
+                        self._state_file,
+                    )
+                    self._save_state(state)
+                return state
             except (json.JSONDecodeError, OSError) as e:
-                logger.warning("Failed to load sync state: %s", e)
+                logger.warning("Failed to load sync state from %s: %s", candidate, e)
         return {}
 
     def _save_state(self, state: dict[str, Any]) -> None:

--- a/src/memory/group_ids.py
+++ b/src/memory/group_ids.py
@@ -1,0 +1,68 @@
+"""Helpers for canonical and legacy group ID handling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from memory.connectors.github.paths import normalize_github_repo_slug
+from memory.project import detect_project, normalize_org_repo_slug, normalize_project_name
+
+
+@dataclass(frozen=True)
+class GroupIdPlan:
+    """Canonical group IDs plus detected legacy aliases."""
+
+    project_group_id: str
+    github_group_id: str | None
+    legacy_project_ids: tuple[str, ...]
+    legacy_github_ids: tuple[str, ...]
+
+    @property
+    def unified(self) -> bool:
+        return self.github_group_id is None or self.project_group_id == self.github_group_id
+
+
+def build_group_id_plan(
+    *,
+    project_id: str | None,
+    github_repo: str | None,
+    cwd: str | None = None,
+) -> GroupIdPlan:
+    """Build canonical and legacy ID sets for the current install."""
+    canonical_github_id = normalize_github_repo_slug(github_repo) if github_repo else None
+    normalized_project_slug = normalize_org_repo_slug(project_id)
+    normalized_project_name = normalize_project_name(project_id or "")
+    canonical_project_id = (
+        normalized_project_slug or normalized_project_name or detect_project(cwd)
+    )
+
+    if (
+        project_id
+        and canonical_github_id
+        and normalized_project_name == normalize_project_name(canonical_github_id)
+    ):
+        canonical_project_id = canonical_github_id
+
+    if canonical_project_id == "unnamed-project":
+        canonical_project_id = detect_project(cwd)
+
+    legacy_project_ids: list[str] = []
+    if project_id and "/" in project_id:
+        flattened = normalize_project_name(project_id)
+        if flattened and flattened != canonical_project_id:
+            legacy_project_ids.append(flattened)
+    elif project_id and normalized_project_name != canonical_project_id:
+        legacy_project_ids.append(normalized_project_name)
+
+    legacy_github_ids: list[str] = []
+    if github_repo:
+        raw_repo = github_repo.strip()
+        if raw_repo and canonical_github_id and raw_repo != canonical_github_id:
+            legacy_github_ids.append(raw_repo)
+
+    return GroupIdPlan(
+        project_group_id=canonical_project_id,
+        github_group_id=canonical_github_id,
+        legacy_project_ids=tuple(dict.fromkeys(legacy_project_ids)),
+        legacy_github_ids=tuple(dict.fromkeys(legacy_github_ids)),
+    )

--- a/src/memory/group_ids.py
+++ b/src/memory/group_ids.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from memory.connectors.github.paths import normalize_github_repo_slug
-from memory.project import detect_project, normalize_org_repo_slug, normalize_project_name
+from memory.project import (
+    detect_project,
+    normalize_org_repo_slug,
+    normalize_project_name,
+)
 
 
 @dataclass(frozen=True)
@@ -19,7 +23,10 @@ class GroupIdPlan:
 
     @property
     def unified(self) -> bool:
-        return self.github_group_id is None or self.project_group_id == self.github_group_id
+        return (
+            self.github_group_id is None
+            or self.project_group_id == self.github_group_id
+        )
 
 
 def build_group_id_plan(
@@ -29,7 +36,9 @@ def build_group_id_plan(
     cwd: str | None = None,
 ) -> GroupIdPlan:
     """Build canonical and legacy ID sets for the current install."""
-    canonical_github_id = normalize_github_repo_slug(github_repo) if github_repo else None
+    canonical_github_id = (
+        normalize_github_repo_slug(github_repo) if github_repo else None
+    )
     normalized_project_slug = normalize_org_repo_slug(project_id)
     normalized_project_name = normalize_project_name(project_id or "")
     canonical_project_id = (

--- a/src/memory/project.py
+++ b/src/memory/project.py
@@ -84,6 +84,20 @@ def normalize_project_name(name: str) -> str:
     return normalized
 
 
+def normalize_org_repo_slug(org_repo: str) -> str | None:
+    """Normalize an owner/repo slug while preserving the slash separator."""
+    raw = (org_repo or "").strip()
+    if not raw or "/" not in raw:
+        return None
+
+    owner, repo = raw.split("/", 1)
+    owner_norm = normalize_project_name(owner)
+    repo_norm = normalize_project_name(repo)
+    if not owner_norm or not repo_norm:
+        return None
+    return f"{owner_norm}/{repo_norm}"
+
+
 def get_project_hash(cwd: str) -> str:
     """Get a hash-based project identifier for uniqueness.
 
@@ -142,12 +156,12 @@ def _extract_org_repo_from_remote_url(remote_url: str) -> str | None:
     # SSH format: git@host:org/repo.git or git@host:org/repo
     ssh_match = re.match(r"^git@[^:]+:([^/]+/[^/]+?)(?:\.git)?$", remote_url)
     if ssh_match:
-        return ssh_match.group(1).lower()
+        return normalize_org_repo_slug(ssh_match.group(1))
 
     # HTTPS format: https://host/org/repo.git or https://host/org/repo
     https_match = re.match(r"^https?://[^/]+/([^/]+/[^/]+?)(?:\.git)?$", remote_url)
     if https_match:
-        return https_match.group(1).lower()
+        return normalize_org_repo_slug(https_match.group(1))
 
     return None
 
@@ -250,7 +264,9 @@ def detect_project(cwd: str | None = None) -> str:
     # 1. Check environment variable first (highest priority)
     env_project = os.getenv("AI_MEMORY_PROJECT_ID")
     if env_project and env_project.strip():
-        project_name = normalize_project_name(env_project)
+        project_name = normalize_org_repo_slug(env_project) or normalize_project_name(
+            env_project
+        )
         logger.debug(
             "using_env_project",
             extra={"env_value": env_project, "normalized": project_name},

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -321,6 +321,43 @@ LOG_LEVEL=WARNING
         assert "$HOME" not in str(config.queue_path)
         assert config.queue_path == Path.home() / ".custom-queue" / "queue.jsonl"
 
+    def test_install_dir_rejects_root_filesystem_expansion(self, monkeypatch):
+        """Regression: HOME=/ causes ~/.ai-memory to expand to /.ai-memory.
+
+        In minimal Docker images where HOME is unset (defaults to /), the
+        default_factory Path.home() / ".ai-memory" resolves to /.ai-memory
+        which is on the read-only root filesystem. The validator must raise
+        rather than silently producing this path, because downstream code
+        (github-sync container in particular) would then hit OSError on every
+        write to install_dir, silently dropping data.
+
+        Caught during Phase B live verification of PR #111 — the bug surfaced
+        only when the github-sync Docker container was rebuilt with PR #111's
+        new code that writes state to install_dir/github-state/ instead of
+        project_root/.audit/state/.
+        """
+        import pytest
+
+        reset_config()
+        monkeypatch.setenv("HOME", "/")
+        # Default_factory will now produce Path("/.ai-memory")
+        with pytest.raises(ValueError, match="/\\.ai-memory"):
+            get_config()
+
+    def test_install_dir_explicit_env_var_bypasses_root_guard(self, monkeypatch):
+        """HOME=/ with explicit AI_MEMORY_INSTALL_DIR works correctly.
+
+        The container fix is to set AI_MEMORY_INSTALL_DIR=/app explicitly.
+        This test verifies that explicit override works even when HOME=/.
+        """
+        reset_config()
+        monkeypatch.setenv("HOME", "/")
+        monkeypatch.setenv("INSTALL_DIR", "/app")
+
+        config = get_config()
+
+        assert config.install_dir == Path("/app")
+
     def test_frozen_config_immutable(self):
         """AC 7.4.1: Frozen config (immutable after creation) with frozen=True."""
         reset_config()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -302,7 +302,10 @@ LOG_LEVEL=WARNING
     def test_path_expansion_tilde(self, monkeypatch):
         """AC 7.4.1: Path expansion for ~ with field_validator."""
         reset_config()
-        monkeypatch.setenv("INSTALL_DIR", "~/custom-ai-memory")
+        # AI_MEMORY_INSTALL_DIR is the canonical alias (higher precedence than
+        # INSTALL_DIR); the test conftest pre-sets it at module load so we must
+        # override it explicitly to exercise tilde expansion.
+        monkeypatch.setenv("AI_MEMORY_INSTALL_DIR", "~/custom-ai-memory")
 
         config = get_config()
 
@@ -340,18 +343,40 @@ LOG_LEVEL=WARNING
 
         reset_config()
         monkeypatch.setenv("HOME", "/")
-        # Default_factory will now produce Path("/.ai-memory")
+        # Delete conftest-set AI_MEMORY_INSTALL_DIR and any INSTALL_DIR to force
+        # the default_factory path (which should then produce /.ai-memory and raise).
+        monkeypatch.delenv("AI_MEMORY_INSTALL_DIR", raising=False)
+        monkeypatch.delenv("INSTALL_DIR", raising=False)
         with pytest.raises(ValueError, match="/\\.ai-memory"):
             get_config()
 
     def test_install_dir_explicit_env_var_bypasses_root_guard(self, monkeypatch):
         """HOME=/ with explicit AI_MEMORY_INSTALL_DIR works correctly.
 
-        The container fix is to set AI_MEMORY_INSTALL_DIR=/app explicitly.
-        This test verifies that explicit override works even when HOME=/.
+        The container fix sets AI_MEMORY_INSTALL_DIR=/app in docker-compose
+        for the github-sync service. This test verifies:
+        1. AliasChoices accepts AI_MEMORY_INSTALL_DIR as the env var name
+        2. The explicit override bypasses the HOME=/ validator guard
         """
         reset_config()
         monkeypatch.setenv("HOME", "/")
+        monkeypatch.setenv("AI_MEMORY_INSTALL_DIR", "/app")
+
+        config = get_config()
+
+        assert config.install_dir == Path("/app")
+
+    def test_install_dir_accepts_legacy_install_dir_alias(self, monkeypatch):
+        """AliasChoices also accepts INSTALL_DIR (legacy field-name form).
+
+        Backward-compat: existing code or configs that set INSTALL_DIR
+        (the field name) rather than AI_MEMORY_INSTALL_DIR (canonical)
+        must keep working. The first-priority alias AI_MEMORY_INSTALL_DIR
+        must be absent for the fallback to apply.
+        """
+        reset_config()
+        monkeypatch.setenv("HOME", "/")
+        monkeypatch.delenv("AI_MEMORY_INSTALL_DIR", raising=False)
         monkeypatch.setenv("INSTALL_DIR", "/app")
 
         config = get_config()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -31,6 +31,7 @@ def _get_real_project_module():
 _project_module = _get_real_project_module()
 detect_project = _project_module.detect_project
 normalize_project_name = _project_module.normalize_project_name
+normalize_org_repo_slug = _project_module.normalize_org_repo_slug
 get_project_hash = _project_module.get_project_hash
 
 
@@ -103,6 +104,16 @@ class TestNormalizeProjectName:
     def test_normalization_examples(self, input_name, expected):
         """Test various normalization examples."""
         assert normalize_project_name(input_name) == expected
+
+
+class TestNormalizeOrgRepoSlug:
+    """Test owner/repo normalization while preserving slash separators."""
+
+    def test_preserves_separator_and_normalizes_case(self):
+        assert normalize_org_repo_slug("Axonify/Thunderball") == "axonify/thunderball"
+
+    def test_returns_none_for_non_repo_values(self):
+        assert normalize_org_repo_slug("plain-project") is None
 
 
 class TestGetProjectHash:
@@ -213,6 +224,14 @@ class TestDetectProject:
         monkeypatch.chdir(project_dir)
         result = detect_project()
         assert result == "current-project"
+
+    def test_env_project_id_owner_repo_preserves_slash(self, monkeypatch, tmp_path):
+        """AI_MEMORY_PROJECT_ID keeps owner/repo form when provided."""
+        project_dir = tmp_path / "ignored-project"
+        project_dir.mkdir()
+        monkeypatch.setenv("AI_MEMORY_PROJECT_ID", "Axonify/Thunderball")
+        result = detect_project(str(project_dir))
+        assert result == "axonify/thunderball"
 
     def test_symlink_resolution(self, tmp_path):
         """Symlinks should be resolved to actual path."""

--- a/tests/unit/connectors/github/test_code_sync.py
+++ b/tests/unit/connectors/github/test_code_sync.py
@@ -303,6 +303,28 @@ def _make_initialized_sync(
         return CodeBlobSync(mock_client, config)
 
 
+def test_init_normalizes_group_id():
+    mock_client = MagicMock()
+    config = MagicMock()
+    config.github_branch = "main"
+    config.github_repo = "Axonify/Thunderball"
+    config.github_code_blob_max_size = 102400
+    config.github_code_blob_include = ""
+    config.github_code_blob_include_max_size = 512000
+    config.github_code_blob_exclude = ""
+    config.github_sync_circuit_breaker_threshold = 5
+    config.github_sync_circuit_breaker_reset = 60
+    config.security_scanning_enabled = False
+
+    with (
+        patch("memory.connectors.github.code_sync.MemoryStorage"),
+        patch("memory.connectors.github.code_sync.get_qdrant_client"),
+    ):
+        sync = CodeBlobSync(mock_client, config)
+
+    assert sync._group_id == "axonify/thunderball"
+
+
 def _make_filtering_sync():
     sync = CodeBlobSync.__new__(CodeBlobSync)
     sync.config = MagicMock()

--- a/tests/unit/connectors/github/test_github_sync_cli.py
+++ b/tests/unit/connectors/github/test_github_sync_cli.py
@@ -13,10 +13,10 @@ def test_status_display(capsys, tmp_path, monkeypatch):
     """--status shows sync state."""
     monkeypatch.chdir(tmp_path)
 
-    # Create state directory and file
-    state_dir = tmp_path / ".audit" / "state"
+    # Create canonical install state directory and file
+    state_dir = tmp_path / "github-state"
     state_dir.mkdir(parents=True)
-    state_file = state_dir / "github_sync_state.json"
+    state_file = state_dir / "github_sync_state_owner__repo.json"
     state_file.write_text(
         '{"issues": {"last_synced": "2026-01-01T00:00:00", "last_count": 42}}'
     )
@@ -26,6 +26,7 @@ def test_status_display(capsys, tmp_path, monkeypatch):
     config.github_repo = "owner/repo"
     config.github_code_blob_enabled = True
     config.github_sync_interval = 1800
+    config.install_dir = tmp_path
 
     with (
         patch.object(github_sync, "get_config", return_value=config),

--- a/tests/unit/connectors/github/test_sync.py
+++ b/tests/unit/connectors/github/test_sync.py
@@ -65,7 +65,9 @@ def test_engine_group_id_from_repo():
     ):
         engine = GitHubSyncEngine(config)
     assert engine._group_id == "owner/repo"
-    assert engine._state_file == Path("/tmp/install/github-state/github_sync_state_owner__repo.json")
+    assert engine._state_file == Path(
+        "/tmp/install/github-state/github_sync_state_owner__repo.json"
+    )
 
 
 # -- Helper: create a mock engine for async tests ---------------------

--- a/tests/unit/connectors/github/test_sync.py
+++ b/tests/unit/connectors/github/test_sync.py
@@ -56,14 +56,16 @@ def test_engine_group_id_from_repo():
     """group_id derived from github_repo config."""
     config = MagicMock()
     config.github_sync_enabled = True
-    config.github_repo = "owner/repo"
+    config.github_repo = "Owner/Repo"
     config.github_token.get_secret_value.return_value = "ghp_test"
+    config.install_dir = Path("/tmp/install")
     with (
         patch("memory.connectors.github.sync.MemoryStorage"),
         patch("memory.connectors.github.sync.get_qdrant_client"),
     ):
         engine = GitHubSyncEngine(config)
     assert engine._group_id == "owner/repo"
+    assert engine._state_file == Path("/tmp/install/github-state/github_sync_state_owner__repo.json")
 
 
 # -- Helper: create a mock engine for async tests ---------------------
@@ -77,6 +79,7 @@ def _make_engine():
     config.github_token.get_secret_value.return_value = "ghp_test"
     config.github_branch = "main"
     config.project_path = "/tmp/test-project"
+    config.install_dir = Path("/tmp/install")
     config.get_qdrant_url.return_value = "http://localhost:6333"
     config.qdrant_api_key = None
     with (
@@ -972,6 +975,26 @@ def test_load_state_corrupt_file(tmp_path):
 
     state = engine._load_state()
     assert state == {}
+
+
+def test_load_state_reads_legacy_repo_case_file(tmp_path):
+    """Legacy mixed-case install state file is loaded and migrated."""
+    engine = _make_engine()
+    engine.config.install_dir = tmp_path
+    engine.repo = "Owner/Repo"
+    engine._state_dir = tmp_path / "github-state"
+    engine._state_file = engine._state_dir / "github_sync_state_owner__repo.json"
+
+    legacy_state_file = engine._state_dir / "github_sync_state_Owner__Repo.json"
+    legacy_state_file.parent.mkdir(parents=True, exist_ok=True)
+    legacy_state_file.write_text(
+        '{"issues": {"last_synced": "2026-01-01T00:00:00", "last_count": 7}}',
+        encoding="utf-8",
+    )
+
+    state = engine._load_state()
+    assert state["issues"]["last_count"] == 7
+    assert engine._state_file.exists()
 
 
 def test_save_state_atomic_write(tmp_path):

--- a/tests/unit/test_group_ids.py
+++ b/tests/unit/test_group_ids.py
@@ -1,0 +1,42 @@
+"""Tests for canonical and legacy group ID planning."""
+
+from memory.group_ids import build_group_id_plan
+
+
+def test_build_group_id_plan_for_owner_repo_project():
+    plan = build_group_id_plan(
+        project_id="Axonify/Thunderball",
+        github_repo="Axonify/Thunderball",
+    )
+
+    assert plan.project_group_id == "axonify/thunderball"
+    assert plan.github_group_id == "axonify/thunderball"
+    assert plan.unified is True
+    assert plan.legacy_project_ids == ("axonify-thunderball",)
+    assert plan.legacy_github_ids == ("Axonify/Thunderball",)
+
+
+def test_build_group_id_plan_respects_intentional_split_ids():
+    plan = build_group_id_plan(
+        project_id="custom-project",
+        github_repo="Owner/Repo",
+    )
+
+    assert plan.project_group_id == "custom-project"
+    assert plan.github_group_id == "owner/repo"
+    assert plan.unified is False
+    assert plan.legacy_project_ids == ()
+    assert plan.legacy_github_ids == ("Owner/Repo",)
+
+
+def test_build_group_id_plan_treats_flattened_repo_as_legacy_alias():
+    plan = build_group_id_plan(
+        project_id="axonify-thunderball",
+        github_repo="Axonify/Thunderball",
+    )
+
+    assert plan.project_group_id == "axonify/thunderball"
+    assert plan.github_group_id == "axonify/thunderball"
+    assert plan.unified is True
+    assert plan.legacy_project_ids == ("axonify-thunderball",)
+    assert plan.legacy_github_ids == ("Axonify/Thunderball",)


### PR DESCRIPTION
## Summary
- normalize GitHub repo-derived `group_id` handling and sync-state resolution to the canonical lowercase `owner/repo` form, while still recognizing legacy mixed-case and older state-file locations
- add `audit_group_ids.py` and `migrate_group_ids.py` so installs can detect and repair split legacy IDs instead of relying on a one-off manual Qdrant/data cleanup
- update `run-with-env.sh`, `aim-github-sync`, and `GITHUB-INTEGRATION.md` so the documented status, reset, audit, and migration paths match what the runtime actually does

## Why this is broader than a one-off
I started from the Thunderball cleanup case, but validation showed the one-off data fix was not enough on its own:
- runtime code paths were not generating/reading IDs consistently
- the wrapper path did not load all of the env needed by the new recovery flow
- the docs and skill examples still pointed at stale state-file/status behavior

That is why this PR reaches past the raw normalization change into the wrapper and documentation contract. If that feels like too much surface area for this issue, I think it would be reasonable to take a narrower maintainer-owned approach instead; I preferred to ship the full truthful path so the next install/operator is not left rediscovering the same mismatch manually.

## Test plan
- [x] `./.venv/bin/pytest tests/unit/test_group_ids.py tests/unit/connectors/github/test_github_sync_cli.py`
- [x] `shellcheck scripts/memory/run-with-env.sh`
- [x] `AI_MEMORY_INSTALL_DIR="/Users/pmahncke/workspace/ai-memory" AI_MEMORY_ENV_FILE="$HOME/.ai-memory/docker/.env" "/Users/pmahncke/workspace/ai-memory/scripts/memory/run-with-env.sh" audit_group_ids.py --fail-on-legacy`
- [x] `AI_MEMORY_INSTALL_DIR="/Users/pmahncke/workspace/ai-memory" AI_MEMORY_ENV_FILE="$HOME/.ai-memory/docker/.env" "/Users/pmahncke/workspace/ai-memory/scripts/memory/run-with-env.sh" migrate_group_ids.py`


Made with [Cursor](https://cursor.com)