### PR TITLE
TD-443: Parzival pipeline ceremony + reliability fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to AI Memory Module will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Parzival orchestration pipeline — ceremony reduction and reliability fixes** (TD-443): Reduced dispatch friction for simple cases while strengthening reliability for edge cases across the 5-skill pipeline (`aim-parzival-team-builder`, `aim-bmad-dispatch`, `aim-agent-dispatch`, `aim-model-dispatch`, `aim-agent-lifecycle`).
+  - **Fast Path for single-agent dispatches** (R1): `aim-parzival-team-builder/SKILL.md` adds explicit `Fast Path: Single Agent` section with trigger criteria (single agent ✕ no parallelization ✕ clear file ownership ✕ single review cycle ✕ no cross-cutting concerns) and a compact YAML output form — no full team-design conversation for dispatches that do not need one.
+  - **Structured Dispatch Plan schema v1** (R2): Authoritative schema defined in `aim-parzival-team-builder/SKILL.md` (`Dispatch Plan Schema` section). `aim-bmad-dispatch`, `aim-agent-dispatch`, `aim-model-dispatch`, `aim-agent-lifecycle` each accept and re-emit the plan verbatim. Prevents prose paraphrase from corrupting model IDs (e.g., `glm-5.1:cloud` ⇒ `glm-5`) or file lists.
+  - **Pre-spawn model validation** (R3): Fail-fast gate added to `tmux-dispatch/steps/step-02-launch-pane.md` and `bmad-dispatch/steps/step-02-launch-and-activate.md` — `model` is grepped against the backend's catalog (`models-ollama.md`, `models-openrouter.md`) BEFORE any tmux pane is created. Invalid model names no longer consume pane slots. Claude-native dispatches are not gated here — the Anthropic API rejects invalid model names at request time.
+  - **Workspace-root CWD sentinel** (R4): `test -d _ai-memory && test -d _bmad && test -d oversight` replaces the single-marker `ls _ai-memory/` check in `claude-native/workflow.md`, `tmux-dispatch/steps/step-02`, and `bmad-dispatch/steps/step-02`. The co-presence requirement distinguishes workspace root from a nested source repo clone (e.g., `ai-memory/`) that would previously have passed a false positive.
+  - **Model catalog refresh** (R5): `glm-5.1:cloud` added to `aim-model-dispatch/references/models-ollama.md` (General Purpose Medium table + All Models quick-reference list). `providers.md` `defaultModel` remains `glm-5:cloud` — promotion to `glm-5.1:cloud` requires a separate `providers.json` sync decision and is NOT included in this release.
+- **Orchestration skill "Invoke don't read" enforcement** (TD-396 bundle): All 5 orchestration skill SKILL.md files now carry a prominent invocation rule at the top — Parzival MUST invoke these skills via the Skill tool, never read-and-paraphrase. GC-21 wording in `_ai-memory/pov/constraints/global/constraints.md` updated to describe the provider-conditional pipeline — Claude: team-builder → dispatch → model-dispatch. Non-Claude: team-builder → dispatch → lifecycle → model-dispatch.
+
 ## [2.3.1] - 2026-04-09
 
 Endpoint alignment and documentation accuracy patch.

--- a/_ai-memory/pov/constraints/global/constraints.md
+++ b/_ai-memory/pov/constraints/global/constraints.md
@@ -66,7 +66,7 @@ Run this checklist after every 10 messages to prevent constraint drift:
 - GC-18: Does any oversight document I am updating exceed 500 lines or 50 items? If yes, have I applied sharding?
 - GC-19: Have I spawned any agent without AI_MEMORY_AGENT_ID or outside tmux?
 - GC-20: Have I sent instruction in the same message as BMAD activation command?
-- GC-21: Have I dispatched any agent without following the full orchestration pipeline (team-builder → dispatch skill → model-dispatch tmux spawn with AI_MEMORY_AGENT_ID → aim-agent-lifecycle MANDATORY)?
+- GC-21: Have I dispatched any agent without following the full provider-conditional orchestration pipeline? Claude: team-builder → dispatch (bmad or generic) → model-dispatch. Non-Claude: team-builder → dispatch (bmad or generic) → agent-lifecycle → model-dispatch. Each skill invoked via the Skill tool, never read-and-paraphrased.
 
 ### Active During Agent Work (Layer 3)
 - GC-09: Have I reviewed all agent output before presenting?
@@ -98,4 +98,4 @@ IF ANY CHECK FAILS: Course-correct IMMEDIATELY before continuing.
 | GC-18: Oversized document without sharding | MEDIUM | Apply sharding strategy, create index file |
 | GC-19: Spawned agent without AI_MEMORY_AGENT_ID or outside tmux | HIGH | Stop, recreate via tmux with AI_MEMORY_AGENT_ID |
 | GC-20: Instruction in activation message | HIGH | Re-send: activation first, wait for menu, then instruct separately |
-| GC-21: Skipped orchestration pipeline step | CRITICAL | Stop dispatch, restart from the missed step. Full pipeline: aim-parzival-team-builder → aim-bmad-dispatch/aim-agent-dispatch → aim-agent-lifecycle (MUST load BEFORE spawn) → aim-model-dispatch (spawn called from lifecycle Step 4). NEVER spawn an agent without lifecycle loaded. Additional rules: fresh agent per task (never reuse across roles or stories), one story per SM (shutdown after each), /bmad-bmm-code-review for reviews (/bmad-agent-bmm-dev for implementation only), review loop uses fresh reviewer agents |
+| GC-21: Skipped orchestration pipeline step | CRITICAL | Stop dispatch, restart from the missed step. Provider-conditional pipeline: **Claude** — aim-parzival-team-builder → aim-bmad-dispatch or aim-agent-dispatch → aim-model-dispatch (claude-native workflow spawns teammate). **Non-Claude** — aim-parzival-team-builder → aim-bmad-dispatch or aim-agent-dispatch → aim-agent-lifecycle (MUST load BEFORE spawn) → aim-model-dispatch (tmux spawn called from lifecycle Step 1). Every skill in the chain MUST be invoked via the Skill tool — NEVER read the skill file and execute steps manually. Additional rules: fresh agent per task (never reuse across roles or stories), one story per SM (shutdown after each), /bmad-bmm-code-review for reviews (/bmad-agent-bmm-dev for implementation only), review loop uses fresh reviewer agents |

--- a/_ai-memory/pov/skills/aim-agent-dispatch/SKILL.md
+++ b/_ai-memory/pov/skills/aim-agent-dispatch/SKILL.md
@@ -5,6 +5,8 @@ description: Generic agent instruction preparation and activation
 
 # Agent Dispatch -- Generic Agent Activation
 
+> **INVOCATION RULE**: Parzival MUST invoke this skill via the Skill tool. NEVER read this file and execute steps manually -- that bypasses validation, schema enforcement, and pipeline routing. Reading is for audit and authoring; invocation is the only sanctioned execution path.
+
 **Purpose**: Prepare instructions for generic agents (no BMAD persona). For BMAD agents, use /aim-bmad-dispatch instead.
 
 ---
@@ -13,6 +15,29 @@ description: Generic agent instruction preparation and activation
 
 - **EC-02 (moved from Execution phase)**: MUST use the instruction template for every agent dispatch. Story files are planning artifacts -- implementation instructions translate requirements into precise, actionable specifications.
 - **GC-11 L3**: ALWAYS use the instruction template for every agent dispatch. Every requirement must cite a project file. Every DONE WHEN criterion must be objectively measurable.
+
+---
+
+## Dispatch Plan Input (v1)
+
+This skill is invoked by `aim-parzival-team-builder` with a structured
+Dispatch Plan object. See the `Dispatch Plan Schema` section in
+`aim-parzival-team-builder/SKILL.md` for the authoritative definition.
+
+**First action on invocation**: Re-emit the received plan verbatim — no
+paraphrase, no field renames, no model-ID shortening. If any key is missing
+or malformed, STOP and request a corrected plan from the caller.
+
+**Before routing (Step 4)**: Copy the plan into the downstream invocation.
+Fields used by this skill:
+- `provider` — routes to Claude path vs. non-Claude path
+- `agent` + `agent_id` — sets `AI_MEMORY_AGENT_ID`
+- `model` — passed through verbatim
+- `task_summary` + `files` + `complexity` — feed the instruction template
+- `workspace_root` — verified downstream by the CWD sentinel
+- `reviewer_plan` — informs whether a follow-up dispatch will be required
+
+**Never re-derive fields.** Exact model ID and file list propagate unchanged.
 
 ---
 
@@ -59,17 +84,20 @@ IF ANY CHECK FAILS: fix the instruction before proceeding.
 
 ### 4. Route Based on Provider
 
-Check provider from the dispatch plan:
+Check `provider` field from the Dispatch Plan:
 
-**Claude provider:**
+**Claude provider (`provider: claude`):**
 → /aim-model-dispatch (MANDATORY next step)
-Pass: instruction, AI_MEMORY_AGENT_ID, model from dispatch plan.
+Pass the full Dispatch Plan object plus the assembled instruction.
 
 **Non-Claude provider:**
 → /aim-agent-lifecycle (MANDATORY next step)
-Pass: instruction, AI_MEMORY_AGENT_ID, provider, model from dispatch plan.
+Pass the full Dispatch Plan object plus the assembled instruction. Lifecycle
+then invokes model-dispatch at its Step 1.
 
 MUST spawn fresh agent for every task — never reuse across roles or stories.
+MUST pass the Dispatch Plan verbatim — do NOT paraphrase model IDs or collapse
+file lists.
 
 ### 5. Dispatch Complete
 

--- a/_ai-memory/pov/skills/aim-agent-lifecycle/SKILL.md
+++ b/_ai-memory/pov/skills/aim-agent-lifecycle/SKILL.md
@@ -5,6 +5,8 @@ description: tmux agent lifecycle management for non-Claude providers
 
 # Agent Lifecycle -- Non-Claude Provider Agent Management
 
+> **INVOCATION RULE**: Parzival MUST invoke this skill via the Skill tool. NEVER read this file and execute steps manually -- that bypasses spawn, monitoring, and correction-loop tracking. Reading is for audit and authoring; invocation is the only sanctioned execution path.
+
 **Purpose**: Manage tmux-spawned agents for non-Claude providers. Invokes /aim-model-dispatch for tmux spawn, sends instructions via tmux send-keys, monitors via tmux capture-pane, and shuts down via tmux kill-pane. Called by /aim-bmad-dispatch and /aim-agent-dispatch when provider is not Claude.
 
 ---
@@ -28,9 +30,24 @@ Max 3 correction loops -- escalate to user if unresolved.
 
 ---
 
+## Dispatch Plan Input (v1)
+
+This skill receives a structured Dispatch Plan from `aim-bmad-dispatch` or
+`aim-agent-dispatch`. Authoritative schema is in
+`aim-parzival-team-builder/SKILL.md` under `Dispatch Plan Schema`.
+
+**First action on invocation**: Re-emit the plan verbatim. Pass it to
+`aim-model-dispatch` in Step 1 unchanged — model IDs, file lists, and
+`agent_id` MUST survive the hop.
+
+---
+
 ## Step 1: Spawn Agent
 
-Invoke /aim-model-dispatch with the dispatch plan. Model-dispatch routes to the correct tmux workflow for the provider and spawns the agent.
+Invoke /aim-model-dispatch with the Dispatch Plan (pass the object verbatim).
+Model-dispatch runs the pre-spawn validation gates (CWD sentinel, model
+catalog check, wrapper availability), routes to the correct tmux workflow for
+the provider, and spawns the agent.
 
 For BMAD agents, the tmux bmad-dispatch workflow handles two-phase activation (persona command → menu detection → task instruction).
 

--- a/_ai-memory/pov/skills/aim-bmad-dispatch/SKILL.md
+++ b/_ai-memory/pov/skills/aim-bmad-dispatch/SKILL.md
@@ -5,6 +5,8 @@ description: BMAD agent selection, activation commands, and persona loading -- L
 
 # BMAD Dispatch -- BMAD Agent Activation (Layer 3b)
 
+> **INVOCATION RULE**: Parzival MUST invoke this skill via the Skill tool. NEVER read this file and execute steps manually -- that bypasses validation, schema enforcement, and pipeline routing. Reading is for audit and authoring; invocation is the only sanctioned execution path.
+
 **Purpose**: Activate BMAD-specific agents with persona loading, BMAD activation commands, and role-specific behavior. For generic agents without BMAD personas, use aim-agent-dispatch instead.
 
 ---
@@ -14,6 +16,31 @@ description: BMAD agent selection, activation commands, and persona loading -- L
 - **DC-08 (moved from Discovery phase)**: Analyst research MUST precede PM when input is thin. When goals.md is the only input, Analyst must run before PM begins. PM does NOT begin from goals.md alone when input is thin.
 - **Agent activation verification**: Never send an instruction to an unverified agent. Verify activation before proceeding.
 - **One task per instruction**: Never combine multiple tasks in a single dispatch.
+
+---
+
+## Dispatch Plan Input (v1)
+
+This skill is invoked by `aim-parzival-team-builder` with a structured
+Dispatch Plan object. See the `Dispatch Plan Schema` section in
+`aim-parzival-team-builder/SKILL.md` for the authoritative definition.
+
+**First action on invocation**: Re-emit the received plan verbatim — no
+paraphrase, no field renames, no model-ID shortening. If any key is missing
+or malformed, STOP and request a corrected plan from the caller.
+
+**Before routing (Step 3)**: Copy the plan into the downstream invocation.
+Fields used by this skill:
+- `provider` — routes to Claude path vs. non-Claude path
+- `agent` + `agent_id` — selects BMAD activation command, sets
+  `AI_MEMORY_AGENT_ID`
+- `model` — passed through verbatim (never collapsed to a tier label)
+- `task_summary` + `files` + `complexity` — feed the instruction template
+- `workspace_root` — verified downstream by the CWD sentinel
+- `reviewer_plan` — informs whether a follow-up dispatch will be required
+
+**Never re-derive fields.** If the plan says `model: glm-5.1:cloud`, the
+downstream skill receives `glm-5.1:cloud` — not `glm-5`, not "latest GLM".
 
 ---
 
@@ -87,17 +114,21 @@ Extends the generic instruction template (from /aim-agent-dispatch) with:
 
 ### 3. Route Based on Provider
 
-Check provider from the dispatch plan:
+Check `provider` field from the Dispatch Plan:
 
-**Claude provider:**
+**Claude provider (`provider: claude`):**
 → /aim-model-dispatch (MANDATORY next step)
-Pass: BMAD activation command, instruction, AI_MEMORY_AGENT_ID, model from dispatch plan.
+Pass the full Dispatch Plan object plus the BMAD activation command and the
+assembled instruction.
 
 **Non-Claude provider:**
 → /aim-agent-lifecycle (MANDATORY next step)
-Pass: BMAD activation command, instruction, AI_MEMORY_AGENT_ID, provider, model from dispatch plan.
+Pass the full Dispatch Plan object plus the BMAD activation command and the
+assembled instruction. Lifecycle then invokes model-dispatch at its Step 1.
 
 MUST spawn fresh agent for every task — never reuse across roles or stories.
+MUST pass the Dispatch Plan verbatim — do NOT paraphrase model IDs or collapse
+file lists.
 
 #### Core Project Agents (bmm-)
 

--- a/_ai-memory/pov/skills/aim-model-dispatch/SKILL.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/SKILL.md
@@ -5,7 +5,38 @@ description: Select the appropriate LLM model for each agent based on task compl
 
 # Model Dispatch -- Model Selection and Provider Routing
 
+> **INVOCATION RULE**: Parzival MUST invoke this skill via the Skill tool. NEVER read this file and execute steps manually -- that bypasses pre-spawn model validation, CWD sentinel checks, and wrapper resolution. Reading is for audit and authoring; invocation is the only sanctioned execution path.
+
 **Purpose**: Select the appropriate LLM model and route to the correct provider workflow. Called by /aim-bmad-dispatch, /aim-agent-dispatch, and /aim-agent-lifecycle.
+
+---
+
+## Dispatch Plan Input (v1)
+
+This skill receives a structured Dispatch Plan from the upstream dispatch
+skill. Authoritative schema is defined in `aim-parzival-team-builder/SKILL.md`
+under `Dispatch Plan Schema`.
+
+**First action on invocation**: Re-emit the received plan verbatim. If a key
+is missing or the `model` field is empty when the plan requires a concrete
+model (non-Claude providers always require a concrete `model`), STOP and
+return a plan-validation error to the caller.
+
+### Pre-Spawn Validation Gates (run in order)
+
+Gates 2 (model catalog check) and 3 (wrapper availability) apply to non-Claude provider paths only. Claude-native does not require catalog validation (the Anthropic API rejects invalid model names) or wrapper check (uses Agent tool directly via Claude Code).
+
+1. **CWD Sentinel** — Verify workspace root by co-presence of `_ai-memory/`,
+   `_bmad/`, and `oversight/`. See workflow files under `workflows/` for the
+   bash implementation. `workspace_root` from the Dispatch Plan is the
+   expected path.
+2. **Model catalog check** — For `provider: ollama`, grep
+   `references/models-ollama.md` for the exact `model` string. For `provider:
+   openrouter`, grep `references/models-openrouter.md`. Fail-fast on miss with
+   the catalog path in the error message.
+3. **Wrapper availability** — Verify the backend wrapper exists on PATH.
+
+Gates 1–3 run before tmux pane creation; Gate 1 also runs before Agent spawn for Claude-native. A failed gate aborts the dispatch without consuming a pane slot or teammate slot.
 
 ---
 

--- a/_ai-memory/pov/skills/aim-model-dispatch/references/models-claude.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/references/models-claude.md
@@ -96,3 +96,11 @@ claude-haiku-4-5-20251001
 When dispatching via model-dispatch without specifying a model:
 - **Claude native:** Uses your default Claude settings
 - **OpenRouter:** Defaults to `claude-sonnet-4-6` for cost/performance balance
+
+---
+
+## All Models (Quick Reference)
+
+`claude-opus-4-6`
+`claude-sonnet-4-6`
+`claude-haiku-4-5-20251001`

--- a/_ai-memory/pov/skills/aim-model-dispatch/references/models-ollama.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/references/models-ollama.md
@@ -41,6 +41,7 @@ Balanced performance and speed. Good default choice for most tasks.
 
 | Model | Notes |
 |-------|-------|
+| `glm-5.1:cloud` | GLM-5.1, refreshed general-purpose model |
 | `glm-5:cloud` | **Default** — GLM-5, reliable all-rounder |
 | `glm-4.7:cloud` | GLM-4.7, previous generation |
 | `minimax-m2.5:cloud` | MiniMax M2.5, good general performance |
@@ -109,6 +110,7 @@ qwen3-coder:480b-cloud
 qwen3.5:397b-cloud
 mistral-large-3:675b-cloud
 deepseek-v3.2:cloud
+glm-5.1:cloud
 glm-5:cloud
 glm-4.7:cloud
 minimax-m2.5:cloud

--- a/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-02-launch-and-activate.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-02-launch-and-activate.md
@@ -21,13 +21,71 @@ Open a tmux pane, launch Claude Code with the backend-appropriate wrapper, and s
 
 ## MANDATORY SEQUENCE
 
+### 0a. Verify Workspace Root (CWD Sentinel)
+
+Run BEFORE any pane creation. The sentinel requires the co-presence of
+`_ai-memory/`, `_bmad/`, and `oversight/` — a single-marker check is
+insufficient because a nested source repo (e.g., `ai-memory/`) also contains
+`_ai-memory/` and would pass.
+
+```bash
+# Scope: dev workspace dispatches only. End-user installs (~/.ai-memory/) launch
+# via skill installer wrappers and do not require this sentinel.
+# Enforced on every spawn, not just the first in a session.
+if ! (test -d _ai-memory && test -d _bmad && test -d oversight); then
+  echo "FAIL: CWD is not workspace root. Expected _ai-memory/, _bmad/, oversight/ all present."
+  echo "CWD: $(pwd)"
+  echo "Aborting dispatch. cd to workspace root and re-invoke."
+  exit 1
+fi
+echo "OK: workspace root ($(pwd))"
+```
+
+If this check fails, stop — do not proceed to pane creation.
+
+### 0b. Pre-Spawn Model Validation
+
+Validate MODEL against the catalog BEFORE creating a tmux pane. An invalid
+model name wastes a pane slot and produces a cryptic runtime error. Fail-fast
+here with a clear catalog-reference message.
+
+```bash
+# Skip validation when MODEL is empty (native Claude default) or BACKEND=gemini
+# (Gemini CLI handles its own model selection interactively).
+if [ -n "${MODEL}" ] && [ "${BACKEND}" != "gemini" ]; then
+  SKILL_DIR="$(pwd)/_ai-memory/pov/skills/aim-model-dispatch"
+  CATALOG_FILE=""
+  case "${BACKEND}" in
+    ollama)      CATALOG_FILE="${SKILL_DIR}/references/models-ollama.md" ;;
+    openrouter)  CATALOG_FILE="${SKILL_DIR}/references/models-openrouter.md" ;;
+  esac
+  if [ -n "${CATALOG_FILE}" ]; then
+    if [ ! -f "${CATALOG_FILE}" ]; then
+      echo "FAIL: catalog file for backend '${BACKEND}' expected at ${CATALOG_FILE} but not found."
+      echo "This is a deployment issue — reinstall or verify model-dispatch wrappers are installed."
+      exit 1
+    fi
+    if ! grep -Fq "\`${MODEL}\`" "${CATALOG_FILE}"; then
+      echo "FAIL: model '${MODEL}' not found in catalog ${CATALOG_FILE}."
+      echo "Available models listed in that file. Correct the dispatch plan and re-invoke."
+      exit 1
+    fi
+    echo "OK: model '${MODEL}' validated against ${BACKEND} catalog"
+  else
+    echo "WARN: no catalog file for backend '${BACKEND}' -- skipping pre-spawn validation"
+  fi
+fi
+```
+
+If validation fails, stop — do not create a pane.
+
 ### 0. Verify Wrapper Command Exists
 
 ```bash
 # WRAPPER_CMD is from step-01 dispatch plan
 if ! command -v "${WRAPPER_CMD%% *}" &>/dev/null; then
   echo "ERROR: Wrapper command '${WRAPPER_CMD}' not found in PATH."
-  echo "Install it by running: bash .claude/skills/model-dispatch/scripts/install.sh"
+  echo "Install it by running: bash _ai-memory/pov/skills/aim-model-dispatch/scripts/install.sh"
   echo "Aborting dispatch."
   exit 1
 fi
@@ -133,6 +191,8 @@ ONLY when the pane is open, Claude launched, the activation command has been sen
 ## SYSTEM SUCCESS/FAILURE METRICS
 
 ### SUCCESS:
+- Workspace root sentinel passed (`_ai-memory/` + `_bmad/` + `oversight/` all present)
+- Model validated against the catalog for the selected backend
 - Pane created with captured PANE_TARGET ID
 - Wrapper launched with correct backend flags
 - 5-second init wait completed
@@ -141,6 +201,8 @@ ONLY when the pane is open, Claude launched, the activation command has been sen
 - Pane verified as alive
 
 ### FAILURE:
+- CWD sentinel failed (one of the workspace-root markers missing)
+- MODEL not present in catalog for the backend (spawn must not proceed)
 - Sending activation command before Claude Code finishes initializing
 - Pressing Enter more than once after the command
 - Sending task directions at this stage (too early)

--- a/_ai-memory/pov/skills/aim-model-dispatch/workflows/claude-native/workflow.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/workflows/claude-native/workflow.md
@@ -44,26 +44,35 @@ EC-01, EC-04, EC-05, EC-06, EC-09, EC-10
 
 ---
 
-## MANDATORY: Verify Working Directory
+## MANDATORY: Verify Working Directory (Workspace Root Sentinel)
 
-**Before ANY TeamCreate or Agent spawn, verify CWD is the project root.**
+**Before EVERY TeamCreate or Agent spawn, verify CWD is the workspace root.**
 
 Teammates inherit the lead's working directory. If CWD is wrong, teammates
-cannot find BMAD skills, story files, or project context.
+cannot find BMAD skills, oversight docs, or project context. The workspace root
+is distinguished from a nested source repo (e.g., `ai-memory/`) by the
+co-presence of all three sentinel directories: `_ai-memory/`, `_bmad/`, and
+`oversight/`. Checking only `_ai-memory/` produces a false positive when CWD
+has drifted into a source repo clone.
 
 ```
-# Run this check EVERY TIME before creating a team:
+# Scope: dev workspace dispatches only. End-user installs (~/.ai-memory/) launch
+# via skill installer wrappers and do not require this sentinel.
+# Run this check EVERY TIME before creating a team or spawning an agent:
 Bash: pwd
-# MUST output the project root containing _ai-memory/ directory
-# e.g., /mnt/e/projects/dev-rag-stack/document_pipeline
-# If CWD is DocIntel/ or any subdirectory: cd to project root FIRST
+# MUST output the workspace root (e.g., /mnt/e/projects/dev-ai-memory)
 
-Bash: ls _ai-memory/ > /dev/null 2>&1 && echo "OK: project root" || echo "FAIL: wrong directory"
-# MUST output "OK: project root"
-# If "FAIL": stop, cd to project root, re-verify
+Bash: test -d _ai-memory && test -d _bmad && test -d oversight \
+      && echo "OK: workspace root" \
+      || echo "FAIL: not workspace root (missing one of _ai-memory/, _bmad/, oversight/)"
+# MUST output "OK: workspace root"
+# If "FAIL": stop, cd to workspace root, re-verify.
+# A single-marker check (e.g., ls _ai-memory/) is INSUFFICIENT -- a nested
+# source repo (ai-memory/) also contains _ai-memory/ and will pass.
 ```
 
-**DO NOT PROCEED if this check fails.** This is Rule 4 enforcement.
+**DO NOT PROCEED if this check fails.** The sentinel is enforced on every spawn,
+not just the first one in a session -- `cd` drifts silently across Bash calls.
 
 ---
 

--- a/_ai-memory/pov/skills/aim-model-dispatch/workflows/tmux-dispatch/steps/step-02-launch-pane.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/workflows/tmux-dispatch/steps/step-02-launch-pane.md
@@ -21,13 +21,71 @@ Create a tmux pane, launch Claude Code with the backend-appropriate wrapper comm
 
 ## MANDATORY SEQUENCE
 
+### 0a. Verify Workspace Root (CWD Sentinel)
+
+Run BEFORE any pane creation. The sentinel requires the co-presence of
+`_ai-memory/`, `_bmad/`, and `oversight/` — a single-marker check is
+insufficient because a nested source repo (e.g., `ai-memory/`) also contains
+`_ai-memory/` and would pass.
+
+```bash
+# Scope: dev workspace dispatches only. End-user installs (~/.ai-memory/) launch
+# via skill installer wrappers and do not require this sentinel.
+# Enforced on every spawn, not just the first in a session.
+if ! (test -d _ai-memory && test -d _bmad && test -d oversight); then
+  echo "FAIL: CWD is not workspace root. Expected _ai-memory/, _bmad/, oversight/ all present."
+  echo "CWD: $(pwd)"
+  echo "Aborting dispatch. cd to workspace root and re-invoke."
+  exit 1
+fi
+echo "OK: workspace root ($(pwd))"
+```
+
+If this check fails, stop — do not proceed to pane creation.
+
+### 0b. Pre-Spawn Model Validation
+
+Validate MODEL against the catalog BEFORE creating a tmux pane. An invalid
+model name wastes a pane slot and produces a cryptic runtime error. Fail-fast
+here with a clear catalog-reference message.
+
+```bash
+# Skip validation when MODEL is empty (native Claude default) or BACKEND=gemini
+# (Gemini CLI handles its own model selection interactively).
+if [ -n "${MODEL}" ] && [ "${BACKEND}" != "gemini" ]; then
+  SKILL_DIR="$(pwd)/_ai-memory/pov/skills/aim-model-dispatch"
+  CATALOG_FILE=""
+  case "${BACKEND}" in
+    ollama)      CATALOG_FILE="${SKILL_DIR}/references/models-ollama.md" ;;
+    openrouter)  CATALOG_FILE="${SKILL_DIR}/references/models-openrouter.md" ;;
+  esac
+  if [ -n "${CATALOG_FILE}" ]; then
+    if [ ! -f "${CATALOG_FILE}" ]; then
+      echo "FAIL: catalog file for backend '${BACKEND}' expected at ${CATALOG_FILE} but not found."
+      echo "This is a deployment issue — reinstall or verify model-dispatch wrappers are installed."
+      exit 1
+    fi
+    if ! grep -Fq "\`${MODEL}\`" "${CATALOG_FILE}"; then
+      echo "FAIL: model '${MODEL}' not found in catalog ${CATALOG_FILE}."
+      echo "Available models listed in that file. Correct the dispatch plan and re-invoke."
+      exit 1
+    fi
+    echo "OK: model '${MODEL}' validated against ${BACKEND} catalog"
+  else
+    echo "WARN: no catalog file for backend '${BACKEND}' -- skipping pre-spawn validation"
+  fi
+fi
+```
+
+If validation fails, stop — do not create a pane.
+
 ### 0. Verify Wrapper Command Exists
 
 ```bash
 # WRAPPER_CMD is from step-01 dispatch plan
 if ! command -v "${WRAPPER_CMD%% *}" &>/dev/null; then
   echo "ERROR: Wrapper command '${WRAPPER_CMD}' not found in PATH."
-  echo "Install it by running: bash .claude/skills/model-dispatch/scripts/install.sh"
+  echo "Install it by running: bash _ai-memory/pov/skills/aim-model-dispatch/scripts/install.sh"
   echo "Aborting dispatch."
   exit 1
 fi
@@ -112,6 +170,8 @@ ONLY when pane is created, Claude launched, 5-second init wait completed, and pa
 ## SYSTEM SUCCESS/FAILURE METRICS
 
 ### SUCCESS:
+- Workspace root sentinel passed (`_ai-memory/` + `_bmad/` + `oversight/` all present)
+- Model validated against the catalog for the selected backend
 - Pane created with captured PANE_TARGET ID
 - Wrapper command executed with allowedTools flags
 - 5-second initialization wait completed
@@ -119,6 +179,8 @@ ONLY when pane is created, Claude launched, 5-second init wait completed, and pa
 - PANE_TARGET available for subsequent steps
 
 ### FAILURE:
+- CWD sentinel failed (one of the workspace-root markers missing)
+- MODEL not present in catalog for the backend (spawn must not proceed)
 - Pane creation failed (check tmux session exists)
 - Wrapper command not found (check PATH)
 - Initialization timeout (increase sleep duration)

--- a/_ai-memory/pov/skills/aim-parzival-team-builder/SKILL.md
+++ b/_ai-memory/pov/skills/aim-parzival-team-builder/SKILL.md
@@ -6,38 +6,126 @@ context: fork
 
 # Team Builder
 
+> **INVOCATION RULE**: Parzival MUST invoke this skill via the Skill tool. NEVER read this file and execute steps manually -- that bypasses validation, schema enforcement, and pipeline routing. Reading is for audit and authoring; invocation is the only sanctioned execution path.
+
 **Purpose**: Analyze work to be parallelized, design the appropriate team structure (single agent, 2-tier, or 3-tier), and produce a team design document ready for execution via the agent-dispatch cycle.
 
 **Note**: This skill is the entry point for team design. Parzival designs teams here, then executes them via the agent-dispatch workflow. Parzival activates agents himself -- the user does not run agents.
 
 ---
 
-## Single Agent Fast Path
+## Fast Path: Single Agent
 
-When the work is a single task that does not benefit from parallelization:
+The fast path bypasses the full 6-step design process for dispatches that a
+single agent can execute without coordination. It still produces a structured
+dispatch plan and still routes through the full pipeline — ceremony is trimmed,
+the contract is not.
+
+### Trigger Criteria (ALL must hold)
+
+- **Single agent**: exactly one executor, no lead/worker split
+- **No parallelization**: no peer agents, no file-ownership partitioning
+- **Clear file ownership**: every file the agent will touch is already known at
+  dispatch time (no "will discover what to modify")
+- **Single review cycle**: at most one review CYCLE (the cycle may be dual Sonnet+Opus via `reviewer_plan.mode: dual`)
+- **No cross-cutting concerns**: the task does not force interface contracts
+  with other in-flight work
+
+If any criterion fails, fall through to the full Team Design Process.
+
+### Fast Path Execution
+
 1. Collect provider and model preferences (Step 1b)
 2. Assign agent role and AI_MEMORY_AGENT_ID (Step 2.3)
 3. Prepare the context block (Step 4 format)
-4. Present compact output for approval
-5. Route to /aim-bmad-dispatch or /aim-agent-dispatch
+4. Emit the compact Dispatch Plan (see `Dispatch Plan Schema` below) for approval
+5. On approval, route to `/aim-bmad-dispatch` or `/aim-agent-dispatch` — the
+   plan object is passed verbatim to the downstream skill
 
-**Criteria for single agent path:**
-- One task, one agent, one review cycle
-- No file ownership conflicts (only one agent working)
-- No parallel coordination needed
+**No activation greeting, no menu display, no multi-step analysis narration.**
+The fast path should read like a form, not a conversation.
 
-**Compact output**: When the fast path is selected, skip ceremony. Produce only:
+### Fast Path Compact Output Example
+
+```yaml
+# Dispatch Plan v1
+provider: claude
+model: claude-sonnet-4-6
+agent: dev
+agent_id: dev-auth
+task_summary: "Implement Story 4.2 password-reset endpoint"
+files:
+  - /abs/path/src/auth/reset.py
+  - /abs/path/tests/test_reset.py
+workspace_root: /mnt/e/projects/dev-ai-memory
+complexity: moderate
+reviewer_plan:
+  mode: single
+  models: [claude-sonnet-4-6]
+route: aim-bmad-dispatch
+# Approve?
 ```
-Fast Path: Single agent
-Provider: [claude | openrouter | ollama | ...]
-Agent: [role] (AI_MEMORY_AGENT_ID: [id], Model: [model tier])
-Mode: [execution | planning]
-Task: [one-line description]
-Files: [list]
-Route: [aim-bmad-dispatch or aim-agent-dispatch]
-Approve?
+
+---
+
+## Dispatch Plan Schema (v1)
+
+Every team-builder invocation — fast path, preset, or full design — emits a
+**Dispatch Plan** object. Downstream skills (`aim-bmad-dispatch`,
+`aim-agent-dispatch`, `aim-model-dispatch`) MUST accept this object as
+structured data and re-emit it verbatim to the next skill in the chain.
+
+**Goal**: model IDs like `glm-5.1:cloud` must survive the pipeline without
+paraphrase-corruption (no `glm-5`, no "use the latest glm"). File lists must
+not collapse to prose.
+
+### Schema
+
+```yaml
+# Dispatch Plan v1
+provider: claude | openrouter | ollama | gemini | deepseek | groq | cerebras | mistral | openai | vertex-ai | siliconflow
+model: <exact-model-id-string>       # verbatim, e.g., "glm-5.1:cloud", "claude-sonnet-4-6"
+agent: <role-name>                   # dev | sm | pm | architect | analyst | ux-designer | qa | tech-writer | code-reviewer | <generic>
+agent_id: <AI_MEMORY_AGENT_ID>       # e.g., "dev-auth", "review-opus", "sm-sprint-2"
+task_summary: <one-line>
+files:
+  - <absolute-path-1>
+  - <absolute-path-2>
+workspace_root: <absolute-path>      # MUST contain _ai-memory/ + _bmad/ + oversight/
+complexity: straightforward | moderate | significant | complex
+reviewer_plan:
+  mode: none | single | dual
+  models: [<reviewer-model-1>, <reviewer-model-2>]  # empty list when mode=none
+route: aim-bmad-dispatch | aim-agent-dispatch      # which dispatch skill to invoke next
 ```
-Do not produce a full activation greeting, menu display, or multi-step analysis for a single-task dispatch. The fast path should be fast.
+
+**Example: no review cycle** (`reviewer_plan.mode: none`)
+
+```yaml
+reviewer_plan:
+  mode: none
+  models: []
+```
+
+### Round-Trip Rules
+
+- **All keys always present.** Emit `null` or empty list for not-applicable
+  fields rather than omitting the key — keeps schema stable.
+- **No paraphrasing.** When passing the plan to the next skill, copy the object
+  as-is. Never reformat model IDs, never summarize file lists to "the auth
+  files", never drop `agent_id`.
+- **Validation gate.** The downstream skill MUST re-emit the plan unchanged in
+  its first action. If a field is missing or malformed, STOP and request a
+  corrected plan from the caller.
+- **Source of truth.** `workspace_root` is verified by the CWD sentinel in
+  `aim-model-dispatch`. The plan is the record; the sentinel is the check.
+
+### When Full Design Is Required
+
+The full 6-step Team Design Process emits one Dispatch Plan per team member
+plus a Team Document describing the overall structure. The fast path emits a
+single plan. Presets emit a preset-specific fan-out of plans. In all cases the
+schema above applies per-agent.
 
 ---
 
@@ -210,9 +298,13 @@ Before executing, verify:
 
 ## Output
 
-The team design document (Steps 1-6) is the deliverable. It feeds into the agent-dispatch cycle.
+The team design document (Steps 1-6) is the deliverable. It feeds into the
+agent-dispatch cycle via one or more Dispatch Plan objects (see `Dispatch Plan
+Schema`).
 
-**Do NOT assemble a copy-paste team prompt in the output.** The design document contains the context blocks (Step 4) and the templates are reference formats for dispatch. Prompt assembly happens at dispatch time — not here.
+**Do NOT assemble a copy-paste team prompt in the output.** The design document
+contains the context blocks (Step 4) and the templates are reference formats
+for dispatch. Prompt assembly happens at dispatch time — not here.
 
 **Templates:**
 - [`templates/team-prompt-2tier.template.md`](templates/team-prompt-2tier.template.md) — 2-tier team prompt format (lead + workers)
@@ -220,8 +312,10 @@ The team design document (Steps 1-6) is the deliverable. It feeds into the agent
 
 Parzival activates all agents himself — the user does not run agents.
 
-**MANDATORY NEXT STEP**: After user approves the dispatch plan:
-- BMAD agents → /aim-bmad-dispatch
-- Generic agents → /aim-agent-dispatch
+**MANDATORY NEXT STEP**: After user approves the dispatch plan(s):
+- BMAD agents (plan `route: aim-bmad-dispatch`) → invoke `/aim-bmad-dispatch`
+- Generic agents (plan `route: aim-agent-dispatch`) → invoke `/aim-agent-dispatch`
 
-Pass the full dispatch plan (provider, model, agent role, task, files, mode) to the next skill.
+Pass the full Dispatch Plan object verbatim — including exact model ID, full
+file list, and `agent_id`. Downstream skills will re-emit the plan for
+round-trip verification.


### PR DESCRIPTION
## Summary

- Add Fast Path single-agent preset and structured Dispatch Plan v1 schema to reduce ceremony for simple dispatches
- Add pre-spawn model validation gate so invalid model names fail fast before consuming pane slots
- Add three-marker workspace-root CWD sentinel that distinguishes workspace root from a nested source repo clone
- Add `glm-5.1:cloud` to the ollama model catalog
- Strengthen orchestration skill invocation discipline with prominent "Invoke don't read" callouts and clarified GC-21 wording (bundles TD-396)

## Background

TD-443 surfaced six concrete friction and reliability issues in the Parzival orchestration pipeline. With 17+ dispatches planned in PLAN-021 (v2.4.0), even small per-dispatch overhead compounds quickly. This PR reduces the simple-case ceremony while strengthening edge-case reliability — without weakening the GC-21 contract.

## Changes

### Skills (5)
- `_ai-memory/pov/skills/aim-parzival-team-builder/SKILL.md` — Fast Path: Single Agent + Dispatch Plan Schema v1 + Invocation Rule
- `_ai-memory/pov/skills/aim-bmad-dispatch/SKILL.md` — Dispatch Plan Input + Invocation Rule + tightened provider routing
- `_ai-memory/pov/skills/aim-agent-dispatch/SKILL.md` — Dispatch Plan Input + Invocation Rule + tightened provider routing
- `_ai-memory/pov/skills/aim-model-dispatch/SKILL.md` — Dispatch Plan Input + Invocation Rule + Pre-Spawn Validation Gates section
- `_ai-memory/pov/skills/aim-agent-lifecycle/SKILL.md` — Dispatch Plan Input + Invocation Rule + Step 1 names the three pre-spawn gates

### Workflows (3)
- `_ai-memory/pov/skills/aim-model-dispatch/workflows/claude-native/workflow.md` — three-marker CWD sentinel
- `_ai-memory/pov/skills/aim-model-dispatch/workflows/tmux-dispatch/steps/step-02-launch-pane.md` — CWD sentinel + pre-spawn model validation
- `_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-02-launch-and-activate.md` — CWD sentinel + pre-spawn model validation

### Reference catalogs (2)
- `_ai-memory/pov/skills/aim-model-dispatch/references/models-ollama.md` — `glm-5.1:cloud` added
- `_ai-memory/pov/skills/aim-model-dispatch/references/models-claude.md` — All Models quick-reference section added (inline-backtick token form)

### Constraints (1)
- `_ai-memory/pov/constraints/global/constraints.md` — GC-21 wording updated for provider-conditional pipeline (TD-396 bundle)

### Changelog
- `CHANGELOG.md` — `[Unreleased]` section with TD-443 + TD-396 entries

## Test plan

- [ ] CWD sentinel: from workspace root, verify `test -d _ai-memory && test -d _bmad && test -d oversight` succeeds; from a nested source repo clone, verify it fails (only 2 of 3 markers present)
- [ ] Pre-spawn model validation: with a valid ollama model (e.g., `glm-5.1:cloud`), verify the gate passes; with an invalid model, verify the gate aborts before pane creation
- [ ] Catalog resolution: from workspace root, `[ -f "$(pwd)/_ai-memory/pov/skills/aim-model-dispatch/references/models-ollama.md" ]` succeeds
- [ ] Fast Path: invoke `aim-parzival-team-builder` for a single-agent task with clear file ownership; verify it returns the compact YAML form rather than the full team-design conversation
- [ ] Schema round-trip: dispatch through the full pipeline; verify a model ID like `glm-5.1:cloud` survives intact end-to-end without being paraphrased
- [ ] GC-21 wording: read the updated row in `constraints/global/constraints.md`; verify it accurately describes both the Claude and non-Claude pipeline paths
- [ ] Invocation Rule presence: all 5 orchestration SKILL.md files have the callout at the top

Closes #109