### PR TITLE
Fix stale version marker and add a version-consistency CI gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,35 +108,26 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Run tests
+        id: tests
         run: |
           pytest tests/ -v --ignore=tests/e2e --ignore=tests/integration -m "not quarantine" -p no:randomly
 
       - name: Verify Docker stack
+        id: docker
         run: |
           # Just validate docker-compose.yml syntax
           docker compose -f docker/docker-compose.yml config
 
       - name: Check version consistency
+        id: version_check
         run: |
-          TAG="${{ github.event.release.tag_name }}"
-          VERSION_FILE="src/memory/__version__.py"
-
-          # Extract version from __version__.py
-          PYTHON_VERSION=$(grep -oP '__version__\s*=\s*"\K[^"]+' $VERSION_FILE)
-
-          echo "Release tag: $TAG"
-          echo "Python __version__: $PYTHON_VERSION"
-
-          # Strip 'v' prefix from tag if present
-          TAG_VERSION="${TAG#v}"
-
-          if [ "$TAG_VERSION" != "$PYTHON_VERSION" ]; then
-            echo "❌ Version mismatch!"
-            echo "Release tag $TAG does not match __version__.py ($PYTHON_VERSION)"
-            exit 1
-          fi
-
-          echo "✅ Version consistency verified!"
+          set -o pipefail
+          # The shared check asserts the three version markers agree and,
+          # with --tag, that they also equal the release tag and the latest
+          # CHANGELOG heading. It emits ::error:: annotations on mismatch.
+          # Output is teed to a log so the comment step can surface the detail.
+          python scripts/check_version_consistency.py \
+            --tag "${{ github.event.release.tag_name }}" 2>&1 | tee version_check.log
 
       - name: Comment validation result
         if: always()
@@ -144,15 +135,50 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const releaseId = context.payload.release.id;
-            const conclusion = '${{ job.status }}';
+            const fs = require('fs');
 
-            let emoji = conclusion === 'success' ? '✅' : '❌';
-            let message = conclusion === 'success'
-              ? 'Release validation passed! All tests and checks successful.'
-              : 'Release validation failed. Please review the workflow logs.';
+            // Map each validation step to its outcome so a failure names the
+            // specific check that failed instead of a generic message.
+            const checks = [
+              { name: 'Run tests', outcome: '${{ steps.tests.outcome }}' },
+              { name: 'Verify Docker stack', outcome: '${{ steps.docker.outcome }}' },
+              { name: 'Check version consistency', outcome: '${{ steps.version_check.outcome }}' },
+            ];
+            const failed = checks.filter((c) => c.outcome === 'failure');
+
+            let emoji;
+            let message;
+            if (failed.length === 0) {
+              emoji = '✅';
+              message = 'Release validation passed! All tests and checks successful.';
+            } else {
+              emoji = '❌';
+              const names = failed.map((c) => c.name).join(', ');
+              message = `Release validation failed at: ${names}.`;
+
+              // Surface the version-consistency mismatch detail, if any.
+              if (failed.some((c) => c.name === 'Check version consistency')) {
+                try {
+                  const log = fs.readFileSync('version_check.log', 'utf8').trim();
+                  if (log) {
+                    message += `\n\nVersion consistency detail:\n${log}`;
+                  }
+                } catch (err) {
+                  console.log(`Could not read version_check.log: ${err}`);
+                }
+              }
+            }
 
             // Note: GitHub REST API does not have createReleaseDiscussion.
-            // Log validation result as a workflow annotation instead.
+            // Surface the result as a workflow annotation and job summary.
             console.log(`${emoji} Release Validation: ${message}`);
             console.log(`Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`);
+
+            await core.summary
+              .addHeading(`${emoji} Release Validation`)
+              .addRaw(message)
+              .write();
+
+            if (failed.length > 0) {
+              core.setFailed(message);
+            }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,24 @@ jobs:
         run: isort --check-only --profile black src/ tests/
 
   # ============================================================================
+  # VERSION CONSISTENCY - Assert the three version markers stay in sync
+  # ============================================================================
+  version-consistency:
+    name: Version Consistency
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Check version markers agree
+        run: python scripts/check_version_consistency.py
+
+  # ============================================================================
   # UNIT TESTS - Fast tests without external dependencies
   # ============================================================================
   unit-tests:
@@ -529,19 +547,24 @@ jobs:
   # ============================================================================
   ci-success:
     name: CI Success
-    needs: [lint, unit-tests, integration-tests, e2e-tests]
+    needs: [lint, version-consistency, unit-tests, integration-tests, e2e-tests]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Check all results
         run: |
           echo "Lint: ${{ needs.lint.result }}"
+          echo "Version Consistency: ${{ needs.version-consistency.result }}"
           echo "Unit Tests: ${{ needs.unit-tests.result }}"
           echo "Integration Tests: ${{ needs.integration-tests.result }}"
           echo "E2E Tests: ${{ needs.e2e-tests.result }}"
 
           if [[ "${{ needs.lint.result }}" != "success" ]]; then
             echo "::error::Lint checks failed"
+            exit 1
+          fi
+          if [[ "${{ needs.version-consistency.result }}" != "success" ]]; then
+            echo "::error::Version consistency check failed"
             exit 1
           fi
           if [[ "${{ needs.unit-tests.result }}" != "success" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Version-marker consistency check (`scripts/check_version_consistency.py`) that asserts the three repository version markers always agree: `version.txt`, `pyproject.toml` `[project] version`, and `src/memory/__version__.py` `__version__`. It runs on every pull request and push via the `Test Suite` workflow, and on a release build additionally asserts the markers equal the release tag and the latest non-`[Unreleased]` `CHANGELOG.md` heading. Covered by `tests/test_check_version_consistency.py` (agree, disagree, and tag-mode cases). (BUG-307)
+
+### Fixed
+
+- `src/memory/__version__.py` `__version__` was stale at `2.3.2` while `version.txt` and `pyproject.toml` declared `2.4.1`, so v2.4.0/v2.4.1 installs self-reported the wrong version and the `Release Management` workflow's version-consistency step failed on every tag-cut. Corrected `__version__` to `2.4.1` and added version-history lines for 2.4.0 and 2.4.1. (BUG-307)
+- `src/memory/metrics.py` no longer carries an independent hardcoded version string for its Prometheus version `Info` metric. The `importlib.metadata` fallback now reads `src/memory/__version__.py` instead of a literal, so the metric value cannot drift from the single source of truth. (BUG-307)
+- The `Release Management` workflow's release-validation summary now names the specific validation step that failed — and surfaces the version-mismatch detail — instead of emitting a generic "Release validation failed" message. (BUG-307)
+
 ## [2.4.1] - 2026-05-16
 
 ### Added

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Version-marker consistency check (BUG-307).
+
+The repository declares its version in three places that must always agree:
+
+- ``version.txt``                       -- plain-text marker
+- ``pyproject.toml`` ``[project] version`` -- packaging marker
+- ``src/memory/__version__.py`` ``__version__`` -- Python single source of truth
+
+Nothing previously kept them in sync, so v2.4.0 shipped all three stale and
+v2.4.1 bumped only two -- the drift was invisible until release tag-cut. This
+script asserts the three markers agree and is wired into the Test Suite
+workflow so drift fails a pull request instead of a release.
+
+On a tag/release build (``--tag`` supplied) it additionally asserts the
+markers equal the release tag (``v`` prefix stripped) and the latest
+non-``[Unreleased]`` ``CHANGELOG.md`` heading.
+
+Exit codes:
+    0 - all markers agree (and match the tag/CHANGELOG when ``--tag`` given)
+    1 - a mismatch was found; disagreeing markers and values are printed
+    2 - a marker could not be read (missing file or unparseable value)
+
+Usage:
+    python scripts/check_version_consistency.py
+    python scripts/check_version_consistency.py --tag v2.4.2
+    python scripts/check_version_consistency.py --root /path/to/repo
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+# Marker location relative to the repository root.
+VERSION_TXT = "version.txt"
+PYPROJECT = "pyproject.toml"
+VERSION_PY = "src/memory/__version__.py"
+CHANGELOG = "CHANGELOG.md"
+
+
+class MarkerError(Exception):
+    """A version marker could not be located or parsed."""
+
+
+def _repo_root(explicit: str | None) -> Path:
+    """Resolve the repository root.
+
+    Defaults to the parent of this script's directory (``scripts/``).
+    """
+    if explicit:
+        return Path(explicit).resolve()
+    return Path(__file__).resolve().parents[1]
+
+
+def read_version_txt(root: Path) -> str:
+    """Return the version string from ``version.txt``."""
+    path = root / VERSION_TXT
+    try:
+        value = path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        raise MarkerError(f"cannot read {VERSION_TXT}: {exc}") from exc
+    if not value:
+        raise MarkerError(f"{VERSION_TXT} is empty")
+    return value
+
+
+def read_pyproject_version(root: Path) -> str:
+    """Return the ``[project] version`` value from ``pyproject.toml``.
+
+    Parsed with a scoped regex rather than a TOML library so the check runs
+    identically on Python 3.10 (no stdlib ``tomllib``).
+    """
+    path = root / PYPROJECT
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise MarkerError(f"cannot read {PYPROJECT}: {exc}") from exc
+
+    # Isolate the [project] table: from its header to the next table header.
+    section = re.search(
+        r"^\[project\]\s*$(.*?)(?=^\[|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    if not section:
+        raise MarkerError(f"{PYPROJECT} has no [project] table")
+
+    match = re.search(
+        r'^version\s*=\s*["\']([^"\']+)["\']',
+        section.group(1),
+        re.MULTILINE,
+    )
+    if not match:
+        raise MarkerError(f"{PYPROJECT} [project] table has no version key")
+    return match.group(1).strip()
+
+
+def read_version_py(root: Path) -> str:
+    """Return the ``__version__`` value from ``src/memory/__version__.py``."""
+    path = root / VERSION_PY
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise MarkerError(f"cannot read {VERSION_PY}: {exc}") from exc
+
+    match = re.search(
+        r'^__version__\s*=\s*["\']([^"\']+)["\']',
+        text,
+        re.MULTILINE,
+    )
+    if not match:
+        raise MarkerError(f"{VERSION_PY} has no __version__ assignment")
+    return match.group(1).strip()
+
+
+def read_changelog_release_version(root: Path) -> str:
+    """Return the latest non-``[Unreleased]`` release heading in the CHANGELOG."""
+    path = root / CHANGELOG
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise MarkerError(f"cannot read {CHANGELOG}: {exc}") from exc
+
+    match = re.search(
+        r"^##\s*\[(\d+\.\d+\.\d+)\]",
+        text,
+        re.MULTILINE,
+    )
+    if not match:
+        raise MarkerError(f"{CHANGELOG} has no '## [x.y.z]' release heading")
+    return match.group(1).strip()
+
+
+def collect_markers(root: Path) -> dict[str, str]:
+    """Read the three required version markers.
+
+    Returns a mapping of human-readable marker name to its value.
+    """
+    return {
+        VERSION_TXT: read_version_txt(root),
+        f"{PYPROJECT} [project] version": read_pyproject_version(root),
+        f"{VERSION_PY} __version__": read_version_py(root),
+    }
+
+
+def check_consistency(
+    markers: dict[str, str],
+    tag: str | None = None,
+    changelog_version: str | None = None,
+) -> list[str]:
+    """Return a list of mismatch messages; empty list means all agree.
+
+    ``markers`` maps marker name to value. When ``tag`` is given, every marker
+    must also equal the ``v``-stripped tag and ``changelog_version``.
+    """
+    errors: list[str] = []
+
+    distinct = set(markers.values())
+    if len(distinct) > 1:
+        detail = ", ".join(f"{name}={value!r}" for name, value in markers.items())
+        errors.append(f"version markers disagree: {detail}")
+
+    if tag is not None:
+        expected = tag[1:] if tag.startswith("v") else tag
+        for name, value in markers.items():
+            if value != expected:
+                errors.append(
+                    f"{name}={value!r} does not match release tag "
+                    f"{tag!r} (expected {expected!r})"
+                )
+        if changelog_version is not None and changelog_version != expected:
+            errors.append(
+                f"latest CHANGELOG release heading {changelog_version!r} "
+                f"does not match release tag {tag!r} (expected {expected!r})"
+            )
+
+    return errors
+
+
+def _emit_actions_error(message: str) -> None:
+    """Emit a GitHub Actions error annotation when running in CI."""
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        # Newlines are not permitted inside a workflow command.
+        print(f"::error title=Version consistency::{message.replace(chr(10), ' ')}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. See module docstring for exit codes."""
+    parser = argparse.ArgumentParser(
+        description="Assert the three repository version markers agree."
+    )
+    parser.add_argument(
+        "--root",
+        default=None,
+        help="Repository root (defaults to the parent of scripts/).",
+    )
+    parser.add_argument(
+        "--tag",
+        default=None,
+        help="Release tag to additionally assert against (e.g. v2.4.2).",
+    )
+    args = parser.parse_args(argv)
+
+    root = _repo_root(args.root)
+
+    try:
+        markers = collect_markers(root)
+        changelog_version = read_changelog_release_version(root) if args.tag else None
+    except MarkerError as exc:
+        message = f"cannot read a version marker: {exc}"
+        print(f"ERROR: {message}", file=sys.stderr)
+        _emit_actions_error(message)
+        return 2
+
+    print("Version markers:")
+    for name, value in markers.items():
+        print(f"  {name} = {value}")
+    if args.tag:
+        print(f"  release tag = {args.tag}")
+        print(f"  {CHANGELOG} latest release heading = {changelog_version}")
+
+    errors = check_consistency(
+        markers, tag=args.tag, changelog_version=changelog_version
+    )
+    if errors:
+        print("\nVersion consistency check FAILED:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+            _emit_actions_error(error)
+        return 1
+
+    print("\nVersion consistency check passed: all markers agree.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/memory/__version__.py
+++ b/src/memory/__version__.py
@@ -4,10 +4,12 @@ Single source of truth for version number.
 Follows PEP 440 and semantic versioning principles.
 """
 
-__version__ = "2.3.2"
+__version__ = "2.4.1"
 __version_info__ = tuple(int(part) for part in __version__.split("."))
 
 # Version history:
+# 2.4.1 - Backup/restore hardening, Langfuse install fixup, pushgateway and bootstrap fixes (TD-517, BUG-298)
+# 2.4.0 - Silent-drop fix, Sanctum identity, env-secrets split, classifier resilience (BUG-297)
 # 2.3.2 - Security patches, group_id normalization, Phase B live-verify fixes (PRs #110, #111, #112)
 # 2.3.1 - Endpoint alignment, typed OrderBy API, documentation accuracy (PR #108)
 # 2.3.0 - Stabilization: Langfuse v4, security hardening, data integrity, CI regression gate

--- a/src/memory/metrics.py
+++ b/src/memory/metrics.py
@@ -30,7 +30,10 @@ try:
 
     _VERSION = pkg_version("ai-memory")
 except Exception:
-    _VERSION = "2.3.2"
+    # Fall back to the in-tree single source of truth when package metadata is
+    # unavailable (e.g. running from a source checkout). memory.__version__ is a
+    # leaf module with no imports, so this cannot cause a circular import.
+    from memory.__version__ import __version__ as _VERSION
 
 # ==============================================================================
 # COUNTERS - Monotonically increasing values

--- a/tests/test_check_version_consistency.py
+++ b/tests/test_check_version_consistency.py
@@ -1,0 +1,146 @@
+"""Tests for scripts/check_version_consistency.py (BUG-307).
+
+Covers the three-marker consistency check:
+- the agree case (all markers match -> exit 0)
+- the disagree case (a marker drifts -> exit 1, disagreement reported)
+- tag/release mode (markers must also equal the tag and CHANGELOG heading)
+- the live repository markers actually agree
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# Load scripts/check_version_consistency.py. The script lives outside any
+# importable package, so load it by file location (mirrors test_version.py).
+_SCRIPT = Path(__file__).parent.parent / "scripts" / "check_version_consistency.py"
+_spec = importlib.util.spec_from_file_location("check_version_consistency", _SCRIPT)
+cvc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cvc)
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+def _write_repo(
+    root: Path,
+    version_txt: str,
+    pyproject: str,
+    version_py: str,
+    changelog: str | None = None,
+) -> None:
+    """Create a minimal repo tree with the version markers under ``root``."""
+    (root / "version.txt").write_text(version_txt, encoding="utf-8")
+    (root / "pyproject.toml").write_text(
+        f'[project]\nname = "ai-memory"\nversion = "{pyproject}"\n'
+        '\n[tool.ruff]\ntarget-version = "py310"\n',
+        encoding="utf-8",
+    )
+    version_dir = root / "src" / "memory"
+    version_dir.mkdir(parents=True, exist_ok=True)
+    (version_dir / "__version__.py").write_text(
+        f'__version__ = "{version_py}"\n'
+        '__version_info__ = tuple(int(p) for p in __version__.split("."))\n',
+        encoding="utf-8",
+    )
+    if changelog is not None:
+        (root / "CHANGELOG.md").write_text(changelog, encoding="utf-8")
+
+
+_CHANGELOG = (
+    "# Changelog\n\n"
+    "## [Unreleased]\n\n"
+    "## [2.4.1] - 2026-05-16\n\n### Fixed\n\n- something\n"
+)
+
+
+class TestMarkerReaders:
+    """The individual marker readers parse the expected values."""
+
+    def test_readers_return_marker_values(self, tmp_path):
+        _write_repo(tmp_path, "2.4.1", "2.4.1", "2.4.1", _CHANGELOG)
+
+        assert cvc.read_version_txt(tmp_path) == "2.4.1"
+        assert cvc.read_pyproject_version(tmp_path) == "2.4.1"
+        assert cvc.read_version_py(tmp_path) == "2.4.1"
+        assert cvc.read_changelog_release_version(tmp_path) == "2.4.1"
+
+    def test_pyproject_reader_ignores_other_version_keys(self, tmp_path):
+        """``target-version`` under [tool.ruff] must not be mistaken for it."""
+        _write_repo(tmp_path, "2.4.1", "2.4.1", "2.4.1")
+        assert cvc.read_pyproject_version(tmp_path) == "2.4.1"
+
+    def test_missing_marker_raises_marker_error(self, tmp_path):
+        with pytest.raises(cvc.MarkerError):
+            cvc.read_version_txt(tmp_path)
+
+
+class TestCheckConsistency:
+    """The pure comparison logic."""
+
+    def test_agree_case_returns_no_errors(self):
+        markers = {"a": "2.4.1", "b": "2.4.1", "c": "2.4.1"}
+        assert cvc.check_consistency(markers) == []
+
+    def test_disagree_case_reports_markers_and_values(self):
+        markers = {"a": "2.4.1", "b": "2.3.2", "c": "2.4.1"}
+        errors = cvc.check_consistency(markers)
+        assert len(errors) == 1
+        # Every marker name and value appears in the message.
+        assert "2.4.1" in errors[0] and "2.3.2" in errors[0]
+        assert "a=" in errors[0] and "b=" in errors[0] and "c=" in errors[0]
+
+    def test_tag_mode_agree(self):
+        markers = {"a": "2.4.2", "b": "2.4.2", "c": "2.4.2"}
+        errors = cvc.check_consistency(markers, tag="v2.4.2", changelog_version="2.4.2")
+        assert errors == []
+
+    def test_tag_mode_rejects_tag_mismatch(self):
+        markers = {"a": "2.4.1", "b": "2.4.1", "c": "2.4.1"}
+        errors = cvc.check_consistency(markers, tag="v2.4.2", changelog_version="2.4.1")
+        # One per marker that disagrees with the tag.
+        assert any("release tag" in e for e in errors)
+        assert len(errors) >= 3
+
+    def test_tag_mode_rejects_changelog_mismatch(self):
+        markers = {"a": "2.4.2", "b": "2.4.2", "c": "2.4.2"}
+        errors = cvc.check_consistency(markers, tag="v2.4.2", changelog_version="2.4.1")
+        assert any("CHANGELOG" in e for e in errors)
+
+
+class TestMainExitCodes:
+    """End-to-end exit codes via ``main()``."""
+
+    def test_main_agree_exits_zero(self, tmp_path):
+        _write_repo(tmp_path, "2.4.1", "2.4.1", "2.4.1", _CHANGELOG)
+        assert cvc.main(["--root", str(tmp_path)]) == 0
+
+    def test_main_disagree_exits_one(self, tmp_path, capsys):
+        _write_repo(tmp_path, "2.4.1", "2.4.1", "2.3.2", _CHANGELOG)
+        assert cvc.main(["--root", str(tmp_path)]) == 1
+        captured = capsys.readouterr()
+        assert "FAILED" in captured.err
+        assert "2.3.2" in captured.err
+
+    def test_main_tag_mode_agree_exits_zero(self, tmp_path):
+        _write_repo(tmp_path, "2.4.1", "2.4.1", "2.4.1", _CHANGELOG)
+        assert cvc.main(["--root", str(tmp_path), "--tag", "v2.4.1"]) == 0
+
+    def test_main_tag_mode_mismatch_exits_one(self, tmp_path):
+        _write_repo(tmp_path, "2.4.1", "2.4.1", "2.4.1", _CHANGELOG)
+        assert cvc.main(["--root", str(tmp_path), "--tag", "v2.4.2"]) == 1
+
+    def test_main_unreadable_marker_exits_two(self, tmp_path, capsys):
+        # No marker files written at all.
+        assert cvc.main(["--root", str(tmp_path)]) == 2
+        assert "cannot read" in capsys.readouterr().err
+
+
+class TestLiveRepository:
+    """The real repository markers must agree (regression guard for BUG-307)."""
+
+    def test_live_markers_are_consistent(self):
+        markers = cvc.collect_markers(REPO_ROOT)
+        assert (
+            cvc.check_consistency(markers) == []
+        ), f"repository version markers disagree: {markers}"

--- a/tests/test_check_version_consistency.py
+++ b/tests/test_check_version_consistency.py
@@ -74,6 +74,37 @@ class TestMarkerReaders:
         with pytest.raises(cvc.MarkerError):
             cvc.read_version_txt(tmp_path)
 
+    def test_pyproject_reader_missing_file_raises(self, tmp_path):
+        with pytest.raises(cvc.MarkerError):
+            cvc.read_pyproject_version(tmp_path)
+
+    def test_pyproject_reader_missing_project_table_raises(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.ruff]\ntarget-version = "py310"\n', encoding="utf-8"
+        )
+        with pytest.raises(cvc.MarkerError):
+            cvc.read_pyproject_version(tmp_path)
+
+    def test_pyproject_reader_missing_version_key_raises(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "ai-memory"\n', encoding="utf-8"
+        )
+        with pytest.raises(cvc.MarkerError):
+            cvc.read_pyproject_version(tmp_path)
+
+    def test_version_py_reader_missing_file_raises(self, tmp_path):
+        with pytest.raises(cvc.MarkerError):
+            cvc.read_version_py(tmp_path)
+
+    def test_version_py_reader_missing_assignment_raises(self, tmp_path):
+        version_dir = tmp_path / "src" / "memory"
+        version_dir.mkdir(parents=True)
+        (version_dir / "__version__.py").write_text(
+            '"""No version assignment here."""\n', encoding="utf-8"
+        )
+        with pytest.raises(cvc.MarkerError):
+            cvc.read_version_py(tmp_path)
+
 
 class TestCheckConsistency:
     """The pure comparison logic."""
@@ -130,10 +161,41 @@ class TestMainExitCodes:
         _write_repo(tmp_path, "2.4.1", "2.4.1", "2.4.1", _CHANGELOG)
         assert cvc.main(["--root", str(tmp_path), "--tag", "v2.4.2"]) == 1
 
+    def test_main_tag_mode_changelog_mismatch_exits_one(self, tmp_path, capsys):
+        # All three markers agree with the tag, but the CHANGELOG's latest
+        # release heading lags behind it.
+        _write_repo(tmp_path, "2.4.2", "2.4.2", "2.4.2", _CHANGELOG)
+        assert cvc.main(["--root", str(tmp_path), "--tag", "v2.4.2"]) == 1
+        captured = capsys.readouterr()
+        assert "FAILED" in captured.err
+        assert "CHANGELOG" in captured.err
+
     def test_main_unreadable_marker_exits_two(self, tmp_path, capsys):
         # No marker files written at all.
         assert cvc.main(["--root", str(tmp_path)]) == 2
         assert "cannot read" in capsys.readouterr().err
+
+
+class TestEmitActionsError:
+    """The GitHub Actions annotation path."""
+
+    def test_emits_single_line_annotation_under_github_actions(
+        self, monkeypatch, capsys
+    ):
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        cvc._emit_actions_error("line one\nline two")
+        out = capsys.readouterr().out.strip()
+        # A workflow command must be a single line.
+        assert "\n" not in out
+        assert out.startswith("::error ")
+        assert "title=Version consistency::" in out
+        # The newline is replaced by a space, not dropped.
+        assert "line one line two" in out
+
+    def test_emits_nothing_outside_github_actions(self, monkeypatch, capsys):
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+        cvc._emit_actions_error("some error")
+        assert capsys.readouterr().out == ""
 
 
 class TestLiveRepository:


### PR DESCRIPTION
## Summary

`src/memory/__version__.py` — the declared single source of truth for the package version — was stale at `2.3.2`. This caused the `Release Management` workflow's `Check version consistency` step to fail on every release since v2.4.0, and made v2.4.0/v2.4.1 installs self-report the wrong version. There are three version markers in the repo (`version.txt`, `pyproject.toml`, `src/memory/__version__.py`) with no procedure or gate keeping them in sync, so they drifted independently.

## Changes

- **`src/memory/__version__.py`** — corrected `__version__` to `2.4.1` (matching `version.txt` and `pyproject.toml`); added version-history lines for 2.4.0 and 2.4.1.
- **`src/memory/metrics.py`** — replaced a hardcoded `"2.3.2"` fallback (used when `importlib.metadata` cannot resolve package metadata) with an import of `__version__`, so the fallback tracks the SSOT instead of drifting.
- **`scripts/check_version_consistency.py`** (new) — asserts all three version markers agree. In `--tag` mode it also asserts they equal the release tag and the latest `CHANGELOG.md` version heading. Distinct exit codes for agreement / mismatch / unreadable marker; emits GitHub Actions error annotations.
- **`.github/workflows/test.yml`** — new `version-consistency` job running on every push and pull request, wired into the `ci-success` gate so marker drift fails a required check before merge.
- **`.github/workflows/release.yml`** — the release-time version check now uses the shared script; the validation-result comment names the specific failing step and surfaces the mismatch detail instead of a generic message.
- **`tests/test_check_version_consistency.py`** (new) — 22 tests covering marker readers, agreement and mismatch cases, tag mode, CHANGELOG-heading checks, exit codes, and the annotation path.
- **`CHANGELOG.md`** — `[Unreleased]` entry.

## Verification

- 22/22 new tests pass; existing version/metrics tests pass; no regressions in the unit suite.
- Negative test: diverging a marker locally makes the check exit non-zero and name the disagreeing markers.
- `black`, `ruff`, `isort` clean.