### PR TITLE
Reconcile the bug/TD INDEX at session close

### DIFF
--- a/_ai-memory/pov/templates/bug-report.template.md
+++ b/_ai-memory/pov/templates/bug-report.template.md
@@ -57,6 +57,7 @@ New → In Progress → Fixed → Verified → Closed
                       ↓
                   Reopened (if verification fails) → In Progress
 ```
+Closed-class statuses: Fixed, Verified, Closed. Open-class: New, In Progress, Reopened.
 
 ### Severity Guide
 - **Critical**: System down, data loss, security vulnerability

--- a/_ai-memory/pov/workflows/session/close/steps-c/step-02-update-tracking.md
+++ b/_ai-memory/pov/workflows/session/close/steps-c/step-02-update-tracking.md
@@ -106,13 +106,34 @@ Wait for user response. Execute any requested documentation updates.
 
 ---
 
-### 5. Verify Tracking State
+### 5. Reconcile the Bug / Tech-Debt INDEX
+
+Run the tracking-freshness skill so the bug and tech-debt `INDEX.md` files are
+reconciled against the current `bugs/*.md` and `tech-debt/*.md` records before
+the session closes:
+
+/aim-tracking-freshness --check
+
+- Reports `INDEX files are fully in sync` → note it and proceed.
+- Reports any divergence, missing-from-INDEX, orphan row, missing INDEX file, or
+  skipped / no-status record → present the summary to the user; on confirmation
+  run `/aim-tracking-freshness --write` to regenerate the INDEX files, then
+  re-run `--check` to confirm sync.
+
+This applies to `bugs/INDEX.md` + `tech-debt/INDEX.md` the same close-time
+discipline already applied to `SESSION_WORK_INDEX.md`. Skipping it is the drift
+root-caused in `oversight/tracking/RCA-tracking-system-drift-PM296.md` (RC-1).
+
+---
+
+### 6. Verify Tracking State
 
 After all updates, confirm:
 - Task tracker reflects current reality
 - Decision log includes all session decisions
 - Blockers log includes all session blockers
 - Risk register is current (update if user requested)
+- Bug/TD INDEX reconciled and in sync (per section 5)
 
 ## CRITICAL STEP COMPLETION NOTE
 


### PR DESCRIPTION
## Summary

Adds a session-close step that reconciles `oversight/bugs/INDEX.md` and `oversight/tech-debt/INDEX.md` against the current record files, using the `aim-tracking-freshness` skill — the same close-time discipline already applied to `SESSION_WORK_INDEX.md`.

Previously the session-close workflow never reconciled the bug/TD INDEX files, so they drifted silently between sessions. This is the RC-1 fix from `oversight/tracking/RCA-tracking-system-drift-PM296.md`.

## Changes

- `_ai-memory/pov/workflows/session/close/steps-c/step-02-update-tracking.md` — new section 5 "Reconcile the Bug / Tech-Debt INDEX" (runs `aim-tracking-freshness --check`, and `--write` on confirmed drift); "Verify Tracking State" renumbered to 6 with a reconciliation bullet.
- `_ai-memory/pov/templates/bug-report.template.md` — documents the bug closed-class statuses (Fixed, Verified, Closed), matching the tech-debt-report template.

## Test plan

POV workflow-instruction + template changes — no code paths. Verified by review.