### PR TITLE
Add shadow drop-reason observability to tier-2 injection (PLAN-028 P2-2 Phase A)

### DIFF
--- a/.claude/hooks/scripts/context_injection_tier2.py
+++ b/.claude/hooks/scripts/context_injection_tier2.py
@@ -278,6 +278,7 @@ def main() -> int:
         # WP-2: Apply freshness penalty to code-patterns results (Spec §4.2.5, §4.5.3)
         # Applied before gating — penalized scores affect both gating threshold and greedy selection
         _freshness_blocked_count = 0
+        _freshness_blocked_ids: set[str] = set()
         for _r in all_results:
             if _r.get("collection") != COLLECTION_CODE_PATTERNS:
                 continue
@@ -313,6 +314,10 @@ def main() -> int:
                     )
             if _penalty == 0.0 and _orig_score > 0.0:
                 _freshness_blocked_count += 1
+                # PLAN-028 P2-2 (R2): remember which candidates the freshness
+                # penalty fully blocked so the downstream greedy score-gap drop
+                # is attributed to `freshness_block` (observe-only).
+                _freshness_blocked_ids.add(str(_r.get("id", "")))
 
         # Re-sort after penalty application (penalized scores may have changed relative order)
         all_results.sort(key=lambda r: r.get("score", 0), reverse=True)
@@ -423,6 +428,7 @@ def main() -> int:
             project_id=project_name,
             tier=2,
             return_meta=True,
+            freshness_blocked_ids=_freshness_blocked_ids,
         )
         _tier2_fallback_reject = None
         if _greedy_meta.get("fallback_signaled"):
@@ -506,6 +512,8 @@ def main() -> int:
             gap_threshold=config.injection_score_gap_threshold,
             topic_drift=drift,
             collections_searched=collection_names,
+            rejects=_greedy_meta.get("rejects"),
+            fallback_signaled=_greedy_meta.get("fallback_signaled", False),
         )
 
         # SPEC-021: context_retrieval span — retrieval pipeline complete

--- a/.claude/hooks/scripts/context_injection_tier2.py
+++ b/.claude/hooks/scripts/context_injection_tier2.py
@@ -316,8 +316,12 @@ def main() -> int:
                 _freshness_blocked_count += 1
                 # PLAN-028 P2-2 (R2): remember which candidates the freshness
                 # penalty fully blocked so the downstream greedy score-gap drop
-                # is attributed to `freshness_block` (observe-only).
-                _freshness_blocked_ids.add(str(_r.get("id", "")))
+                # is attributed to `freshness_block` (observe-only). Guard on a
+                # non-empty id so a missing-id result never adds "" — that
+                # sentinel would mislabel another no-id result downstream.
+                _blocked_id = str(_r.get("id", ""))
+                if _blocked_id:
+                    _freshness_blocked_ids.add(_blocked_id)
 
         # Re-sort after penalty application (penalized scores may have changed relative order)
         all_results.sort(key=lambda r: r.get("score", 0), reverse=True)

--- a/_ai-memory/pov/skills/aim-parzival-bootstrap/bootstrap.py
+++ b/_ai-memory/pov/skills/aim-parzival-bootstrap/bootstrap.py
@@ -163,10 +163,14 @@ def main() -> int:
             retrieval_meta.get("fallback_signaled")
             or greedy_meta.get("fallback_signaled")
         )
-        _fallback_reject = None
-        for _r in list(retrieval_meta.get("rejects", [])) + list(
+        # PLAN-028 P2-2 (R4): merge per-drop reject records from both the
+        # Layer-1 retrieval pre-filter and the greedy fill so the bootstrap
+        # audit entry persists the full per-drop "noise" history.
+        _all_rejects = list(retrieval_meta.get("rejects", [])) + list(
             greedy_meta.get("rejects", [])
-        ):
+        )
+        _fallback_reject = None
+        for _r in _all_rejects:
             if _r.get("reason") in ("budget_exceeded", "ceiling_exceeded") and (
                 _r.get("type") == "agent_handoff"
             ):
@@ -195,6 +199,8 @@ def main() -> int:
             tokens_used=tokens_used,
             budget=config.bootstrap_token_budget,
             audit_dir=audit_dir,
+            rejects=_all_rejects,
+            fallback_signaled=_fallback_signaled,
         )
 
         # Tier B — sanctum LORE + BOND prepend (filesystem-only per DEC-253-14)

--- a/src/memory/injection.py
+++ b/src/memory/injection.py
@@ -825,6 +825,7 @@ def select_results_greedy(
     *,
     tier: int = 1,
     return_meta: bool = False,
+    freshness_blocked_ids: set[str] | None = None,
 ) -> tuple[list[dict], int] | tuple[list[dict], int, dict]:
     """Select results using greedy fill until budget exhausted.
 
@@ -845,6 +846,12 @@ def select_results_greedy(
             {fallback_signaled, rejects, budget, tokens_used}. BP-158 P2
             typed-sentinel pattern: fallback_signaled is True iff any
             budget-rejected result was of type "agent_handoff".
+        freshness_blocked_ids: Optional set of point IDs (as strings) that the
+            tier-2 caller drove to score 0.0 via the freshness penalty. When a
+            score-gap drop fires for such an ID, the reject is attributed to the
+            "freshness_block" reason instead of "score_gap" (PLAN-028 P2-2 R2).
+            Observe-only: this changes only the reject reason label, never which
+            results are selected.
 
     Returns:
         Tuple of (selected_results, total_tokens_used) when return_meta=False,
@@ -852,6 +859,7 @@ def select_results_greedy(
     """
     _trace_start = datetime.now(tz=timezone.utc)
     excluded = set(excluded_ids or [])
+    freshness_blocked = set(freshness_blocked_ids or [])
     selected = []
     _selected_token_counts: list[int] = []
     tokens_used = 0
@@ -934,10 +942,16 @@ def select_results_greedy(
 
         # Skip already-injected points
         if point_id in excluded:
+            # PLAN-028 P2-2 (R1): record the cross-turn dedup skip so it is
+            # attributable in the noise histogram. Behavior unchanged (continue).
+            _record_reject(result, "already_injected")
             continue
 
         content = result.get("content", "")
         if not content.strip():
+            # PLAN-028 P2-2 (R1): record the empty-content skip so it is
+            # attributable in the noise histogram. Behavior unchanged (continue).
+            _record_reject(result, "empty_content")
             continue
 
         # BUG-172: Skip duplicate content (same text stored under different types)
@@ -959,7 +973,15 @@ def select_results_greedy(
         result_score = result.get("score", 0)
         if best_score > 0 and result_score < best_score * score_gap_threshold:
             _score_gap_skipped += 1
-            _record_reject(result, "score_gap")
+            # PLAN-028 P2-2 (R2): a code-patterns candidate driven to score 0.0
+            # by the tier-2 freshness penalty is dropped here as a score gap.
+            # Relabel it `freshness_block` so it is attributable in the noise
+            # histogram rather than silently absorbed into score_gap. Selection
+            # is unchanged — only the reject reason label differs (observe-only).
+            _gap_reason = (
+                "freshness_block" if point_id in freshness_blocked else "score_gap"
+            )
+            _record_reject(result, _gap_reason)
             continue
 
         # Count tokens accurately
@@ -1121,6 +1143,8 @@ def log_injection_event(
     collections_searched: list[str] | None = None,
     gap_threshold: float = 0.7,
     gating_mode: str = "full",
+    rejects: list[dict] | None = None,
+    fallback_signaled: bool = False,
 ) -> None:
     """Log injection event to .audit/logs/injection-log.jsonl.
 
@@ -1144,6 +1168,13 @@ def log_injection_event(
         collections_searched: Collections that were queried
         gap_threshold: Score gap threshold used for greedy fill filtering
         gating_mode: Confidence gating path taken ("skip", "soft", or "full")
+        rejects: Per-drop reject records from select_results_greedy /
+            retrieve_bootstrap_context (each ``{type, tokens, score, reason,
+            tier, collection}``). Persisted to the audit entry as the empirical
+            per-drop "noise" history (PLAN-028 P2-2 R3). Defaults to an empty
+            list — backward-compatible with callers that omit it.
+        fallback_signaled: True iff a handoff-class result was budget/ceiling
+            rejected (BP-158 P2). Persisted for audit. Defaults to False.
     """
     log_path = Path(audit_dir) / "logs" / "injection-log.jsonl"
 
@@ -1164,6 +1195,8 @@ def log_injection_event(
         "collections_searched": collections_searched or [],
         "gap_threshold": round(gap_threshold, 4),
         "gating_mode": gating_mode,
+        "rejects": rejects or [],
+        "fallback_signaled": fallback_signaled,
     }
 
     try:

--- a/src/memory/injection.py
+++ b/src/memory/injection.py
@@ -865,9 +865,18 @@ def select_results_greedy(
     tokens_used = 0
     _dedup_skipped = 0
     _score_gap_skipped = 0
+    _freshness_block_skipped = 0
 
     # BP-158 P1: per-reject record accumulator for the typed-sentinel meta.
     rejects: list[dict] = []
+    # Reject-counter accumulator keyed by (reason, collection). The Prometheus
+    # reject counter is pushed ONCE per distinct pair after the loop (via the
+    # count= param) instead of forking a subprocess per drop — the
+    # already_injected skip is high-volume on the UserPromptSubmit hot path
+    # (excluded_ids grows each turn), so per-drop forking would storm the
+    # NFR-P1 budget. Counter totals are identical: count per pair == number of
+    # drops for that pair. The per-drop rejects[] records above are unaffected.
+    reject_counts: dict[tuple[str, str], int] = {}
     tier_label = "1_bootstrap" if tier == 1 else "2_injection"
     fallback_signaled = False
 
@@ -917,16 +926,11 @@ def select_results_greedy(
                     "tokens_used": tokens_used,
                 },
             )
-        try:
-            from memory.metrics_push import push_retrieval_reject_metric_async
-
-            push_retrieval_reject_metric_async(
-                reason=reason,
-                tier=tier_label,
-                collection=collection_label,
-            )
-        except Exception:
-            pass
+        # Accumulate the counter; the aggregated push happens once per
+        # (reason, collection) pair after the loop (see reject_counts above).
+        reject_counts[(reason, collection_label)] = (
+            reject_counts.get((reason, collection_label), 0) + 1
+        )
 
     # BUG-172: Content-hash deduplication for cross-type duplicates
     seen_hashes: set[str] = set()
@@ -972,15 +976,19 @@ def select_results_greedy(
         # post-penalty scores drive both gating and this selection. Do NOT add penalty logic here.
         result_score = result.get("score", 0)
         if best_score > 0 and result_score < best_score * score_gap_threshold:
-            _score_gap_skipped += 1
             # PLAN-028 P2-2 (R2): a code-patterns candidate driven to score 0.0
             # by the tier-2 freshness penalty is dropped here as a score gap.
             # Relabel it `freshness_block` so it is attributable in the noise
             # histogram rather than silently absorbed into score_gap. Selection
             # is unchanged — only the reject reason label differs (observe-only).
-            _gap_reason = (
-                "freshness_block" if point_id in freshness_blocked else "score_gap"
-            )
+            # The two skip counters are tracked separately so each trace field
+            # stays semantically accurate (score_gap_skipped is pure score_gap).
+            if point_id in freshness_blocked:
+                _gap_reason = "freshness_block"
+                _freshness_block_skipped += 1
+            else:
+                _gap_reason = "score_gap"
+                _score_gap_skipped += 1
             _record_reject(result, _gap_reason)
             continue
 
@@ -1000,6 +1008,23 @@ def select_results_greedy(
             # when an agent_handoff is the rejected result.
             _record_reject(result, "budget_exceeded", result_tokens=result_tokens)
             continue
+
+    # Aggregated reject-counter push: one fork per distinct (reason, collection)
+    # pair instead of one per drop. Counter totals are preserved exactly —
+    # count= carries the per-pair drop tally. Fire-and-forget; never raises.
+    if reject_counts:
+        try:
+            from memory.metrics_push import push_retrieval_reject_metric_async
+
+            for (reason, collection_label), count in reject_counts.items():
+                push_retrieval_reject_metric_async(
+                    reason=reason,
+                    tier=tier_label,
+                    collection=collection_label,
+                    count=count,
+                )
+        except Exception:
+            pass
 
     # SPEC-021: Emit greedy fill trace event
     if emit_trace_event:
@@ -1028,6 +1053,7 @@ def select_results_greedy(
                         "excluded_count": len(excluded),
                         "dedup_skipped": _dedup_skipped,
                         "score_gap_skipped": _score_gap_skipped,
+                        "freshness_block_skipped": _freshness_block_skipped,
                         "gap_threshold": score_gap_threshold,
                         "selected_detail": [
                             {

--- a/src/memory/metrics_push.py
+++ b/src/memory/metrics_push.py
@@ -1859,13 +1859,18 @@ except Exception as e:
 
 
 # BP-158 P1/P3: structured observability for retrieval-filter rejections.
-# Cardinality: 4 reason values x 2 tier values x 5 collection values = 40 series,
+# PLAN-028 P2-2 Phase A: generalized to every drop site (already_injected,
+# empty_content, freshness_block added to the original four).
+# Cardinality: 7 reason values x 2 tier values x 5 collection values = 70 series,
 # well under Prometheus OSS cardinality budgets.
 _VALID_REJECT_REASONS = {
     "budget_exceeded",
     "ceiling_exceeded",
     "score_gap",
     "dedup",
+    "already_injected",
+    "empty_content",
+    "freshness_block",
 }
 _VALID_REJECT_TIERS = {"1_bootstrap", "2_injection"}
 
@@ -1880,12 +1885,14 @@ def push_retrieval_reject_metric_async(
 
     Emitted from select_results_greedy and retrieve_bootstrap_context whenever a
     retrieval result is excluded by a filter (budget exhaustion, per-tier ceiling,
-    score-gap, or content-hash dedup). BP-158 P1 mandate: every retrieval-filter
-    exclusion emits both a structured log line and this counter so silent-drop
-    defects (BUG-297 class) become observable.
+    score-gap, content-hash dedup, cross-turn already-injected skip, empty content,
+    or freshness block). BP-158 P1 mandate: every retrieval-filter exclusion emits
+    both a structured log line and this counter so silent-drop defects (BUG-297
+    class) become observable.
 
     Args:
-        reason: One of budget_exceeded, ceiling_exceeded, score_gap, dedup.
+        reason: One of budget_exceeded, ceiling_exceeded, score_gap, dedup,
+            already_injected, empty_content, freshness_block.
         tier: One of 1_bootstrap, 2_injection.
         collection: code-patterns, conventions, discussions, github, jira-data.
         count: Number of rejections to record in this push (default 1).
@@ -1896,7 +1903,7 @@ def push_retrieval_reject_metric_async(
     reason = _validate_label(reason, "reason", _VALID_REJECT_REASONS)
     tier = _validate_label(tier, "tier", _VALID_REJECT_TIERS)
     # Enforce VALID_COLLECTIONS allowlist so the documented cardinality
-    # claim (4 reasons x 2 tiers x 5 collections = 40 series) is bound at
+    # claim (7 reasons x 2 tiers x 5 collections = 70 series) is bound at
     # the call site — unknown collection values surface as observable
     # `unexpected_label_value` WARN rather than silently widening cardinality.
     collection = _validate_label(collection, "collection", VALID_COLLECTIONS)

--- a/tests/test_injection_shadow_obs.py
+++ b/tests/test_injection_shadow_obs.py
@@ -34,10 +34,17 @@ def _isolate_observability(monkeypatch):
     effect (already covered by BP-158 tests) and is only silenced here.
     """
     monkeypatch.setattr("memory.injection.emit_trace_event", None, raising=False)
+    # Body-local import + object setattr: the autouse conftest
+    # reset_metrics_registry fixture pops memory.metrics* from sys.modules each
+    # test, so a module instance captured at file-import time is stale. Importing
+    # here (post-pop) re-caches the instance that the code's call-time
+    # `from memory.metrics_push import ...` resolves to, so the patch sticks.
+    import memory.metrics_push as _mpush
+
     monkeypatch.setattr(
-        "memory.metrics_push.push_retrieval_reject_metric_async",
+        _mpush,
+        "push_retrieval_reject_metric_async",
         lambda *a, **k: None,
-        raising=True,
     )
 
 
@@ -137,6 +144,107 @@ def test_freshness_block_is_observe_only_selection_identical():
 
     assert [r["id"] for r in sel_without] == [r["id"] for r in sel_with]
     assert tok_without == tok_with
+
+
+# --------------------------------------------------------------------------- #
+# Reject-counter push is aggregated, not forked per-drop                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_reject_counter_push_is_aggregated_with_count(monkeypatch):
+    """Many same-(reason, collection) drops emit ONE push carrying count=N.
+
+    Guards against the per-drop subprocess-fork storm: the already_injected
+    skip is high-volume on the UserPromptSubmit hot path, so the counter push
+    must be aggregated. The per-drop rejects[] records stay one-per-drop.
+    """
+    import memory.metrics_push as _mpush
+
+    calls = []
+    monkeypatch.setattr(
+        _mpush,
+        "push_retrieval_reject_metric_async",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    results = [_result(str(i), f"content number {i}", 0.9) for i in range(5)]
+    excluded = [str(i) for i in range(5)]
+    selected, _tokens, meta = select_results_greedy(
+        results,
+        budget=10_000,
+        excluded_ids=excluded,
+        return_meta=True,
+    )
+
+    # Selection unchanged: every candidate was already injected -> none selected.
+    assert selected == []
+    # Per-drop audit records remain one-per-drop (these feed the histogram).
+    assert [r["reason"] for r in meta["rejects"]] == ["already_injected"] * 5
+    # The counter push is aggregated: ONE call for the single
+    # (already_injected, discussions) pair, carrying count=5 — not five forks.
+    assert len(calls) == 1
+    assert calls[0]["reason"] == "already_injected"
+    assert calls[0]["collection"] == "discussions"
+    assert calls[0]["count"] == 5
+
+
+def test_reject_counter_push_bounded_by_distinct_pairs(monkeypatch):
+    """Push count is bounded by distinct (reason, collection) pairs, not drops."""
+    import memory.metrics_push as _mpush
+
+    calls = []
+    monkeypatch.setattr(
+        _mpush,
+        "push_retrieval_reject_metric_async",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    # 3 already_injected + 2 score_gap drops = 5 drops, but only 2 distinct pairs.
+    results = [
+        _result("hi", "high score anchor content", 0.9),
+        _result("x1", "excluded one", 0.9),
+        _result("x2", "excluded two", 0.9),
+        _result("x3", "excluded three", 0.9),
+        _result("g1", "low gap one", 0.1),
+        _result("g2", "low gap two", 0.1),
+    ]
+    selected, _tokens, _meta = select_results_greedy(
+        results,
+        budget=10_000,
+        excluded_ids=["x1", "x2", "x3"],
+        return_meta=True,
+    )
+
+    assert [r["id"] for r in selected] == ["hi"]
+    # Bounded by DISTINCT pairs (2), not by the 5 drops.
+    assert len(calls) == 2
+    by_reason = {c["reason"]: c["count"] for c in calls}
+    assert by_reason == {"already_injected": 3, "score_gap": 2}
+
+
+# --------------------------------------------------------------------------- #
+# Precedence: already_injected wins over freshness_block                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_already_injected_takes_precedence_over_freshness_block():
+    """A result that is BOTH freshness-blocked AND already-injected is recorded
+    under already_injected — the earlier loop branch wins (locked precedence)."""
+    results = [
+        _result("hi", "high score content", 0.9, "code_pattern", "code-patterns"),
+        _result("both", "blocked and injected", 0.0, "code_pattern", "code-patterns"),
+    ]
+    selected, _tokens, meta = select_results_greedy(
+        results,
+        budget=10_000,
+        excluded_ids=["both"],
+        return_meta=True,
+        freshness_blocked_ids={"both"},
+    )
+
+    # 'hi' selected; 'both' dropped once, attributed to already_injected only.
+    assert [r["id"] for r in selected] == ["hi"]
+    assert [r["reason"] for r in meta["rejects"]] == ["already_injected"]
 
 
 def test_return_meta_false_is_backward_compatible():

--- a/tests/test_injection_shadow_obs.py
+++ b/tests/test_injection_shadow_obs.py
@@ -1,0 +1,207 @@
+"""PLAN-028 P2-2 Phase A — injection-noise shadow observability tests.
+
+Covers the observe-only instrumentation added to make every current
+retrieval/injection candidate-drop attributable in the noise histogram:
+
+- R1: ``select_results_greedy`` records ``already_injected`` and
+  ``empty_content`` rejects for the two formerly-silent skip branches.
+- R2: a freshness-penalty-blocked candidate (score driven to 0.0 by the
+  tier-2 hook) is relabeled ``freshness_block`` instead of ``score_gap``.
+- R3: ``log_injection_event`` persists ``rejects[]`` + ``fallback_signaled``
+  and remains backward-compatible when those are omitted.
+
+Prime directive: these changes are observe-only. The SELECTED SET must be
+byte-identical before and after — verified directly here.
+"""
+
+import json
+
+import pytest
+
+from memory.injection import log_injection_event, select_results_greedy
+
+
+@pytest.fixture(autouse=True)
+def _isolate_observability(monkeypatch):
+    """Mock observability at the call boundary so tests stay hermetic.
+
+    - ``emit_trace_event`` -> None (no Langfuse trace buffer writes).
+    - ``push_retrieval_reject_metric_async`` -> no-op (no subprocess fork).
+
+    The authoritative per-drop observability signal asserted by these tests is
+    the in-memory ``meta["rejects"]`` accumulator returned by
+    ``select_results_greedy``; the Prometheus counter is a fire-and-forget side
+    effect (already covered by BP-158 tests) and is only silenced here.
+    """
+    monkeypatch.setattr("memory.injection.emit_trace_event", None, raising=False)
+    monkeypatch.setattr(
+        "memory.metrics_push.push_retrieval_reject_metric_async",
+        lambda *a, **k: None,
+        raising=True,
+    )
+
+
+def _result(point_id, content, score, type_="decision", collection="discussions"):
+    return {
+        "id": point_id,
+        "content": content,
+        "score": score,
+        "type": type_,
+        "collection": collection,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# R1 — formerly-silent drops are now recorded                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_already_injected_skip_is_recorded_and_selection_unchanged():
+    results = [
+        _result("a", "alpha content here", 0.9),
+        _result("b", "beta content here", 0.85),
+    ]
+    selected, _tokens, meta = select_results_greedy(
+        results,
+        budget=10_000,
+        excluded_ids=["a"],
+        return_meta=True,
+    )
+
+    # Observe-only: 'a' excluded as before, 'b' selected — selection unchanged.
+    assert [r["id"] for r in selected] == ["b"]
+    # New signal: the cross-turn dedup skip is now attributable in meta.rejects.
+    assert "already_injected" in [r["reason"] for r in meta["rejects"]]
+
+
+def test_empty_content_skip_is_recorded_and_selection_unchanged():
+    results = [
+        _result("a", "real content", 0.9),
+        _result("b", "   ", 0.85),  # whitespace-only -> empty_content
+    ]
+    selected, _tokens, meta = select_results_greedy(
+        results,
+        budget=10_000,
+        return_meta=True,
+    )
+
+    assert [r["id"] for r in selected] == ["a"]
+    assert "empty_content" in [r["reason"] for r in meta["rejects"]]
+
+
+# --------------------------------------------------------------------------- #
+# R2 — freshness_block relabel (observe-only)                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_freshness_block_relabels_score_gap_drop():
+    results = [
+        _result("hi", "high score content", 0.9, "code_pattern", "code-patterns"),
+        _result("fb", "blocked content", 0.0, "code_pattern", "code-patterns"),
+        _result("sg", "low score content", 0.1, "code_pattern", "code-patterns"),
+    ]
+    selected, _tokens, meta = select_results_greedy(
+        results,
+        budget=10_000,
+        return_meta=True,
+        freshness_blocked_ids={"fb"},
+    )
+
+    # Only the high-score result is selected (best=0.9, cutoff=0.63).
+    assert [r["id"] for r in selected] == ["hi"]
+
+    reasons = [r["reason"] for r in meta["rejects"]]
+    # 'fb' was freshness-blocked -> attributed to freshness_block.
+    assert "freshness_block" in reasons
+    # 'sg' is a genuine low-relevance gap -> still score_gap.
+    assert "score_gap" in reasons
+    # Exactly one of each (no double-count).
+    assert reasons.count("freshness_block") == 1
+    assert reasons.count("score_gap") == 1
+
+
+def test_freshness_block_is_observe_only_selection_identical():
+    """Passing freshness_blocked_ids changes only labels, never selection."""
+    results = [
+        _result("hi", "high score content", 0.9, "code_pattern", "code-patterns"),
+        _result("fb", "blocked content", 0.0, "code_pattern", "code-patterns"),
+        _result("sg", "low score content", 0.1, "code_pattern", "code-patterns"),
+    ]
+
+    sel_without, tok_without, _ = select_results_greedy(
+        list(results), budget=10_000, return_meta=True
+    )
+    sel_with, tok_with, _ = select_results_greedy(
+        list(results), budget=10_000, return_meta=True, freshness_blocked_ids={"fb"}
+    )
+
+    assert [r["id"] for r in sel_without] == [r["id"] for r in sel_with]
+    assert tok_without == tok_with
+
+
+def test_return_meta_false_is_backward_compatible():
+    results = [_result("a", "content one", 0.9)]
+    out = select_results_greedy(results, budget=10_000)
+    assert isinstance(out, tuple)
+    assert len(out) == 2  # (selected, tokens_used) legacy shape
+
+
+# --------------------------------------------------------------------------- #
+# R3 — log_injection_event persists rejects[] + fallback_signaled             #
+# --------------------------------------------------------------------------- #
+
+
+def _read_last_entry(audit_dir):
+    log_path = audit_dir / "logs" / "injection-log.jsonl"
+    lines = log_path.read_text().strip().splitlines()
+    return json.loads(lines[-1])
+
+
+def test_log_injection_event_persists_rejects_and_fallback(tmp_path):
+    rejects = [
+        {
+            "type": "agent_handoff",
+            "tokens": 5000,
+            "score": 0.0,
+            "reason": "ceiling_exceeded",
+            "tier": "1_bootstrap",
+            "collection": "discussions",
+        }
+    ]
+    log_injection_event(
+        tier=1,
+        trigger="skill:test",
+        project="proj",
+        session_id="sess",
+        results_considered=3,
+        results_selected=1,
+        tokens_used=100,
+        budget=2000,
+        audit_dir=tmp_path,
+        rejects=rejects,
+        fallback_signaled=True,
+    )
+    entry = _read_last_entry(tmp_path)
+    assert entry["rejects"] == rejects
+    assert entry["fallback_signaled"] is True
+
+
+def test_log_injection_event_backward_compatible_defaults(tmp_path):
+    log_injection_event(
+        tier=2,
+        trigger="UserPromptSubmit",
+        project="proj",
+        session_id="sess",
+        results_considered=0,
+        results_selected=0,
+        tokens_used=0,
+        budget=0,
+        audit_dir=tmp_path,
+    )
+    entry = _read_last_entry(tmp_path)
+    # New fields default to empty/false — never crashes existing callers.
+    assert entry["rejects"] == []
+    assert entry["fallback_signaled"] is False
+    # Existing fields remain intact.
+    assert entry["tier"] == 2
+    assert entry["gating_mode"] == "full"


### PR DESCRIPTION
## What

Makes every current candidate-drop in the tier-2 retrieval/injection path observable, and persists the per-drop history to the injection audit log — so injection "noise" can be measured empirically before any noise filter is introduced.

This is the measurement (observe-only) phase: it changes **what is logged/measured**, never **what is injected**.

## Why

PLAN-028 P2-2 requires an empirical definition of injection noise — which payload categories surface vs. should surface, with evidence — *before* enabling any filtering. Today several candidate-drops are silent or not persisted, so that distribution can't be measured. This change closes that gap.

## Changes

- `select_results_greedy`: record the two formerly-silent skips (`already_injected`, `empty_content`) as typed rejects; relabel a freshness-penalty-blocked score-gap drop as `freshness_block` when the caller marks the id. Selection control flow is unchanged — only reject metadata/labels differ.
- `log_injection_event`: persist `rejects[]` + `fallback_signaled` to `injection-log.jsonl` (backward-compatible defaults).
- Tier-2 hook + bootstrap consumer: pass the freshness-blocked ids and the merged reject records through to the audit log.
- Reject metric: extend the reason allowlist; emit the Prometheus counter **once per `(reason, collection)` pair via `count=`** rather than forking a subprocess per drop, so the high-volume `already_injected` skip does not add latency on the `UserPromptSubmit` path. Counter totals are unchanged.
- Trace: track `freshness_block` in its own counter so `score_gap_skipped` is not inflated.

## Observe-only guarantee

The set of injected results and total tokens are identical before/after. A unit test asserts this invariance directly (selected ids + tokens unchanged with vs. without the new parameter).

## Testing

- New unit tests: per-drop recording, freshness relabel + no double-count, observe-only invariance, audit-log persistence + backward-compat, aggregated-push (one call per pair carrying `count=N`), and reason precedence.
- `ruff` / `black` / `isort` (CI scope) and the related test suite pass locally with `-p no:randomly`.

## Follow-ups (deferred, intentional)

- Phase B will tune actual filters against the distribution this change measures; the freshness-blocked signal on the confidence-skip path and the `freshness_block` histogram lower-bound semantics are documented for that phase.
- The bootstrap `FALLBACK-NEEDED` marker now reports the accurate ceiling reason/tokens/budget (previously fell back to generic defaults) — a minor accuracy improvement.