### PR TITLE
ci: fix env-drift gate dotenv-linter subcommand (lint not check)

### DIFF
--- a/.github/workflows/env-drift.yml
+++ b/.github/workflows/env-drift.yml
@@ -8,11 +8,11 @@ name: Env Drift Gate
 # a deployment-time surprise.
 #
 # Two checks:
-#   1. dotenv-linter check — validates .env file syntax/formatting for both
-#      docker/.env.example and docker/.env.secrets.example separately.
-#      (Note: `check` not `compare` — the two files are intentionally different
-#      key sets: .env.example has all keys; .env.secrets.example has only
-#      sensitive keys. `compare` would fail on that intended asymmetry.)
+#   1. dotenv-linter lint — validates .env file syntax/formatting for both
+#      docker/.env.example and docker/.env.secrets.example separately. Each
+#      file is linted independently; `compare` is intentionally not used
+#      because the two files have different key sets (.env.example has all
+#      keys; .env.secrets.example has only sensitive keys).
 #   2. Pydantic completeness check — scripts/check_env_completeness.py introspects
 #      MemoryConfig.model_fields and asserts every field is documented in
 #      docker/.env.example (active or commented-out line).
@@ -54,10 +54,10 @@ jobs:
           fi
 
       - name: Check docker/.env.example syntax
-        run: dotenv-linter check docker/.env.example
+        run: dotenv-linter lint docker/.env.example
 
       - name: Check docker/.env.secrets.example syntax
-        run: dotenv-linter check docker/.env.secrets.example
+        run: dotenv-linter lint docker/.env.secrets.example
 
       - name: Check Pydantic schema vs .env.example parity
         env:


### PR DESCRIPTION
## Summary

The `Env Drift Gate` workflow (`.github/workflows/env-drift.yml`) invokes `dotenv-linter check <file>`, but the `dotenv-linter` CLI has no `check` subcommand — valid subcommands are `lint`, `compare`, `fix`, and `list`. The CLI parses `check` as the first filename argument and dies with `File 'check' does not exist`, exit code 2.

## Impact

Latent in `main` since v2.4.0 merge `93ad34b`. The workflow only triggers on PRs touching `src/memory/config.py`, the `.env.example` files, or `docker-compose.yml` — so it never ran on a `main` push, and PR #148 was the first PR since v2.4.0 to touch one of those paths. Hence the first-ever surfacing of this bug.

`Env Drift Gate` is not in `required_status_checks`, so it never blocked a merge — but it has been silently failing on every PR that touches its trigger paths since `93ad34b`, leaving the env-drift detection feature effectively dead.

## Fix

Two changes to `.github/workflows/env-drift.yml`:

1. **`run: dotenv-linter check <file>` → `run: dotenv-linter lint <file>`** at both step invocations (lines 55, 58).
2. **Comment block (lines 11-15)** rewritten to remove the misleading "`check` not `compare`" defense — the original author confused `check` with a real subcommand. The new comment correctly states that `compare` is intentionally not used because the two files have different key sets.

Step `name:` fields preserved (`Check ... syntax` is fine as a human-readable step name).

## Test plan

- [ ] CI on this PR runs the `Env Drift Gate` workflow against the fixed YAML — confirms `dotenv-linter lint` is a valid invocation.
- [ ] If `dotenv-linter lint` surfaces real `.env.example` syntax issues on first run, that is a content bug to fix separately — the workflow restoration here is independent of any content findings.

## Independence

Touches only `.github/workflows/env-drift.yml`. No source, no test, no CHANGELOG (CI hygiene; no user-facing change).