### PR TITLE
feat(memory): externalize best-practice store via resolve_project_id (RISK-021 / TASK-071 4(d).0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **RISK-021 / TASK-071 Phase 4(d).0** — New standalone script
+  `scripts/memory/store_best_practice.py` externalizes the "Phase 4: Store to
+  Database" Python block that was previously inlined in
+  `_ai-memory/skills/aim-best-practices-researcher/RESEARCH-METHODOLOGY.md` and
+  `SKILL.md`. The script accepts `--content`, `--session-id`, `--group-id`
+  (optional), `--source-hook`, `--domain`, `--tags`, `--source`, and
+  `--source-date`. Invoke via
+  `scripts/memory/run-with-env.sh store_best_practice.py …` (BP-013 Pattern B).
+  Companion unit tests in `tests/unit/test_store_best_practice_script.py`
+  (importlib + sys.modules patching, mocked resolver at call boundary per DEC-109).
+
+### Changed
+
+- **RISK-021 — Deliberate behaviour change (DEC-108 C-1 / DEC-106
+  correctness-restoration carve-out)**: `aim-best-practices-researcher` Phase 4
+  previously resolved project scope via `os.environ.get("AI_MEMORY_PROJECT_ID")`
+  with a `RuntimeError` on unset (env-only). The new `store_best_practice.py`
+  script routes scope through `resolve_project_id(cwd=os.getcwd(),
+  explicit=args.group_id)`, which supports four tiers — explicit `--group-id`
+  flag → `AI_MEMORY_PROJECT_ID` env → `.ai-memory-project` marker file → git
+  remote → fail-loud `ValueError`. This aligns the BP write path with every
+  other memory script already updated by PR #160 (BUG-314). Across 7 Session-61
+  runs the old env-only path fragmented into 4 distinct scope values; the new
+  path is deterministic. This change is disclosed per DEC-105 / DEC-108 C-1 and
+  must appear in the PR description.
+
 ## [2.4.5] - 2026-05-29
 
 ### Fixed

--- a/_ai-memory/skills/aim-best-practices-researcher/RESEARCH-METHODOLOGY.md
+++ b/_ai-memory/skills/aim-best-practices-researcher/RESEARCH-METHODOLOGY.md
@@ -83,39 +83,19 @@ WebSearch: "[topic] official documentation 2026"
 
 ## Phase 4: Store to Database
 
-```python
-import os
-import sys
-sys.path.insert(0, os.path.join(os.path.expanduser("~/.ai-memory"), "src"))
-from memory.storage import store_best_practice
-
-# Project scope is required-explicit (PLAN-028 P1, DEC-PM298-D4). Resolve it
-# deterministically from AI_MEMORY_PROJECT_ID — never from os.getcwd(), which is
-# unreliable for this forked skill subprocess. Fail loud if it is not set.
-project_id = os.environ.get("AI_MEMORY_PROJECT_ID")
-if not project_id:
-    raise RuntimeError(
-        "AI_MEMORY_PROJECT_ID is not set — cannot store a best practice without "
-        "an explicit project scope. Set AI_MEMORY_PROJECT_ID and retry."
-    )
-
-result = store_best_practice(
-    content="Concise best practice description",
-    session_id="current-session-id",
-    source_hook="manual",
-    group_id=project_id,
-    domain="topic-domain",
-    tags=["topic", "keywords"],
-    source="https://source-url.com",
-    source_date="2026-01-29",
-    auto_seeded=True
-)
-
-if result.get("status") == "stored":
-    print(f"Stored: {result['memory_id']}")
-elif result.get("status") == "duplicate":
-    print(f"Duplicate skipped")
+```bash
+scripts/memory/run-with-env.sh store_best_practice.py \
+    --content "Concise best practice description" \
+    --session-id "current-session-id" \
+    --domain "topic-domain" \
+    --tags topic keywords \
+    --source "https://source-url.com" \
+    --source-date "2026-01-29"
+# Optionally pin scope explicitly: --group-id <project-id>
+# (resolved automatically via full-precedence chain if omitted)
 ```
+
+Output: `Stored: <memory_id>` on success, `Duplicate skipped` if already present.
 
 ### Valid source_hook Values
 

--- a/_ai-memory/skills/aim-best-practices-researcher/SKILL.md
+++ b/_ai-memory/skills/aim-best-practices-researcher/SKILL.md
@@ -34,33 +34,17 @@ results = search_memories(
     memory_type=["guideline", "rule"],
     limit=5
 )
+```
 
+```bash
 # Phase 4: Store findings
-import os
-import sys
-sys.path.insert(0, os.path.join(os.path.expanduser("~/.ai-memory"), "src"))
-from memory.storage import store_best_practice
-
-# Project scope is required-explicit (PLAN-028 P1, DEC-PM298-D4). Resolve it
-# deterministically from AI_MEMORY_PROJECT_ID — never from os.getcwd(), which is
-# unreliable for this forked skill subprocess. Fail loud if it is not set.
-project_id = os.environ.get("AI_MEMORY_PROJECT_ID")
-if not project_id:
-    raise RuntimeError(
-        "AI_MEMORY_PROJECT_ID is not set — cannot store a best practice without "
-        "an explicit project scope. Set AI_MEMORY_PROJECT_ID and retry."
-    )
-result = store_best_practice(
-    content="Best practice description",
-    session_id="current-session",
-    source_hook="manual",
-    group_id=project_id,
-    domain="python",
-    tags=["topic"],
-    source="https://source-url.com",
-    source_date="2026-01-29",
-    auto_seeded=True
-)
+scripts/memory/run-with-env.sh store_best_practice.py \
+    --content "Best practice description" \
+    --session-id "current-session" \
+    --domain "python" \
+    --tags topic \
+    --source "https://source-url.com" \
+    --source-date "2026-01-29"
 ```
 
 ## 5-Phase Workflow
@@ -97,52 +81,24 @@ Generate next BP-ID and create `oversight/knowledge/best-practices/BP-XXX-[topic
 
 ### Phase 4: Store to Database (MANDATORY)
 
-**CRITICAL**: You MUST execute this code to store findings to the database.
+**CRITICAL**: You MUST run this command to store findings to the database.
 Without this step, research is lost and BUG-048 occurs.
 
-```python
-# MANDATORY - Execute this code block
-import os
-import sys
-sys.path.insert(0, os.path.join(os.path.expanduser("~/.ai-memory"), "src"))
-from memory.storage import store_best_practice
-
-# Get session_id from environment or use placeholder
-session_id = os.environ.get("CLAUDE_SESSION_ID", "manual-research")
-
-# Project scope is required-explicit (PLAN-028 P1, DEC-PM298-D4). Resolve it
-# deterministically from AI_MEMORY_PROJECT_ID — never from os.getcwd(), which is
-# unreliable for this forked skill subprocess. Fail loud if it is not set.
-project_id = os.environ.get("AI_MEMORY_PROJECT_ID")
-if not project_id:
-    raise RuntimeError(
-        "AI_MEMORY_PROJECT_ID is not set — cannot store a best practice without "
-        "an explicit project scope. Set AI_MEMORY_PROJECT_ID and retry."
-    )
-
-result = store_best_practice(
-    content="YOUR_FINDING_CONTENT_HERE",  # Replace with actual finding
-    session_id=session_id,
-    source_hook="manual",
-    group_id=project_id,  # Explicit project scope (project-scoped per W-01)
-    domain="YOUR_DOMAIN",  # e.g., "python", "testing", "architecture"
-    tags=["YOUR", "TAGS"],  # Replace with relevant tags
-    source="SOURCE_URL",  # URL where you found this
-    source_date="2026-02-03",  # Today's date
-    auto_seeded=True,
-    type="guideline"  # Stored as guideline in conventions collection
-)
-
-# Verify storage succeeded
-if result.get("status") == "stored":
-    print(f"SUCCESS: Stored to conventions collection: {result['memory_id']}")
-else:
-    print(f"WARNING: {result.get('status', 'unknown')} - {result}")
+```bash
+# MANDATORY - Run this command to store findings
+scripts/memory/run-with-env.sh store_best_practice.py \
+    --content "YOUR_FINDING_CONTENT_HERE" \
+    --session-id "YOUR_SESSION_ID" \
+    --domain "YOUR_DOMAIN" \
+    --tags YOUR TAGS \
+    --source "SOURCE_URL" \
+    --source-date "2026-05-30"
+# Optionally pin scope: --group-id <project-id>  (resolved automatically if omitted)
 ```
 
 **Checklist before moving to Phase 5**:
-- [ ] Executed store_best_practice() code above
-- [ ] Received "SUCCESS: Stored" confirmation
+- [ ] Ran store_best_practice.py via run-with-env.sh
+- [ ] Received "Stored: <id>" or "Duplicate skipped" confirmation
 - [ ] If duplicate, that's OK - finding already exists
 
 ### Phase 5: Skill Evaluation

--- a/scripts/memory/store_best_practice.py
+++ b/scripts/memory/store_best_practice.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# scripts/memory/store_best_practice.py
+"""Store a single best practice to the conventions collection.
+
+Externalizes the "Phase 4: Store to Database" inline Python block from
+aim-best-practices-researcher, routing project-scope resolution through the
+canonical resolve_project_id helper (RISK-021 fix).
+
+**Deliberate behaviour change (RISK-021 / DEC-108 C-1 / DEC-106 carve-out)**:
+The skill previously resolved scope via env-only lookup with a ``RuntimeError``
+on unset. This script routes through ``resolve_project_id(cwd=os.getcwd(),
+explicit=args.group_id)``, which supports four tiers (explicit flag →
+AI_MEMORY_PROJECT_ID env → .ai-memory-project marker → git remote) before
+raising ``ValueError``. This is a correctness-restoration change per DEC-106,
+not a silent behaviour change.
+
+Invoke via:
+    scripts/memory/run-with-env.sh store_best_practice.py \\
+        --content "..." --session-id "..." [options]
+"""
+
+import argparse
+import logging
+import os
+import sys
+
+from memory.project import resolve_project_id
+from memory.storage import store_best_practice
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
+def main() -> int:
+    """Entry point for storing a single best practice.
+
+    Returns:
+        0 on success (stored or duplicate).
+        2 on project-scope resolution failure or storage validation error.
+        1 on unexpected storage error.
+    """
+    parser = argparse.ArgumentParser(
+        description="Store a best practice to the conventions collection",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  ./run-with-env.sh store_best_practice.py \\
+      --content "Use type hints in Python 3.10+" \\
+      --session-id "sess-abc123" \\
+      --domain python --tags typing hints
+
+  # Explicit project scope:
+  ./run-with-env.sh store_best_practice.py \\
+      --content "..." --session-id "..." --group-id my-project
+""",
+    )
+    parser.add_argument(
+        "--content",
+        required=True,
+        help="Best practice text content",
+    )
+    parser.add_argument(
+        "--session-id",
+        required=True,
+        dest="session_id",
+        help="Current Claude session ID",
+    )
+    parser.add_argument(
+        "--group-id",
+        default=None,
+        dest="group_id",
+        help=(
+            "Project group ID (optional — resolves via full-precedence chain: "
+            "explicit flag → AI_MEMORY_PROJECT_ID env → .ai-memory-project marker "
+            "→ git remote → fail-loud ValueError)"
+        ),
+    )
+    parser.add_argument(
+        "--source-hook",
+        default="manual",
+        dest="source_hook",
+        help="Hook that captured this best practice (default: manual)",
+    )
+    parser.add_argument(
+        "--domain",
+        default=None,
+        help="Topic domain (e.g. python, testing, architecture)",
+    )
+    parser.add_argument(
+        "--tags",
+        nargs="*",
+        default=None,
+        help="Tags (space-separated list)",
+    )
+    parser.add_argument(
+        "--source",
+        default=None,
+        help="Source URL",
+    )
+    parser.add_argument(
+        "--source-date",
+        default=None,
+        dest="source_date",
+        help="Source date (YYYY-MM-DD)",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        group_id = resolve_project_id(cwd=os.getcwd(), explicit=args.group_id)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        result = store_best_practice(
+            content=args.content,
+            session_id=args.session_id,
+            source_hook=args.source_hook,
+            group_id=group_id,
+            domain=args.domain,
+            tags=args.tags,
+            source=args.source,
+            source_date=args.source_date,
+            auto_seeded=True,
+        )
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    except Exception as exc:
+        logger.error(
+            "store_failed",
+            extra={"error_type": type(exc).__name__, "error": str(exc)},
+        )
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if result.get("status") == "stored":
+        print(f"Stored: {result['memory_id']}")
+    elif result.get("status") == "duplicate":
+        print("Duplicate skipped")
+    else:
+        print(
+            f"WARNING: unexpected status {result.get('status')!r} — {result}",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_store_best_practice_script.py
+++ b/tests/unit/test_store_best_practice_script.py
@@ -1,0 +1,324 @@
+"""Tests for scripts/memory/store_best_practice.py (RISK-021 fix).
+
+Verifies the externalized CLI script:
+- routes project-scope through resolve_project_id (NOT env-only),
+- passes the resolved group_id to store_best_practice,
+- honours the stdout contract (Stored: <id> / Duplicate skipped),
+- fails loudly (exit 2) when scope cannot be resolved.
+
+Mock strategy (DEC-109 / CI convention 1):
+  resolve_project_id is patched at the call boundary inside memory.project —
+  NOT detect_project (patching detect_project is a dead mock; the resolver
+  calls it internally and goes green-local / red-CI).
+
+Environment convention (DEC-109 / CI convention 2):
+  All tests run with AI_MEMORY_PROJECT_ID unset so resolution is exercised
+  through the full-precedence chain (or mocked at the boundary above).
+
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_REPO = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO / "scripts" / "memory" / "store_best_practice.py"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BASE_ARGV = [
+    "store_best_practice.py",
+    "--content",
+    "Always use type hints in Python 3.10+",
+    "--session-id",
+    "sess-test-001",
+]
+
+
+def _make_resolve_mock(
+    return_value: str = "test-project",
+    side_effect: Exception | None = None,
+) -> MagicMock:
+    m = MagicMock()
+    if side_effect is not None:
+        m.side_effect = side_effect
+    else:
+        m.return_value = return_value
+    return m
+
+
+def _make_store_mock(
+    status: str = "stored",
+    memory_id: str | None = "mem-abc-001",
+) -> MagicMock:
+    m = MagicMock()
+    m.return_value = {"status": status, "memory_id": memory_id}
+    return m
+
+
+def _inject_fakes(
+    monkeypatch,
+    resolve_mock: MagicMock,
+    store_mock: MagicMock,
+) -> None:
+    """Patch memory.project and memory.storage into sys.modules.
+
+    Must be called BEFORE _load_module() so that the ``from memory.*``
+    top-level imports in the script bind to the mocks.
+    """
+    project_mod = types.ModuleType("memory.project")
+    project_mod.resolve_project_id = resolve_mock
+
+    storage_mod = types.ModuleType("memory.storage")
+    storage_mod.store_best_practice = store_mock
+
+    monkeypatch.setitem(sys.modules, "memory.project", project_mod)
+    monkeypatch.setitem(sys.modules, "memory.storage", storage_mod)
+
+
+def _load_module():
+    """Load the script module fresh for each test.
+
+    Evicts any previously cached version so module-level imports rebind to
+    the sys.modules patches installed by _inject_fakes().
+    """
+    for key in list(sys.modules.keys()):
+        if "store_best_practice_under_test" in key:
+            del sys.modules[key]
+    spec = importlib.util.spec_from_file_location(
+        "store_best_practice_under_test", _SCRIPT
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_script_exists():
+    """Sanity: the script file was created at the expected path."""
+    assert _SCRIPT.exists(), f"script not found: {_SCRIPT}"
+
+
+def test_explicit_group_id_forwarded_to_resolver(monkeypatch):
+    """--group-id CLI flag is forwarded to resolve_project_id as explicit=."""
+    resolve_mock = _make_resolve_mock("my-explicit-project")
+    store_mock = _make_store_mock()
+    _inject_fakes(monkeypatch, resolve_mock, store_mock)
+    monkeypatch.setattr(sys, "argv", [*_BASE_ARGV, "--group-id", "my-explicit-project"])
+    monkeypatch.delenv("AI_MEMORY_PROJECT_ID", raising=False)
+
+    mod = _load_module()
+    rc = mod.main()
+
+    assert rc == 0
+    resolve_mock.assert_called_once()
+    assert resolve_mock.call_args.kwargs.get("explicit") == "my-explicit-project"
+    assert isinstance(
+        resolve_mock.call_args.kwargs.get("cwd"), str
+    )  # N-2: cwd always passed
+
+
+def test_store_receives_resolved_group_id(monkeypatch):
+    """store_best_practice is called with the id returned by resolve_project_id."""
+    resolve_mock = _make_resolve_mock("resolved-project-id")
+    store_mock = _make_store_mock()
+    _inject_fakes(monkeypatch, resolve_mock, store_mock)
+    monkeypatch.setattr(sys, "argv", _BASE_ARGV)
+    monkeypatch.delenv("AI_MEMORY_PROJECT_ID", raising=False)
+
+    mod = _load_module()
+    rc = mod.main()
+
+    assert rc == 0
+    store_mock.assert_called_once()
+    assert store_mock.call_args.kwargs["group_id"] == "resolved-project-id"
+
+
+def test_fail_loud_when_resolver_raises_value_error(monkeypatch, capsys):
+    """main() returns 2 and writes to stderr when resolve_project_id raises ValueError.
+
+    store_best_practice must NOT be called — the script halts before storage.
+    """
+    resolve_mock = _make_resolve_mock(
+        side_effect=ValueError(
+            "no project scope found — explicit, env, marker, git all absent"
+        )
+    )
+    store_mock = _make_store_mock()
+    _inject_fakes(monkeypatch, resolve_mock, store_mock)
+    monkeypatch.setattr(sys, "argv", _BASE_ARGV)
+    monkeypatch.delenv("AI_MEMORY_PROJECT_ID", raising=False)
+
+    mod = _load_module()
+    rc = mod.main()
+
+    assert rc == 2
+    store_mock.assert_not_called()
+    _, err = capsys.readouterr()
+    assert "ERROR" in err
+
+
+def test_stdout_stored_contract(monkeypatch, capsys):
+    """Prints 'Stored: <memory_id>' when storage returns status=stored."""
+    resolve_mock = _make_resolve_mock("any-project")
+    store_mock = _make_store_mock(status="stored", memory_id="mem-xyz-999")
+    _inject_fakes(monkeypatch, resolve_mock, store_mock)
+    monkeypatch.setattr(sys, "argv", _BASE_ARGV)
+    monkeypatch.delenv("AI_MEMORY_PROJECT_ID", raising=False)
+
+    mod = _load_module()
+    rc = mod.main()
+
+    assert rc == 0
+    out, _ = capsys.readouterr()
+    assert "Stored: mem-xyz-999" in out
+
+
+def test_stdout_duplicate_skipped_contract(monkeypatch, capsys):
+    """Prints 'Duplicate skipped' when storage returns status=duplicate."""
+    resolve_mock = _make_resolve_mock("any-project")
+    store_mock = _make_store_mock(status="duplicate", memory_id=None)
+    _inject_fakes(monkeypatch, resolve_mock, store_mock)
+    monkeypatch.setattr(sys, "argv", _BASE_ARGV)
+    monkeypatch.delenv("AI_MEMORY_PROJECT_ID", raising=False)
+
+    mod = _load_module()
+    rc = mod.main()
+
+    assert rc == 0
+    out, _ = capsys.readouterr()
+    assert "Duplicate skipped" in out
+
+
+def test_store_called_with_full_kwargs(monkeypatch):
+    """All store_best_practice kwargs are passed correctly from their CLI args."""
+    resolve_mock = _make_resolve_mock("proj-full")
+    store_mock = _make_store_mock()
+    _inject_fakes(monkeypatch, resolve_mock, store_mock)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "store_best_practice.py",
+            "--content",
+            "Use httpx with explicit timeouts",
+            "--session-id",
+            "sess-999",
+            "--source-hook",
+            "PostToolUse",
+            "--domain",
+            "python",
+            "--tags",
+            "httpx",
+            "timeout",
+            "--source",
+            "https://example.com/httpx-timeouts",
+            "--source-date",
+            "2026-05-30",
+        ],
+    )
+    monkeypatch.delenv("AI_MEMORY_PROJECT_ID", raising=False)
+
+    mod = _load_module()
+    rc = mod.main()
+
+    assert rc == 0
+    kw = store_mock.call_args.kwargs
+    assert kw["content"] == "Use httpx with explicit timeouts"
+    assert kw["session_id"] == "sess-999"
+    assert kw["source_hook"] == "PostToolUse"
+    assert kw["group_id"] == "proj-full"
+    assert kw["domain"] == "python"
+    assert kw["tags"] == ["httpx", "timeout"]
+    assert kw["source"] == "https://example.com/httpx-timeouts"
+    assert kw["source_date"] == "2026-05-30"
+    assert kw["auto_seeded"] is True
+
+
+def test_no_env_explicit_no_group_id_calls_resolver_without_explicit(monkeypatch):
+    """When --group-id is omitted, resolver is called with explicit=None (env-tier path)."""
+    resolve_mock = _make_resolve_mock("env-resolved-project")
+    store_mock = _make_store_mock()
+    _inject_fakes(monkeypatch, resolve_mock, store_mock)
+    monkeypatch.setattr(sys, "argv", _BASE_ARGV)  # no --group-id
+    monkeypatch.delenv("AI_MEMORY_PROJECT_ID", raising=False)
+
+    mod = _load_module()
+    rc = mod.main()
+
+    assert rc == 0
+    resolve_mock.assert_called_once()
+    # explicit= must be None — resolver handles env/marker/git tiers internally
+    assert resolve_mock.call_args.kwargs.get("explicit") is None
+
+
+def test_no_sys_path_insert_in_script():
+    """Script must not use the sys.path.insert anti-pattern (BP-013 Pattern B)."""
+    src = _SCRIPT.read_text(encoding="utf-8")
+    assert "sys.path.insert" not in src, (
+        "store_best_practice.py must not use sys.path.insert — "
+        "run-with-env.sh supplies the venv (BP-013 Pattern B)"
+    )
+
+
+def test_script_uses_resolve_project_id():
+    """Script must call resolve_project_id (not inline env-only resolution)."""
+    src = _SCRIPT.read_text(encoding="utf-8")
+    assert "resolve_project_id" in src
+    assert 'os.environ.get("AI_MEMORY_PROJECT_ID")' not in src, (
+        "store_best_practice.py must not contain env-only resolution — "
+        "that is the RISK-021 defect being fixed"
+    )
+
+
+def test_storage_value_error_returns_exit_2(monkeypatch, capsys):
+    """main() returns 2 and writes to stderr when store_best_practice raises ValueError.
+
+    Distinct from the resolver-ValueError path: this exercises the storage
+    validation guard (e.g. empty group_id, content too short) → exit 2.
+    """
+    resolve_mock = _make_resolve_mock("any-project")
+    store_mock = _make_store_mock()
+    store_mock.side_effect = ValueError("group_id is required and must be non-empty")
+    _inject_fakes(monkeypatch, resolve_mock, store_mock)
+    monkeypatch.setattr(sys, "argv", _BASE_ARGV)
+    monkeypatch.delenv("AI_MEMORY_PROJECT_ID", raising=False)
+
+    mod = _load_module()
+    rc = mod.main()
+
+    assert rc == 2
+    _, err = capsys.readouterr()
+    assert "ERROR" in err
+
+
+def test_unknown_status_warns_to_stderr(monkeypatch, capsys):
+    """Unknown status from storage prints WARNING to stderr; stdout stays empty; exit 1.
+
+    Covers the else branch added by M-1. Non-zero exit signals false-success
+    avoidance: storage may return "blocked" or "failed" — those are real failure
+    conditions, not silent successes.
+    """
+    resolve_mock = _make_resolve_mock("any-project")
+    store_mock = _make_store_mock(status="unexpected-status", memory_id=None)
+    _inject_fakes(monkeypatch, resolve_mock, store_mock)
+    monkeypatch.setattr(sys, "argv", _BASE_ARGV)
+    monkeypatch.delenv("AI_MEMORY_PROJECT_ID", raising=False)
+
+    mod = _load_module()
+    rc = mod.main()
+
+    assert rc == 1
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert "WARNING" in err


### PR DESCRIPTION
## Description

Externalizes the inline **"Phase 4: Store to Database"** Python block from the `aim-best-practices-researcher` skill into a standalone CLI script, `scripts/memory/store_best_practice.py`, and routes its project-scope resolution through the shared `resolve_project_id` helper (the RISK-021 fix). Part of TASK-071 (Skill Script Externalization), Phase 4(d).0 — the focused, single-purpose pre-Pilot PR agreed in DEC-108 C-1.

## Related Issue

Related: **RISK-021** (best-practices conventions write fragmented `group_id` across 4 distinct scope values over 7 runs) · TASK-071 Phase 4(d).0. Follows **PR #160 / BUG-314** (which introduced `resolve_project_id` and routed every other memory script through it; the BP *write* path was the remaining caller).

## Type of Change

- [x] New feature (non-breaking change which adds functionality) — new standalone script
- [x] Refactoring — inline skill code → externalized, testable script
- [ ] Breaking change

> ⚠️ **Deliberate behaviour change (disclosed)** — see the dedicated section below. Non-breaking (strictly more permissive), but called out explicitly.

## Changes Made

- **NEW** `scripts/memory/store_best_practice.py` — argparse CLI (`--content`, `--session-id`, `--group-id` optional, `--source-hook`, `--domain`, `--tags`, `--source`, `--source-date`). Resolves scope via `resolve_project_id(cwd=os.getcwd(), explicit=args.group_id)`, calls `store_best_practice()`, prints `Stored: <id>` / `Duplicate skipped`, warns to stderr + exits non-zero on a non-success status. Invoked via `run-with-env.sh` (BP-013 Pattern B); no `sys.path.insert`.
- **NEW** `tests/unit/test_store_best_practice_script.py` — 12 in-process unit tests (sys.modules injection + mocked resolver at the call boundary), following the merged `test_parzival_bootstrap_script.py` precedent.
- **MOD** `_ai-memory/skills/aim-best-practices-researcher/{RESEARCH-METHODOLOGY.md,SKILL.md}` — Phase-4 inline Python replaced with the `run-with-env.sh store_best_practice.py …` invocation; checklist updated to the new stdout contract.
- **MOD** `CHANGELOG.md` — Added + Changed entries (the Changed entry carries the RISK-021 disclosure below).

## ⚠️ Deliberate Behaviour Change (RISK-021)

Per the CHANGELOG requirement that this be surfaced in the PR description:

The skill's Phase-4 write **previously** resolved project scope via `os.environ.get("AI_MEMORY_PROJECT_ID")` with a `RuntimeError` on unset (**env-only**). The new script routes through `resolve_project_id`, which adds three more precedence tiers:

```
explicit --group-id  →  AI_MEMORY_PROJECT_ID env  →  .ai-memory-project marker  →  git remote  →  fail-loud ValueError
```

This aligns the BP write path with every other memory script already updated by PR #160 (BUG-314). Across 7 Session-61 runs the old env-only path fragmented conventions across **4 distinct scope values**; the new path is deterministic. Classified as a **correctness-restoration change** (DEC-106 carve-out) and shipped as its own focused PR per **DEC-108 C-1**. Non-breaking: an unset env now resolves via the additional tiers instead of hard-failing.

## Testing

### Test Environment
- **Python Version:** 3.12 (`~/.ai-memory/.venv`)
- **OS:** Linux (WSL2)

### Test Checklist
- [x] Unit tests pass (`pytest tests/unit/test_store_best_practice_script.py` → **12 passed**, `AI_MEMORY_PROJECT_ID` unset)
- [x] Manual testing completed (`store_best_practice.py --help` runs; real `from memory.* import` resolves at runtime)
- [ ] Integration / E2E / Docker — N/A for this change

### Test Cases Covered
1. `--group-id` forwarded to resolver as `explicit=`; resolver called with `cwd=`.
2. Resolved id forwarded to `store_best_practice`; full kwargs incl. `auto_seeded=True`.
3. Fail-loud `ValueError` from the resolver → exit 2, store not called.
4. `ValueError` from `store_best_practice` (empty group_id) → exit 2.
5. stdout contract: `Stored: <id>` / `Duplicate skipped`.
6. Unknown/`blocked`/`failed` status → WARNING to stderr + exit 1 (false-success avoidance).
7. Source asserts: no `sys.path.insert`; no env-only resolution.

**CI conventions** (per #160): tests mock `resolve_project_id` at the call boundary (NOT `detect_project`), run with `AI_MEMORY_PROJECT_ID` unset, and inject fake `memory.*` modules so the suite runs without `memory` installed.

## Documentation
- [x] Docstrings on the new script + every test
- [x] CHANGELOG.md updated (Added + Changed with RISK-021 disclosure)
- [ ] README/INSTALL — N/A

## Breaking Changes
- [ ] This PR introduces breaking changes — **No.** (Behaviour change is disclosed above; non-breaking.)

## Security Considerations
- [x] No sensitive data exposed
- [x] Improves tenant isolation — closes a `group_id` fragmentation path on the conventions collection (RISK-021), consistent with BUG-314.

## Out-of-Scope Follow-ups (noted, not in this PR)
1. The `aim-best-practices-researcher` **read/search** examples (SKILL.md Phase 1/3) still use the old `sys.path.insert` + env-only idiom — that is the read path, outside 4(d).0's write-path scope (likely PLAN-028 P5 source-side re-home).
2. `scripts/memory/seed_best_practices.py` hand-rolls `--group-id`/`AI_MEMORY_PROJECT_ID` (and uses `sys.path.insert`) — adjacent but distinct (bulk seed), a candidate for the same resolver in a later item.

## Additional Context

Verified pre-PR with a dual-model review (independent holistic + adversarial passes) and a source-of-truth re-verification against `main` HEAD. The in-process test approach mirrors the already-merged `test_parzival_bootstrap_script.py` (the sibling extraction from BUG-314). Opened as **draft** pending lead-dev review coordination.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
