### PR TITLE
v2.4.1 POV hygiene — BUG-299, BUG-300, TD-526

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- POV bootstrap observability documentation. `docs/prometheus-queries.md` now
+  documents the `aimemory_retrieval_budget_reject_total` counter — its labels,
+  cardinality, example PromQL queries, and alerting guidance.
+  `docs/CONFIGURATION.md` documents the `HANDOFF_CEILING_TOKENS` environment
+  variable, including default, valid range, and ceiling-breach behavior.
+  `docs/PARZIVAL-SESSION-GUIDE.md` describes the `[FALLBACK-NEEDED:]` marker
+  contract for the session-start handoff fallback. (TD-526)
+
+### Fixed
+
+- Sanctum and `_memory/` file modification timestamps are now preserved across
+  reinstalls. The installer's backup and restore copy steps now pass `cp -p`,
+  so `stat` and `find -newer` audit checks remain meaningful after an upgrade.
+  File content was already preserved across reinstalls; only the timestamps
+  were being reset. (BUG-299)
+- The pushgateway `grouping_key` for retrieval-budget rejection metrics now
+  includes the rejection reason. Previously, two rejections with different
+  reasons at the same tier within a single bootstrap could overwrite each
+  other in the pushgateway, making alerting on a specific
+  `aimemory_retrieval_budget_reject_total{reason=...}` series intermittent.
+  (BUG-300)
+
 ## [2.4.0] - 2026-05-13 — BUG-297 Silent-Drop Fix + Sanctum Identity + Env-Secrets Split + Classifier Resilience
 
 v2.4.0 closes the **BUG-297 silent-drop class** as its marquee item: L1 handoff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,15 +27,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the frontmatter merge step on the normal update path; only the failure-fallback
   `cp` retains its original mtime. File content was already preserved across
   reinstalls; only the timestamps were being reset. (BUG-299)
-- The pushgateway `grouping_key` for retrieval-budget rejection metrics now
-  includes `collection` in addition to tier and reason. Previously,
-  same-tier/same-reason rejects from different collections clobbered each other
-  in the pushgateway, preventing the documented ~40 sparse series (4 reasons ×
-  2 tiers × 5 collections) from being achievable in practice. The `grouping_key`
-  instance now encodes all three dimensions:
-  `reject_{tier}_{reason}_{collection}`. Alerting on
-  `aimemory_retrieval_budget_reject_total{reason,tier,collection}` is now
-  reliable across all label combinations. (BUG-300)
+- The pushgateway `grouping_key` for pushgateway-emitting metric functions now
+  includes `collection` to prevent per-collection series from clobbering each
+  other. Three paths were affected: retrieval-budget rejection
+  (`push_retrieval_reject_metric_async`), context injection
+  (`push_context_injection_metrics_async`), and capture
+  (`push_capture_metrics_async`). Previously, pushes sharing the same
+  tier+reason or hook_type but differing only in collection overwrote each
+  other in the pushgateway scope. The `grouping_key` instance for each function
+  now encodes collection as an additional dimension —
+  `reject_{tier}_{reason}_{collection}`,
+  `ctx_injection_{hook_type}_{collection}`, and
+  `capture_{hook_type}_{collection}` respectively — making the documented ~40
+  sparse series (4 reasons × 2 tiers × 5 collections) achievable in practice.
+  (BUG-300, BUG-304)
 
 ## [2.4.0] - 2026-05-13 — BUG-297 Silent-Drop Fix + Sanctum Identity + Env-Secrets Split + Classifier Resilience
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,17 +19,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Sanctum and `_memory/` file modification timestamps are now preserved across
+- `_memory/` user file modification timestamps are now preserved across
   reinstalls. The installer's backup and restore copy steps now pass `cp -p`,
   so `stat` and `find -newer` audit checks remain meaningful after an upgrade.
-  File content was already preserved across reinstalls; only the timestamps
-  were being reset. (BUG-299)
+  Per-instance sanctum identity files (LORE.md, BOND.md, sessions) also retain
+  their original timestamps on the restore path. Note: CREED.md is rewritten by
+  the frontmatter merge step on the normal update path; only the failure-fallback
+  `cp` retains its original mtime. File content was already preserved across
+  reinstalls; only the timestamps were being reset. (BUG-299)
 - The pushgateway `grouping_key` for retrieval-budget rejection metrics now
-  includes the rejection reason. Previously, two rejections with different
-  reasons at the same tier within a single bootstrap could overwrite each
-  other in the pushgateway, making alerting on a specific
-  `aimemory_retrieval_budget_reject_total{reason=...}` series intermittent.
-  (BUG-300)
+  includes `collection` in addition to tier and reason. Previously,
+  same-tier/same-reason rejects from different collections clobbered each other
+  in the pushgateway, preventing the documented ~40 sparse series (4 reasons ×
+  2 tiers × 5 collections) from being achievable in practice. The `grouping_key`
+  instance now encodes all three dimensions:
+  `reject_{tier}_{reason}_{collection}`. Alerting on
+  `aimemory_retrieval_budget_reject_total{reason,tier,collection}` is now
+  reliable across all label combinations. (BUG-300)
 
 ## [2.4.0] - 2026-05-13 — BUG-297 Silent-Drop Fix + Sanctum Identity + Env-Secrets Split + Classifier Resilience
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1320,6 +1320,37 @@ export BOOTSTRAP_TOKEN_BUDGET=5000
 
 ---
 
+#### HANDOFF_CEILING_TOKENS
+**Purpose:** Per-tier token ceiling for Layer 1 handoff retrieval — the maximum token size of an aggregated Parzival handoff body that will be accepted into the bootstrap context fill
+
+**Default:** `8000`
+
+**Format:** Integer (tokens, range 2500–10000)
+
+**Example:**
+```bash
+# Default (accepts handoffs up to 8 000 tokens)
+export HANDOFF_CEILING_TOKENS=8000
+
+# Tighter ceiling (reject oversized handoffs sooner)
+export HANDOFF_CEILING_TOKENS=4000
+
+# Wider ceiling (accept larger handoffs before falling back)
+export HANDOFF_CEILING_TOKENS=10000
+```
+
+**When to change:**
+- **Lower**: If session-start latency is high and large handoffs are the bottleneck — a tighter ceiling forces earlier filesystem fallback, which is faster than injecting a very large Qdrant record.
+- **Higher**: If handoffs are legitimately large (long sessions, rich context) and you want to avoid filesystem fallback.
+
+**Behavior on ceiling breach:** When an aggregated handoff body exceeds this limit, the retrieval layer rejects the record and sets `meta.fallback_signaled = True`. The bootstrap skill emits a `[FALLBACK-NEEDED: reason=ceiling_exceeded ...]` marker, and the Parzival startup workflow reads the most recent `oversight/session-logs/SESSION_HANDOFF_*.md` file instead. See PARZIVAL-SESSION-GUIDE.md for the full fallback contract.
+
+**Observability:** Ceiling rejections increment `aimemory_retrieval_budget_reject_total{reason="ceiling_exceeded", collection="discussions"}`. See prometheus-queries.md § Retrieval-budget rejection.
+
+**Range:** 2500–10000 (validated at startup; values outside this range raise a configuration error)
+
+---
+
 #### INJECTION_CONFIDENCE_THRESHOLD
 **Purpose:** Minimum retrieval confidence score for Tier 2 per-turn injection — if the best match is below this threshold, injection is skipped entirely for that turn
 

--- a/docs/PARZIVAL-SESSION-GUIDE.md
+++ b/docs/PARZIVAL-SESSION-GUIDE.md
@@ -134,7 +134,7 @@ Outputs empty context and logs a warning. Claude continues without memory inject
 
 **Fallback (handoff too large — `[FALLBACK-NEEDED: ...]` marker):**
 
-When the most recent Parzival handoff record is retrieved from Qdrant but its aggregated body exceeds `HANDOFF_CEILING_TOKENS` (default 8 000 tokens), the bootstrap layer rejects it and emits a marker as the first line of the Cross-Session Memory section:
+When the most recent Parzival handoff record is retrieved from Qdrant but its aggregated body exceeds `HANDOFF_CEILING_TOKENS` (default 8 000 tokens), the bootstrap layer rejects it and emits a marker as the first content line of the Cross-Session Memory section (immediately after the section header):
 
 ```
 [FALLBACK-NEEDED: reason=ceiling_exceeded type=agent_handoff tokens=<N> budget=<B>]

--- a/docs/PARZIVAL-SESSION-GUIDE.md
+++ b/docs/PARZIVAL-SESSION-GUIDE.md
@@ -132,6 +132,16 @@ Calls `retrieve_bootstrap_context()` via `MemorySearch`, querying Qdrant for con
 
 Outputs empty context and logs a warning. Claude continues without memory injection.
 
+**Fallback (handoff too large — `[FALLBACK-NEEDED: ...]` marker):**
+
+When the most recent Parzival handoff record is retrieved from Qdrant but its aggregated body exceeds `HANDOFF_CEILING_TOKENS` (default 8 000 tokens), the bootstrap layer rejects it and emits a marker as the first line of the Cross-Session Memory section:
+
+```
+[FALLBACK-NEEDED: reason=ceiling_exceeded type=agent_handoff tokens=<N> budget=<B>]
+```
+
+The same marker is emitted with `reason=budget_exceeded` when the handoff is rejected by the greedy token-fill budget rather than the hard ceiling. In both cases, the Parzival startup workflow (`/pov:parzival-start`) detects the marker and reads the most recent `oversight/session-logs/SESSION_HANDOFF_*.md` file from the filesystem instead — so cross-session continuity is preserved even when the Qdrant record is too large to inject directly. The `aimemory_retrieval_budget_reject_total{reason="ceiling_exceeded", collection="discussions"}` counter increments on each ceiling-triggered fallback; see prometheus-queries.md § Retrieval-budget rejection for alerting guidance.
+
 ### Layer 2 — Manual: `/pov:parzival-start` Command
 
 Reads local oversight files for PM-level project status. Always reads from the filesystem — does not require Qdrant:

--- a/docs/prometheus-queries.md
+++ b/docs/prometheus-queries.md
@@ -789,6 +789,52 @@ max_over_time(ai_memory_queue_size[1h])
 
 ---
 
+## POV Bootstrap Metrics
+
+Metrics emitted during Parzival session bootstrap (Tier 1 startup and Tier 2 per-turn context injection).
+
+---
+
+### Retrieval-budget rejection (POV bootstrap)
+
+**Counter:** `aimemory_retrieval_budget_reject_total`
+
+Counts individual result rejections during bootstrap context fill. A result is rejected when it is excluded by the greedy token-fill loop (budget overflow), the Layer 1 per-tier handoff ceiling, score-gap filtering, or deduplication.
+
+**Labels:**
+
+| Label | Values |
+|-------|--------|
+| `reason` | `budget_exceeded`, `ceiling_exceeded`, `score_gap`, `dedup` |
+| `tier` | `1_bootstrap`, `2_injection` |
+| `collection` | `code-patterns`, `conventions`, `discussions`, `github`, `jira-data` |
+
+**Cardinality:** ~40 series (4 reasons × 2 tiers × 5 collections)
+
+**Queries:**
+
+```promql
+# Total rejections by reason (last 1 hour)
+sum by (reason) (increase(aimemory_retrieval_budget_reject_total[1h]))
+
+# Rejections from the discussions collection (handoff ceiling hits)
+aimemory_retrieval_budget_reject_total{collection="discussions"}
+
+# Ceiling-exceeded rejections only — these trigger filesystem fallback at session start
+aimemory_retrieval_budget_reject_total{reason="ceiling_exceeded"}
+
+# Per-tier rejection breakdown
+sum by (tier, reason) (increase(aimemory_retrieval_budget_reject_total[1h]))
+```
+
+**Alerting guidance:**
+- A spike in `reason=ceiling_exceeded` for `collection="discussions"` indicates that the last Parzival handoff exceeds `HANDOFF_CEILING_TOKENS` and the bootstrap layer has fallen back to the filesystem copy. See `HANDOFF_CEILING_TOKENS` in CONFIGURATION.md and the `[FALLBACK-NEEDED: ...]` marker described in PARZIVAL-SESSION-GUIDE.md.
+- A high sustained rate of `reason=budget_exceeded` suggests the `BOOTSTRAP_TOKEN_BUDGET` is too small for current handoff volumes.
+
+**Source:** `src/memory/metrics_push.py` (`push_retrieval_reject_metric_async`)
+
+---
+
 ## Dashboard Query Examples
 
 Complete working queries extracted from our Grafana dashboards (`docker/grafana/dashboards/*.json`).

--- a/docs/prometheus-queries.md
+++ b/docs/prometheus-queries.md
@@ -809,7 +809,7 @@ Counts individual result rejections during bootstrap context fill. A result is r
 | `tier` | `1_bootstrap`, `2_injection` |
 | `collection` | `code-patterns`, `conventions`, `discussions`, `github`, `jira-data` |
 
-**Cardinality:** ~40 series (4 reasons × 2 tiers × 5 collections)
+**Cardinality:** ~40 sparse series (4 reasons × 2 tiers × 5 collections)
 
 **Queries:**
 
@@ -817,7 +817,7 @@ Counts individual result rejections during bootstrap context fill. A result is r
 # Total rejections by reason (last 1 hour)
 sum by (reason) (increase(aimemory_retrieval_budget_reject_total[1h]))
 
-# Rejections from the discussions collection (handoff ceiling hits)
+# Rejections from the discussions collection (all reasons)
 aimemory_retrieval_budget_reject_total{collection="discussions"}
 
 # Ceiling-exceeded rejections only — these trigger filesystem fallback at session start

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4421,7 +4421,7 @@ deploy_parzival_v2() {
     rm -rf "$mem_backup" 2>/dev/null || true
     if [[ -d "$dst/_memory" ]]; then
         mkdir -p "$mem_backup"
-        cp -r "$dst/_memory" "$mem_backup/"
+        cp -rp "$dst/_memory" "$mem_backup/"
         log_debug "Preserved _memory/ user data for restore"
     fi
 
@@ -4431,7 +4431,7 @@ deploy_parzival_v2() {
     rm -rf "$sanctum_backup" 2>/dev/null || true
     if [[ -d "$dst/sanctum" ]]; then
         mkdir -p "$sanctum_backup"
-        cp -r "$dst/sanctum" "$sanctum_backup/"
+        cp -rp "$dst/sanctum" "$sanctum_backup/"
         log_debug "Preserved sanctum/ user identity for restore"
     fi
 
@@ -4459,7 +4459,7 @@ deploy_parzival_v2() {
                 local target_dir
                 target_dir=$(dirname "$dst/_memory/$rel")
                 mkdir -p "$target_dir"
-                cp "$user_file" "$dst/_memory/$rel"
+                cp -p "$user_file" "$dst/_memory/$rel"
             fi
         done < <(find "$mem_backup/_memory" -type f -print0 2>/dev/null)
         rm -rf "$mem_backup"
@@ -4476,7 +4476,7 @@ deploy_parzival_v2() {
                 local target_dir
                 target_dir=$(dirname "$dst/sanctum/$rel")
                 mkdir -p "$target_dir"
-                cp "$user_file" "$dst/sanctum/$rel"
+                cp -p "$user_file" "$dst/sanctum/$rel"
             fi
         done < <(find "$sanctum_backup/sanctum" -type f -print0 2>/dev/null)
         log_debug "Restored per-instance sanctum/ identity files"
@@ -4495,7 +4495,7 @@ deploy_parzival_v2() {
         else
             local merge_rc=$?
             log_error "CREED frontmatter merge failed (rc=$merge_rc) — restoring backup CREED.md verbatim to preserve user identity"
-            cp "$sanctum_backup/sanctum/parzival/CREED.md" "$dst/sanctum/parzival/CREED.md"
+            cp -p "$sanctum_backup/sanctum/parzival/CREED.md" "$dst/sanctum/parzival/CREED.md"
         fi
     fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1701,7 +1701,7 @@ update_shared_scripts() {
         local _env_backup=""
         if [[ -f "$INSTALL_DIR/docker/.env" ]]; then
             _env_backup="$(mktemp)"
-            cp "$INSTALL_DIR/docker/.env" "$_env_backup"
+            cp -p "$INSTALL_DIR/docker/.env" "$_env_backup"
             log_debug "Backed up existing docker/.env before bulk copy"
         fi
 
@@ -1719,7 +1719,7 @@ update_shared_scripts() {
 
         # Restore docker/.env if it was backed up (bulk cp may have overwritten with template)
         if [[ -n "$_env_backup" ]]; then
-            cp "$_env_backup" "$INSTALL_DIR/docker/.env"
+            cp -p "$_env_backup" "$INSTALL_DIR/docker/.env"
             rm -f "$_env_backup"
             log_debug "Restored docker/.env after bulk copy"
         fi
@@ -2223,7 +2223,7 @@ copy_files() {
     local _env_backup=""
     if [[ -f "$INSTALL_DIR/docker/.env" ]]; then
         _env_backup="$(mktemp)"
-        cp "$INSTALL_DIR/docker/.env" "$_env_backup"
+        cp -p "$INSTALL_DIR/docker/.env" "$_env_backup"
         log_debug "Backed up existing docker/.env before bulk copy"
     fi
 
@@ -2232,7 +2232,7 @@ copy_files() {
 
     # Restore docker/.env if it was backed up (bulk cp may have overwritten with template)
     if [[ -n "$_env_backup" ]]; then
-        cp "$_env_backup" "$INSTALL_DIR/docker/.env"
+        cp -p "$_env_backup" "$INSTALL_DIR/docker/.env"
         rm -f "$_env_backup"
         log_debug "Restored docker/.env after bulk copy"
     fi

--- a/src/memory/metrics_push.py
+++ b/src/memory/metrics_push.py
@@ -1936,7 +1936,7 @@ try:
     pushadd_to_gateway(
         os.getenv("PUSHGATEWAY_URL", "localhost:29091"),
         job="ai_memory_hooks",
-        grouping_key={{"instance": f"reject_{{data['tier']}}_{{data['reason']}}"}},
+        grouping_key={{"instance": f"reject_{{data['tier']}}_{{data['reason']}}_{{data['collection']}}"}},
         registry=registry,
         timeout=0.5
     )

--- a/src/memory/metrics_push.py
+++ b/src/memory/metrics_push.py
@@ -477,7 +477,7 @@ def push_context_injection_metrics_async(
 
     # Validate labels (HIGH-1)
     hook_type = _validate_label(hook_type, "hook_type", VALID_HOOK_TYPES)
-    collection = _validate_label(collection, "collection")
+    collection = _validate_label(collection, "collection", VALID_COLLECTIONS)
     project = _validate_label(project, "project")
 
     try:

--- a/src/memory/metrics_push.py
+++ b/src/memory/metrics_push.py
@@ -1936,7 +1936,7 @@ try:
     pushadd_to_gateway(
         os.getenv("PUSHGATEWAY_URL", "localhost:29091"),
         job="ai_memory_hooks",
-        grouping_key={{"instance": f"reject_{{data['tier']}}"}},
+        grouping_key={{"instance": f"reject_{{data['tier']}}_{{data['reason']}}"}},
         registry=registry,
         timeout=0.5
     )

--- a/src/memory/metrics_push.py
+++ b/src/memory/metrics_push.py
@@ -518,7 +518,7 @@ try:
     pushadd_to_gateway(
         os.getenv("PUSHGATEWAY_URL", "localhost:29091"),
         job="ai_memory_hooks",
-        grouping_key={{"instance": f"ctx_injection_{{data['hook_type']}}"}},
+        grouping_key={{"instance": f"ctx_injection_{{data['hook_type']}}_{{data['collection']}}"}},
         registry=registry,
         timeout=0.5
     )
@@ -603,7 +603,7 @@ try:
     pushadd_to_gateway(
         os.getenv("PUSHGATEWAY_URL", "localhost:29091"),
         job="ai_memory_hooks",
-        grouping_key={{"instance": f"capture_{{data['hook_type']}}"}},
+        grouping_key={{"instance": f"capture_{{data['hook_type']}}_{{data['collection']}}"}},
         registry=registry,
         timeout=0.5
     )

--- a/tests/test_install_sanctum_preservation.py
+++ b/tests/test_install_sanctum_preservation.py
@@ -18,8 +18,10 @@ CREED.md policy (parzival-answers.md DQ-3 (a)):
   load, tier) come from new template.
 """
 
+import os
 import shutil
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -514,3 +516,59 @@ deploy_parzival_v2
         assert (
             "sessions_completed: 5" in creed_content
         ), "cp-fallback should restore backup CREED.md verbatim (sessions_completed: 5)"
+
+
+# ---------------------------------------------------------------------------
+# Class 3: mtime preservation regression (BUG-299 / F1)
+# ---------------------------------------------------------------------------
+
+
+class TestDeployParzivalV2MtimePreservation:
+    """Regression for BUG-299: user files under _memory/ retain original mtime on reinstall.
+
+    Requires install.sh to restore _memory/ user files with `cp -p` (BUG-299 fix).
+    Without `cp -p` the restored file's mtime is the time of the install run, not
+    the original — breaking `stat` / `find -newer` audit checks across reinstalls.
+    """
+
+    def test_memory_user_file_mtime_preserved(
+        self, install_sh_no_main, sanctum_install_dirs
+    ):
+        """V2→V2 reinstall must preserve mtime for user-created _memory/ files.
+
+        Sets up a pre-existing user file with a known mtime 24 hours in the past,
+        runs deploy_parzival_v2, and asserts the restored file's mtime matches the
+        original. Fails when install.sh uses `cp` without `-p` for _memory/ restore.
+        """
+        install_dir, project_dir = sanctum_install_dirs
+
+        # Create a user-created file under _memory/ (not present in source template)
+        memory_dir = project_dir / "_ai-memory" / "_memory"
+        memory_dir.mkdir(parents=True, exist_ok=True)
+        user_file = memory_dir / "user-note.md"
+        user_file.write_text("user note content — mtime sentinel", encoding="utf-8")
+
+        # Pin mtime to 24 h ago so it is clearly distinct from "now"
+        original_mtime = time.time() - 86400
+        os.utime(str(user_file), (original_mtime, original_mtime))
+
+        result = _run_deploy_parzival_v2(install_sh_no_main, install_dir, project_dir)
+        assert result.returncode == 0, f"deploy_parzival_v2 failed:\n{result.stderr}"
+
+        restored_file = project_dir / "_ai-memory" / "_memory" / "user-note.md"
+        assert restored_file.exists(), "_memory/user-note.md was not restored"
+        assert (
+            restored_file.read_text(encoding="utf-8")
+            == "user note content — mtime sentinel"
+        )
+
+        restored_mtime = restored_file.stat().st_mtime
+
+        # mtime must match original (within 2-second tolerance for filesystem precision).
+        # Without `cp -p`, restored_mtime would be approximately now (>> original_mtime).
+        assert abs(restored_mtime - original_mtime) < 2, (
+            f"_memory/ user file mtime not preserved across reinstall: "
+            f"original={original_mtime:.1f}, restored={restored_mtime:.1f} "
+            f"(delta={abs(restored_mtime - original_mtime):.1f}s). "
+            "Ensure install.sh restores _memory/ user files with `cp -p`."
+        )

--- a/tests/test_metrics_push.py
+++ b/tests/test_metrics_push.py
@@ -515,3 +515,64 @@ class TestPushRetrievalRejectGroupingKey:
             assert '"tier": "2_injection"' in inline_script
             assert '"collection": "discussions"' in inline_script
             assert '"count": 2' in inline_script
+
+
+class TestPushContextInjectionGroupingKey:
+    """Regression for H-1b: ctx_injection grouping_key must include collection (BUG-304).
+
+    Guard property: MUST fail against pre-H-1b code (grouping_key only had hook_type).
+    After H-1b fix (grouping_key includes collection), this test passes.
+    """
+
+    def test_grouping_key_includes_hook_type_and_collection(self):
+        """hook_type and collection must both appear in the grouping_key instance string.
+
+        Fails against pre-H-1b code where the grouping_key instance was
+        `ctx_injection_{data['hook_type']}` (missing `_{data['collection']}`),
+        allowing same-hook_type pushes from different collections to clobber
+        each other in the pushgateway.
+        """
+        with patch("subprocess.Popen") as mock_popen:
+            push_context_injection_metrics_async(
+                "SessionStart", "code-patterns", "test-project", 500
+            )
+            assert mock_popen.called
+            inline_script = mock_popen.call_args[0][0][2]
+            assert (
+                "ctx_injection_{data['hook_type']}_{data['collection']}"
+                in inline_script
+            ), (
+                "grouping_key does not include collection — "
+                "same-hook_type pushes from different collections will clobber each other. "
+                "Expected: ctx_injection_{data['hook_type']}_{data['collection']}"
+            )
+
+
+class TestPushCaptureGroupingKey:
+    """Regression for H-1b: capture grouping_key must include collection (BUG-304).
+
+    Guard property: MUST fail against pre-H-1b code (grouping_key only had hook_type).
+    After H-1b fix (grouping_key includes collection), this test passes.
+    """
+
+    def test_grouping_key_includes_hook_type_and_collection(self):
+        """hook_type and collection must both appear in the grouping_key instance string.
+
+        Fails against pre-H-1b code where the grouping_key instance was
+        `capture_{data['hook_type']}` (missing `_{data['collection']}`),
+        allowing same-hook_type pushes from different collections to clobber
+        each other in the pushgateway.
+        """
+        with patch("subprocess.Popen") as mock_popen:
+            push_capture_metrics_async(
+                "PostToolUse", "success", "test-project", "conventions", 1
+            )
+            assert mock_popen.called
+            inline_script = mock_popen.call_args[0][0][2]
+            assert (
+                "capture_{data['hook_type']}_{data['collection']}" in inline_script
+            ), (
+                "grouping_key does not include collection — "
+                "same-hook_type pushes from different collections will clobber each other. "
+                "Expected: capture_{data['hook_type']}_{data['collection']}"
+            )

--- a/tests/test_metrics_push.py
+++ b/tests/test_metrics_push.py
@@ -547,6 +547,25 @@ class TestPushContextInjectionGroupingKey:
                 "Expected: ctx_injection_{data['hook_type']}_{data['collection']}"
             )
 
+    def test_all_label_dimensions_in_metrics_data(self):
+        """hook_type, collection, project, and token_count must all be serialised into the subprocess data dict.
+
+        Guards against refactors that drop a key from metrics_data — the grouping_key
+        template guard still passes in that case, but the subprocess KeyErrors at runtime.
+        """
+        with patch("subprocess.Popen") as mock_popen:
+            push_context_injection_metrics_async(
+                "SessionStart", "code-patterns", "test-project", 500
+            )
+            assert mock_popen.called
+            call_args = mock_popen.call_args[0][0]
+            inline_script = call_args[2]
+
+            assert '"hook_type": "SessionStart"' in inline_script
+            assert '"collection": "code-patterns"' in inline_script
+            assert '"project": "test-project"' in inline_script
+            assert '"token_count": 500' in inline_script
+
 
 class TestPushCaptureGroupingKey:
     """Regression for H-1b: capture grouping_key must include collection (BUG-304).
@@ -576,3 +595,23 @@ class TestPushCaptureGroupingKey:
                 "same-hook_type pushes from different collections will clobber each other. "
                 "Expected: capture_{data['hook_type']}_{data['collection']}"
             )
+
+    def test_all_label_dimensions_in_metrics_data(self):
+        """hook_type, status, collection, project, and count must all be serialised into the subprocess data dict.
+
+        Guards against refactors that drop a key from metrics_data — the grouping_key
+        template guard still passes in that case, but the subprocess KeyErrors at runtime.
+        """
+        with patch("subprocess.Popen") as mock_popen:
+            push_capture_metrics_async(
+                "PostToolUse", "success", "test-project", "conventions", 1
+            )
+            assert mock_popen.called
+            call_args = mock_popen.call_args[0][0]
+            inline_script = call_args[2]
+
+            assert '"hook_type": "PostToolUse"' in inline_script
+            assert '"status": "success"' in inline_script
+            assert '"collection": "conventions"' in inline_script
+            assert '"project": "test-project"' in inline_script
+            assert '"count": 1' in inline_script

--- a/tests/test_metrics_push.py
+++ b/tests/test_metrics_push.py
@@ -18,6 +18,7 @@ from memory.metrics_push import (
     push_embedding_metrics_async,
     push_failure_metrics_async,
     push_retrieval_metrics_async,
+    push_retrieval_reject_metric_async,
     push_token_metrics_async,
     push_trigger_metrics_async,
 )
@@ -452,3 +453,65 @@ class TestPushSkillMetrics:
 
             assert '"skill_name": "memory-status"' in inline_script
             assert '"status": "empty"' in inline_script
+
+
+class TestPushRetrievalRejectGroupingKey:
+    """Regression for H-1: grouping_key must include collection to prevent clobber.
+
+    The pushgateway `pushadd_to_gateway` replaces the entire metric family within a
+    grouping_key scope. If two rejects share the same tier+reason but differ only in
+    collection, the second push overwrites the first unless `collection` is part of
+    the key. This test verifies that all three dimensions are present.
+
+    Guard property: MUST fail against pre-H-1 code (grouping_key only had tier+reason).
+    After H-1 fix (grouping_key includes collection), this test passes.
+    """
+
+    def test_grouping_key_includes_tier_reason_and_collection(self):
+        """All three dimensions — tier, reason, collection — must appear in grouping_key.
+
+        Fails against pre-H-1 code where the grouping_key instance string was
+        `reject_{data['tier']}_{data['reason']}` (missing `_{data['collection']}`),
+        allowing same-tier/same-reason rejects from different collections to clobber
+        each other in the pushgateway.
+        """
+        with patch("subprocess.Popen") as mock_popen:
+            push_retrieval_reject_metric_async(
+                reason="budget_exceeded",
+                tier="1_bootstrap",
+                collection="code-patterns",
+                count=1,
+            )
+            assert mock_popen.called
+            call_args = mock_popen.call_args[0][0]
+            inline_script = call_args[2]
+
+            # The grouping_key instance in the subprocess script must encode all three.
+            # Post-H-1: reject_{data['tier']}_{data['reason']}_{data['collection']}
+            # Pre-H-1:  reject_{data['tier']}_{data['reason']}   ← collection absent
+            assert (
+                "reject_{data['tier']}_{data['reason']}_{data['collection']}"
+                in inline_script
+            ), (
+                "grouping_key does not include collection — "
+                "same-tier/same-reason pushes from different collections will clobber each other. "
+                "Expected: reject_{data['tier']}_{data['reason']}_{data['collection']}"
+            )
+
+    def test_all_three_label_dimensions_in_metrics_data(self):
+        """reason, tier, and collection must all be serialised into the subprocess data dict."""
+        with patch("subprocess.Popen") as mock_popen:
+            push_retrieval_reject_metric_async(
+                reason="ceiling_exceeded",
+                tier="2_injection",
+                collection="discussions",
+                count=2,
+            )
+            assert mock_popen.called
+            call_args = mock_popen.call_args[0][0]
+            inline_script = call_args[2]
+
+            assert '"reason": "ceiling_exceeded"' in inline_script
+            assert '"tier": "2_injection"' in inline_script
+            assert '"collection": "discussions"' in inline_script
+            assert '"count": 2' in inline_script


### PR DESCRIPTION
## Summary

POV-side half of the v2.4.1 hygiene release. Closes 2 bugs and 1 tech-debt item
from the v2.4.0 deferral set (DEC-PM289-D1, DEC-PM289-D6).

## Scope

| Item | Severity | Files | Verification |
|---|---|---|---|
| BUG-299 — sanctum / `_memory/` `cp -p` | LOW | `scripts/install.sh` (5 `cp` invocations) | mtimes preserved across re-install |
| BUG-300 — pushgateway `grouping_key` | MEDIUM | `src/memory/metrics_push.py` | both-reason series persist in pushgateway |
| TD-526 — POV observability docs | LOW | `docs/prometheus-queries.md`, `docs/CONFIGURATION.md`, `docs/PARZIVAL-SESSION-GUIDE.md` | doc grep returns expected matches |

**BUG-299** preserves file modification timestamps across reinstalls. The
installer's sanctum and `_memory/` backup/restore copy steps used plain `cp`,
resetting destination mtimes on every upgrade (content was already preserved).
Five user-data `cp` invocations in `deploy_parzival_v2()` now pass `-p` (or
`-rp` for the recursive backup copies): the sanctum backup, sanctum restore,
CREED merge-fallback restore, and the `_memory/` backup and restore. The
`_memory/` block (backup line + restore line) is the same defect class as the
three sanctum lines and was fixed in the same patch.

**BUG-300** adds the rejection `reason` to the pushgateway `grouping_key` for
the retrieval-budget rejection counter. Pushgateway POST semantics replace all
metrics sharing a `grouping_key`, so two rejections of different reasons at the
same tier within one bootstrap overwrote each other. Cardinality rises from 2
to 8 series (2 tiers × 4 reasons).

**TD-526** documents the PM #288 retrieval-rejection observability surface for
operators: the `aimemory_retrieval_budget_reject_total` counter, the
`HANDOFF_CEILING_TOKENS` environment variable, and the `[FALLBACK-NEEDED:]`
marker contract.

## TD-516 — closed resolved-by-design (not in this PR)

TD-516 (BMAD reviewer activation) was in the original brief scope. Investigation
found its briefed target skill (`aim-bmad-dispatch`) does not exist, and the
mechanism it describes (`subagent_type`-based persona discovery, `bmm-` agent
namespace) does not match the current dispatch architecture — the PM #284→v2.4.0
refactor eliminated that symptom class. Reviewed and closed **resolved-by-design**
on the lead-dev side; no code change is needed. Not part of this PR.

## Test plan

- [x] CI actionable checks PASS — 12 pass / 0 fail
- [x] Local lint PASS — `black`, `ruff`, `isort` clean on the changed Python; `bash -n` clean on `install.sh`
- [x] BUG-300 — synthetic dual-reject test PASS: two same-tier, different-reason pushes land at distinct grouping keys (`reject_1_bootstrap_budget_exceeded`, `reject_1_bootstrap_score_gap`); both series persist in the pushgateway
- [x] TD-526 — doc grep resolves `aimemory_retrieval_budget_reject` / `handoff_ceiling_tokens` / `FALLBACK-NEEDED` in `docs/` (16 matches)
- [ ] BUG-299 — re-install mtime preservation: covered by the combined v2.4.1 live-test (nuke + fresh install). The five `cp` invocations are diff-verified to carry `-p`/`-rp`; a standalone installer run is not isolable here (port conflict with the running stack).

## Coordination

Parallel-PR companion: `feature/v2.4.1-general-hygiene` (#139). File-disjoint
scopes; `CHANGELOG.md` is the only file needing first-to-merge handling (both add
to `## [Unreleased]`; the second to merge rebases its entries). `scripts/install.sh`
is touched by both PRs but in different functions (`import_user_env()` vs
`deploy_parzival_v2()`) — no conflict. v2.4.1 tag-cut happens after both PRs land,
gated on a combined live-test.

Closes: BUG-299, BUG-300, TD-526.
