### PR TITLE
feat(langfuse): trace-flush worker hardening (BUG-315) + agent trace organization + SDK 4.7.x

### DIFF
--- a/.claude/hooks/scripts/agent_response_capture.py
+++ b/.claude/hooks/scripts/agent_response_capture.py
@@ -21,7 +21,7 @@ Input Schema:
 """
 
 # LANGFUSE: Uses trace buffer (Path A). See LANGFUSE-INTEGRATION-SPEC.md §3.1, §4, §7.7
-# SDK VERSION: V3 ONLY. Do NOT use Langfuse() constructor, start_span(), or start_generation().
+# SDK VERSION: V4. Path A files use emit_trace_event() only — no direct langfuse import.
 # CONSTANT: TRACE_CONTENT_MAX = 10000 (no other value permitted)
 
 import json

--- a/.claude/hooks/scripts/agent_response_store_async.py
+++ b/.claude/hooks/scripts/agent_response_store_async.py
@@ -5,7 +5,7 @@ Stores agent responses to discussions collection with proper deduplication.
 """
 
 # LANGFUSE: Uses trace buffer (Path A). See LANGFUSE-INTEGRATION-SPEC.md §3.1, §4, §7.7
-# SDK VERSION: V3 ONLY. Do NOT use Langfuse() constructor, start_span(), or start_generation().
+# SDK VERSION: V4. Path A files use emit_trace_event() only — no direct langfuse import.
 # CONSTANT: TRACE_CONTENT_MAX = 10000 (no other value permitted)
 
 import json

--- a/.claude/hooks/scripts/best_practices_retrieval.py
+++ b/.claude/hooks/scripts/best_practices_retrieval.py
@@ -41,7 +41,7 @@ Exit Codes:
 """
 
 # LANGFUSE: Uses trace buffer (Path A). See LANGFUSE-INTEGRATION-SPEC.md §3.1, §4, §7.7
-# SDK VERSION: V3 ONLY. Do NOT use Langfuse() constructor, start_span(), or start_generation().
+# SDK VERSION: V4. Path A files use emit_trace_event() only — no direct langfuse import.
 # CONSTANT: TRACE_CONTENT_MAX = 10000 (no other value permitted)
 
 import json

--- a/.claude/hooks/scripts/context_injection_tier2.py
+++ b/.claude/hooks/scripts/context_injection_tier2.py
@@ -17,7 +17,7 @@ Performance: <500ms total (NFR-P1, NFR-P5)
 """
 
 # LANGFUSE: Uses trace buffer (Path A). See LANGFUSE-INTEGRATION-SPEC.md §3.1, §4, §7.7
-# SDK VERSION: V3 ONLY. Do NOT use Langfuse() constructor, start_span(), or start_generation().
+# SDK VERSION: V4. Path A files use emit_trace_event() only — no direct langfuse import.
 # CONSTANT: TRACE_CONTENT_MAX = 10000 (no other value permitted)
 
 import contextlib

--- a/.claude/hooks/scripts/error_detection.py
+++ b/.claude/hooks/scripts/error_detection.py
@@ -26,7 +26,7 @@ Exit Codes:
 """
 
 # LANGFUSE: Uses trace buffer (Path A). See LANGFUSE-INTEGRATION-SPEC.md §3.1, §4, §7.7
-# SDK VERSION: V3 ONLY. Do NOT use Langfuse() constructor, start_span(), or start_generation().
+# SDK VERSION: V4. Path A files use emit_trace_event() only — no direct langfuse import.
 # CONSTANT: TRACE_CONTENT_MAX = 10000 (no other value permitted)
 
 import json

--- a/.claude/hooks/scripts/error_pattern_capture.py
+++ b/.claude/hooks/scripts/error_pattern_capture.py
@@ -20,7 +20,7 @@ Pattern: Fork to background using subprocess.Popen + start_new_session=True
 """
 
 # LANGFUSE: Uses trace buffer (Path A). See LANGFUSE-INTEGRATION-SPEC.md §3.1, §4, §7.7
-# SDK VERSION: V3 ONLY. Do NOT use Langfuse() constructor, start_span(), or start_generation().
+# SDK VERSION: V4. Path A files use emit_trace_event() only — no direct langfuse import.
 # CONSTANT: TRACE_CONTENT_MAX = 10000 (no other value permitted)
 
 import hashlib

--- a/.claude/hooks/scripts/error_store_async.py
+++ b/.claude/hooks/scripts/error_store_async.py
@@ -9,7 +9,7 @@ Timeout: Configurable via HOOK_TIMEOUT env var (default: 60s)
 """
 
 # LANGFUSE: Uses trace buffer (Path A). See LANGFUSE-INTEGRATION-SPEC.md §3.1, §4, §7.7
-# SDK VERSION: V3 ONLY. Do NOT use Langfuse() constructor, start_span(), or start_generation().
+# SDK VERSION: V4. Path A files use emit_trace_event() only — no direct langfuse import.
 # CONSTANT: TRACE_CONTENT_MAX = 10000 (no other value permitted)
 
 import asyncio

--- a/.claude/hooks/scripts/first_edit_trigger.py
+++ b/.claude/hooks/scripts/first_edit_trigger.py
@@ -31,7 +31,7 @@ Exit Codes:
 """
 
 # LANGFUSE: Uses trace buffer (Path A). See LANGFUSE-INTEGRATION-SPEC.md §3.1, §4, §7.7
-# SDK VERSION: V3 ONLY. Do NOT use Langfuse() constructor, start_span(), or start_generation().
+# SDK VERSION: V4. Path A files use emit_trace_event() only — no direct langfuse import.
 # CONSTANT: TRACE_CONTENT_MAX = 10000 (no other value permitted)
 
 import json

--- a/.claude/hooks/scripts/manual_save_memory.py
+++ b/.claude/hooks/scripts/manual_save_memory.py
@@ -21,7 +21,7 @@ Exit Codes:
 """
 
 # LANGFUSE: Uses trace buffer (Path A). See LANGFUSE-INTEGRATION-SPEC.md §3.1, §4, §7.7
-# SDK VERSION: V3 ONLY. Do NOT use Langfuse() constructor, start_span(), or start_generation().
+# SDK VERSION: V4. Path A files use emit_trace_event() only — no direct langfuse import.
 # CONSTANT: TRACE_CONTENT_MAX = 10000 (no other value permitted)
 
 import os

--- a/.claude/hooks/scripts/new_file_trigger.py
+++ b/.claude/hooks/scripts/new_file_trigger.py
@@ -28,7 +28,7 @@ Exit Codes:
 """
 
 # LANGFUSE: Uses trace buffer (Path A). See LANGFUSE-INTEGRATION-SPEC.md §3.1, §4, §7.7
-# SDK VERSION: V3 ONLY. Do NOT use Langfuse() constructor, start_span(), or start_generation().
+# SDK VERSION: V4. Path A files use emit_trace_event() only — no direct langfuse import.
 # CONSTANT: TRACE_CONTENT_MAX = 10000 (no other value permitted)
 
 import json

--- a/.claude/hooks/scripts/post_tool_capture.py
+++ b/.claude/hooks/scripts/post_tool_capture.py
@@ -17,7 +17,7 @@ Sources:
 """
 
 # LANGFUSE: Uses trace buffer (Path A). See LANGFUSE-INTEGRATION-SPEC.md §3.1, §4, §7.7
-# SDK VERSION: V3 ONLY. Do NOT use Langfuse() constructor, start_span(), or start_generation().
+# SDK VERSION: V4. Path A files use emit_trace_event() only — no direct langfuse import.
 # CONSTANT: TRACE_CONTENT_MAX = 10000 (no other value permitted)
 
 import json

--- a/.claude/hooks/scripts/pre_compact_save.py
+++ b/.claude/hooks/scripts/pre_compact_save.py
@@ -31,7 +31,7 @@ Sources:
 """
 
 # LANGFUSE: Uses trace buffer (Path A). See LANGFUSE-INTEGRATION-SPEC.md §3.1, §4, §7.7
-# SDK VERSION: V3 ONLY. Do NOT use Langfuse() constructor, start_span(), or start_generation().
+# SDK VERSION: V4. Path A files use emit_trace_event() only — no direct langfuse import.
 # CONSTANT: TRACE_CONTENT_MAX = 10000 (no other value permitted)
 
 import json

--- a/.claude/hooks/scripts/session_start.py
+++ b/.claude/hooks/scripts/session_start.py
@@ -12,7 +12,7 @@ Best Practices (2026):
 """
 
 # LANGFUSE: Uses trace buffer (Path A). See LANGFUSE-INTEGRATION-SPEC.md §3.1, §4, §7.7
-# SDK VERSION: V3 ONLY. Do NOT use Langfuse() constructor, start_span(), or start_generation().
+# SDK VERSION: V4. Path A files use emit_trace_event() only — no direct langfuse import.
 # CONSTANT: TRACE_CONTENT_MAX = 10000 (no other value permitted)
 
 import json

--- a/.claude/hooks/scripts/store_async.py
+++ b/.claude/hooks/scripts/store_async.py
@@ -16,7 +16,7 @@ Sources:
 """
 
 # LANGFUSE: Uses trace buffer (Path A). See LANGFUSE-INTEGRATION-SPEC.md §3.1, §4, §7.7
-# SDK VERSION: V3 ONLY. Do NOT use Langfuse() constructor, start_span(), or start_generation().
+# SDK VERSION: V4. Path A files use emit_trace_event() only — no direct langfuse import.
 # CONSTANT: TRACE_CONTENT_MAX = 10000 (no other value permitted)
 
 import asyncio

--- a/.claude/hooks/scripts/user_prompt_capture.py
+++ b/.claude/hooks/scripts/user_prompt_capture.py
@@ -22,7 +22,7 @@ Input Schema:
 """
 
 # LANGFUSE: Uses trace buffer (Path A). See LANGFUSE-INTEGRATION-SPEC.md §3.1, §4, §7.7
-# SDK VERSION: V3 ONLY. Do NOT use Langfuse() constructor, start_span(), or start_generation().
+# SDK VERSION: V4. Path A files use emit_trace_event() only — no direct langfuse import.
 # CONSTANT: TRACE_CONTENT_MAX = 10000 (no other value permitted)
 
 import json

--- a/.claude/hooks/scripts/user_prompt_store_async.py
+++ b/.claude/hooks/scripts/user_prompt_store_async.py
@@ -5,7 +5,7 @@ Stores user messages to discussions collection with proper deduplication.
 """
 
 # LANGFUSE: Uses trace buffer (Path A). See LANGFUSE-INTEGRATION-SPEC.md §3.1, §4, §7.7
-# SDK VERSION: V3 ONLY. Do NOT use Langfuse() constructor, start_span(), or start_generation().
+# SDK VERSION: V4. Path A files use emit_trace_event() only — no direct langfuse import.
 # CONSTANT: TRACE_CONTENT_MAX = 10000 (no other value permitted)
 
 import asyncio

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   runs the old env-only path fragmented into 4 distinct scope values; the new
   path is deterministic. This change is disclosed per DEC-105 / DEC-108 C-1 and
   must appear in the PR description.
+- **Langfuse SDK upgraded to `>=4.7.0,<4.8.0`** (was `>=4.0.6,<4.1.0`; resolves
+  to 4.7.1). `uv.lock` regenerated. V3→V4 governance comment headers refreshed
+  across trace-emitting modules.
+- **Langfuse agent trace organization (BP-169 G1–G4).** Agent identity is mapped
+  to `user_id` and agent role to a trace tag/metadata (`_resolve_user_id` /
+  `_resolve_role_tag`); `LANGFUSE_TRACING_ENVIRONMENT` is now supported and
+  validated to partition traces within a project by deployment stage/install.
+
+### Fixed
+
+- **BUG-315 — Trace-flush worker wedge (stuck-backlog data stall).** The
+  trace-flush worker could wedge indefinitely when the Langfuse backend passed
+  its health check but hung mid-flush, silently halting all trace delivery (a
+  ~26K-trace backlog accumulated). `src/memory/trace_flush_worker.py` is
+  hardened: an HTTP `/api/public/health` preflight skips the *drain* (not the
+  loop) when the backend is unreachable; a stall watchdog hard-exits a
+  genuinely-wedged worker so Docker (`restart: unless-stopped`) restarts it into
+  a draining state; the heartbeat is taken at the top of each loop (liveness =
+  loop cycling, not a blocking flush); the buffer drains oldest-first via
+  `os.scandir`+sort; files are unlinked only after a successful `flush()`
+  (loss-safe); poison buffer entries are skipped per-entry; and graceful
+  shutdown drains within a bounded deadline. (BUG-315)
+
+### Upgrade Instructions
+
+- **After updating, run `~/.ai-memory/scripts/stack.sh restart`.** The
+  `trace-flush-worker` is image-baked (its Langfuse SDK and worker code are
+  built into the container image via `docker/Dockerfile.worker`), so pulling the
+  new files and re-running `install.sh` alone does **not** upgrade the running
+  worker — without the restart it keeps running the old SDK and old code.
+  `stack.sh restart` rebuilds the image-bake services and waits for health.
 
 ## [2.4.5] - 2026-05-29
 

--- a/docker/github-sync/requirements.txt
+++ b/docker/github-sync/requirements.txt
@@ -19,7 +19,7 @@ prometheus-client==0.24.1
 tenacity==9.1.4
 
 # Langfuse observability (Wave 3, PLAN-011)
-langfuse>=4.0.6,<4.1.0
+langfuse>=4.7.0,<4.8.0
 
 # Required by memory module import chain (memory/__init__.py)
 # BUG-086: memory/__init__.py unconditionally imports async_sdk_wrapper (anthropic)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
 [project.optional-dependencies]
 observability = [
     # LLM Observability — Langfuse tracing (SPEC-020, PLAN-008)
-    "langfuse>=4.0.6,<4.1.0",
+    "langfuse>=4.7.0,<4.8.0",
 ]
 dev = [
     # Testing
@@ -103,7 +103,7 @@ dev = [
     # YAML parsing (required by tests/unit/test_sops_encryption.py)
     "PyYAML>=6.0,<7.0",
     # Include observability deps so CI has langfuse for tests
-    "langfuse>=4.0.6,<4.1.0",
+    "langfuse>=4.7.0,<4.8.0",
     # Streamlit dashboard (CI validation of docker/streamlit/app.py)
     "streamlit==1.56.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ spacy>=3.8.0,<4.0.0
 croniter>=2.0.0,<7.0.0
 
 # LLM Observability — Langfuse tracing (SPEC-020, PLAN-008)
-langfuse>=4.0.0,<4.1.0
+langfuse>=4.7.0,<4.8.0
 
 # Auto-instrumentation for Anthropic SDK calls (SPEC-020 §6)
 opentelemetry-instrumentation-anthropic>=0.1,<1.0.0

--- a/scripts/create_datasets.py
+++ b/scripts/create_datasets.py
@@ -1564,14 +1564,12 @@ def create_all_datasets(dry_run: bool = False) -> int:
         return 0
 
     try:
-        from langfuse import (
-            get_client,  # V3 singleton — NEVER use constructor with explicit creds
-        )
+        from langfuse import get_client  # V4 SDK — get_client() singleton accessor
 
         langfuse = get_client()
     except ImportError as exc:
         print(f"ERROR: langfuse package not installed — {exc}", file=sys.stderr)
-        print("Run: pip install 'langfuse>=4.0.0,<4.1.0'", file=sys.stderr)
+        print("Run: pip install 'langfuse>=4.7.0,<4.8.0'", file=sys.stderr)
         return 1
     except Exception as exc:
         print(f"ERROR: Failed to get Langfuse client — {exc}", file=sys.stderr)

--- a/scripts/create_score_configs.py
+++ b/scripts/create_score_configs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# LANGFUSE: V3 SDK ONLY. See LANGFUSE-INTEGRATION-SPEC.md
-# FORBIDDEN: Langfuse() constructor, start_span(), start_generation(), langfuse_context
+# LANGFUSE: V4 SDK (Path B — direct get_client()). See LANGFUSE-INTEGRATION-SPEC.md
+# FORBIDDEN (removed in V4): start_span(), start_generation(), langfuse_context
 # REQUIRED: get_client(), api.score_configs.create(), api.score_configs.get(), flush()
 """Idempotent Score Config setup in Langfuse.
 
@@ -107,9 +107,7 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
-        from langfuse import (
-            get_client,  # V3 singleton — NEVER use Langfuse() constructor
-        )
+        from langfuse import get_client  # V4 SDK — get_client() singleton accessor
         from langfuse.api.resources.commons.types import (
             ConfigCategory,
             ScoreConfigDataType,

--- a/scripts/memory/aim_status.py
+++ b/scripts/memory/aim_status.py
@@ -29,6 +29,8 @@ from memory.connectors.github.paths import resolve_github_state_file
 from memory.metrics_push import push_skill_metrics_async
 from memory.qdrant_client import get_qdrant_client
 
+TRACE_CONTENT_MAX = 10000  # Path A emit_trace_event content cap (V4; no other value)
+
 
 def _time_ago(iso_ts: str) -> str:
     try:
@@ -327,8 +329,8 @@ def main() -> int:
         emit_trace_event(
             event_type="skill_execution",
             data={
-                "input": "Skill: aim-status"[:10000],
-                "output": "Result: completed"[:10000],
+                "input": "Skill: aim-status"[:TRACE_CONTENT_MAX],
+                "output": "Result: completed"[:TRACE_CONTENT_MAX],
                 "metadata": {"skill_name": "aim-status"},
             },
             session_id=os.environ.get("CLAUDE_SESSION_ID", "unknown"),

--- a/scripts/memory/classification_worker.py
+++ b/scripts/memory/classification_worker.py
@@ -9,7 +9,7 @@ RESOURCE LIMITS:
 """
 
 # LANGFUSE: Uses trace buffer (Path A). See LANGFUSE-INTEGRATION-SPEC.md §3.1, §4, §7.7
-# SDK VERSION: V3 ONLY. Do NOT use Langfuse() constructor, start_span(), or start_generation().
+# SDK VERSION: V4. Path A files use emit_trace_event() only — no direct langfuse import.
 # CONSTANT: TRACE_CONTENT_MAX = 10000 (no other value permitted)
 
 import argparse

--- a/scripts/memory/parzival_save_decision.py
+++ b/scripts/memory/parzival_save_decision.py
@@ -42,6 +42,8 @@ from memory.config import get_config
 from memory.metrics_push import push_skill_metrics_async
 from memory.storage import MemoryStorage
 
+TRACE_CONTENT_MAX = 10000  # Path A emit_trace_event content cap (V4; no other value)
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Save Parzival decision to Qdrant")
@@ -163,8 +165,8 @@ def main() -> int:
         emit_trace_event(
             event_type="skill_execution",
             data={
-                "input": "Skill: parzival-save-decision"[:10000],
-                "output": f"Result: {status}"[:10000],
+                "input": "Skill: parzival-save-decision"[:TRACE_CONTENT_MAX],
+                "output": f"Result: {status}"[:TRACE_CONTENT_MAX],
                 "metadata": {
                     "skill_name": "parzival-save-decision",
                     "dec_id": args.dec_id,

--- a/scripts/memory/parzival_save_handoff.py
+++ b/scripts/memory/parzival_save_handoff.py
@@ -23,6 +23,8 @@ from memory.config import get_config
 from memory.metrics_push import push_skill_metrics_async
 from memory.storage import MemoryStorage
 
+TRACE_CONTENT_MAX = 10000  # Path A emit_trace_event content cap (V4; no other value)
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Save Parzival handoff to Qdrant")
@@ -112,8 +114,8 @@ def main() -> int:
         emit_trace_event(
             event_type="skill_execution",
             data={
-                "input": "Skill: parzival-save-handoff"[:10000],
-                "output": "Result: completed"[:10000],
+                "input": "Skill: parzival-save-handoff"[:TRACE_CONTENT_MAX],
+                "output": "Result: completed"[:TRACE_CONTENT_MAX],
                 "metadata": {"skill_name": "parzival-save-handoff"},
             },
             session_id=os.environ.get("CLAUDE_SESSION_ID", "unknown"),

--- a/scripts/memory/parzival_save_insight.py
+++ b/scripts/memory/parzival_save_insight.py
@@ -22,6 +22,8 @@ from memory.config import get_config
 from memory.metrics_push import push_skill_metrics_async
 from memory.storage import MemoryStorage
 
+TRACE_CONTENT_MAX = 10000  # Path A emit_trace_event content cap (V4; no other value)
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Save Parzival insight to Qdrant")
@@ -92,8 +94,8 @@ def main() -> int:
         emit_trace_event(
             event_type="skill_execution",
             data={
-                "input": "Skill: parzival-save-insight"[:10000],
-                "output": "Result: completed"[:10000],
+                "input": "Skill: parzival-save-insight"[:TRACE_CONTENT_MAX],
+                "output": "Result: completed"[:TRACE_CONTENT_MAX],
                 "metadata": {"skill_name": "parzival-save-insight"},
             },
             session_id=os.environ.get("CLAUDE_SESSION_ID", "unknown"),

--- a/scripts/memory/process_classification_queue.py
+++ b/scripts/memory/process_classification_queue.py
@@ -24,7 +24,7 @@ Reference:
 """
 
 # LANGFUSE: Uses trace buffer (Path A). See LANGFUSE-INTEGRATION-SPEC.md §3.1, §4, §7.7
-# SDK VERSION: V3 ONLY. Do NOT use Langfuse() constructor, start_span(), or start_generation().
+# SDK VERSION: V4. Path A files use emit_trace_event() only — no direct langfuse import.
 # CONSTANT: TRACE_CONTENT_MAX = 10000 (no other value permitted)
 
 import asyncio

--- a/src/memory/evaluator/runner.py
+++ b/src/memory/evaluator/runner.py
@@ -1,5 +1,5 @@
 # LANGFUSE: V4 SDK ONLY. See LANGFUSE-INTEGRATION-SPEC.md
-# FORBIDDEN: Langfuse() constructor, start_span(), start_generation(), langfuse_context
+# FORBIDDEN (removed in V4): start_span(), start_generation(), langfuse_context
 # REQUIRED: get_client(), create_score(), flush()
 """Evaluation runner — fetches traces and observations, evaluates, attaches scores.
 
@@ -606,7 +606,7 @@ class EvaluatorRunner:
         # Reset per-run score accumulator (C-1: avoid cross-run average corruption)
         self._ev_scores = {}
 
-        # V3 singleton — NEVER use Langfuse() constructor directly
+        # V4 SDK — get_client() singleton accessor
         langfuse = get_client()
 
         if until is None:

--- a/src/memory/langfuse_config.py
+++ b/src/memory/langfuse_config.py
@@ -103,6 +103,10 @@ def get_langfuse_client():
     a later call (after env vars are configured) will succeed.
     This is important for long-lived processes (Phase 2, SPEC-020).
 
+    Side effect: if ``LANGFUSE_TRACING_ENVIRONMENT`` is set to a value that fails
+    ``validate_tracing_environment`` (G4, BP-169), it is popped from ``os.environ``
+    so the V4 SDK does not silently ignore a malformed env at construction.
+
     Returns:
         Langfuse client instance, or None if disabled/unavailable.
     """

--- a/src/memory/langfuse_config.py
+++ b/src/memory/langfuse_config.py
@@ -11,6 +11,7 @@ SPEC: LANGFUSE-INTEGRATION-SPEC.md Section 7.2
 
 import logging
 import os
+import re
 import threading
 
 from tenacity import (
@@ -21,6 +22,26 @@ from tenacity import (
 )
 
 logger = logging.getLogger(__name__)
+
+# G4 (BP-169): LANGFUSE_TRACING_ENVIRONMENT partitions traces within a project by
+# deployment stage/install. The v4 SDK reads it natively from the environment;
+# Langfuse enforces this format and silently drops a value that violates it.
+_TRACING_ENVIRONMENT_RE = re.compile(r"^(?!langfuse)[a-z0-9-_]+$")
+_TRACING_ENVIRONMENT_MAX = 40
+
+
+def validate_tracing_environment(value: str | None) -> str | None:
+    """Return ``value`` if it is a valid LANGFUSE_TRACING_ENVIRONMENT, else None.
+
+    Valid = matches ``^(?!langfuse)[a-z0-9-_]+$`` and ≤40 chars (Langfuse's rule).
+    Operator-supplied via env only — never a hardcoded value (multi-operator
+    portability gate).
+    """
+    if not value:
+        return None
+    if len(value) <= _TRACING_ENVIRONMENT_MAX and _TRACING_ENVIRONMENT_RE.match(value):
+        return value
+    return None
 
 
 def _is_retryable(exc: BaseException) -> bool:
@@ -101,6 +122,18 @@ def get_langfuse_client():
         if not enabled:
             logger.debug("Langfuse disabled (LANGFUSE_ENABLED != true)")
             return None
+
+        # G4 (BP-169): validate the operator-supplied tracing environment; drop an
+        # invalid value so the SDK does not silently ignore a malformed env (the
+        # SDK reads LANGFUSE_TRACING_ENVIRONMENT from os.environ at construction).
+        raw_environment = os.environ.get("LANGFUSE_TRACING_ENVIRONMENT")
+        if raw_environment and validate_tracing_environment(raw_environment) is None:
+            logger.warning(
+                "Invalid LANGFUSE_TRACING_ENVIRONMENT %r — ignoring "
+                "(must match ^(?!langfuse)[a-z0-9-_]+$, ≤40 chars)",
+                raw_environment,
+            )
+            os.environ.pop("LANGFUSE_TRACING_ENVIRONMENT", None)
 
         # Note: reads directly from env (not config.py) since this runs in hook subprocesses
         public_key = os.environ.get("LANGFUSE_PUBLIC_KEY", "")

--- a/src/memory/trace_flush_worker.py
+++ b/src/memory/trace_flush_worker.py
@@ -18,11 +18,14 @@ import logging
 import os
 import random
 import signal
+import socket
 import stat
 import sys
+import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
+from urllib.parse import urlparse
 
 try:
     from opentelemetry import trace as otel_trace_api
@@ -101,7 +104,42 @@ FLUSH_INTERVAL = int(os.environ.get("LANGFUSE_FLUSH_INTERVAL", "5"))
 MAX_BUFFER_MB = int(os.environ.get("LANGFUSE_TRACE_BUFFER_MAX_MB", "100"))
 HEARTBEAT_FILE = BUFFER_DIR / ".heartbeat"
 
+# BUG-315: bound the per-iteration drain so one slow flush cannot wedge an
+# unbounded pass over a large backlog. Aligned with LANGFUSE_FLUSH_AT (max events
+# the SDK batches per send) so each pass enqueues at most one batch before the
+# loop cycles (refreshing the heartbeat and re-checking connectivity).
+FLUSH_BATCH_MAX = int(os.environ.get("LANGFUSE_FLUSH_AT", "500"))
+
+# Backend the worker flushes to. flush() blocks (never throws) when this is
+# unreachable, so the loop preflights a TCP probe here and skips the flush when
+# it cannot connect (the container has no wget/curl).
+LANGFUSE_BASE_URL = os.environ.get("LANGFUSE_BASE_URL", "http://langfuse-web:3000")
+PREFLIGHT_TIMEOUT_SECONDS = float(
+    os.environ.get("LANGFUSE_PREFLIGHT_TIMEOUT_SECONDS", "3")
+)
+
+# BUG-315: stall watchdog. If the main loop makes no forward progress (completes
+# no full iteration) for this long, it is considered wedged and the process
+# self-exits so Docker (restart: unless-stopped) restarts it into a draining
+# state — an "unhealthy" healthcheck alone does NOT trigger a restart. Derived
+# from FLUSH_INTERVAL with a wide margin so a slow-but-progressing backlog drain
+# (each bounded batch advances the progress marker) never trips it.
+STALL_DEADLINE_SECONDS = int(
+    os.environ.get(
+        "LANGFUSE_STALL_DEADLINE_SECONDS", str(max(FLUSH_INTERVAL * 12, 120))
+    )
+)
+
 shutdown_requested = False
+
+# Monotonic timestamp of the last completed main-loop iteration. The watchdog
+# thread reads this to detect a wedged loop. Updated at the bottom of each
+# iteration so it reflects drain progress, not raw wall-clock spent inside flush.
+_last_loop_progress = 0.0
+
+# Watchdog wakeup — lets the watchdog wait on its own cadence (not time.sleep, so
+# it stays independent of the main loop's pacing) and be woken promptly on exit.
+_watchdog_wakeup = threading.Event()
 
 
 def _handle_signal(signum, frame):
@@ -112,6 +150,76 @@ def _handle_signal(signum, frame):
 
 signal.signal(signal.SIGTERM, _handle_signal)
 signal.signal(signal.SIGINT, _handle_signal)
+
+
+def _backend_reachable() -> bool:
+    """Return True if a TCP connection to the Langfuse backend can be opened.
+
+    The worker container ships without wget/curl, so connectivity is probed with
+    a short-timeout socket connect. flush() blocks (and never throws) against an
+    unreachable backend, so the loop uses this to skip the flush and keep cycling
+    (evict + heartbeat) instead of wedging inside a doomed retry (BUG-315).
+    """
+    parsed = urlparse(LANGFUSE_BASE_URL)
+    host = parsed.hostname
+    if not host:
+        return False
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    try:
+        with socket.create_connection((host, port), timeout=PREFLIGHT_TIMEOUT_SECONDS):
+            return True
+    except OSError:
+        return False
+
+
+def _resolve_user_id(span_metadata: dict) -> str:
+    """Map a buffered event's agent identity to a Langfuse user_id (BP-169 §2.3).
+
+    Convention: ``agent:<name>`` for agent-attributable events (the capture-time
+    CLAUDE_AGENT_NAME, already in data["metadata"]); ``system:unknown`` when the
+    buffered event carries no identity. The flush worker's own service spans use
+    ``system:trace-flush-worker`` — but the events processed here are relayed
+    agent events, so they carry their real identity, not the worker's.
+    """
+    agent_name = span_metadata.get("agent_name")
+    if agent_name:
+        return f"agent:{agent_name}"[:200]
+    return "system:unknown"
+
+
+def _resolve_role_tag(span_metadata: dict) -> str | None:
+    """Return a ``role:<role>`` tag from the buffered event's agent_role, or None."""
+    agent_role = span_metadata.get("agent_role")
+    if agent_role:
+        return f"role:{agent_role}"[:200]
+    return None
+
+
+def _is_stalled(last_progress: float, now: float) -> bool:
+    """Return True if the loop has made no progress within STALL_DEADLINE_SECONDS."""
+    return (now - last_progress) > STALL_DEADLINE_SECONDS
+
+
+def _watchdog_loop() -> None:
+    """Background watchdog: hard-exit the process if the main loop wedges.
+
+    Measures drain progress via ``_last_loop_progress`` (advanced at the bottom of
+    every main-loop iteration), so a slow-but-progressing backlog drain is never
+    killed — only a loop stuck inside a blocking flush/process pass trips it.
+
+    Uses ``os._exit`` (not ``sys.exit``): when the main thread is wedged in a
+    blocking flush, a SystemExit raised in this thread cannot terminate the
+    process, so a hard exit is the only way to let Docker restart the container.
+    """
+    while not shutdown_requested:
+        if _last_loop_progress and _is_stalled(_last_loop_progress, time.monotonic()):
+            logger.warning(
+                "Trace flush loop stalled — no progress for >%ss (wedged flush?). "
+                "Self-exiting so Docker restarts the worker into a draining state.",
+                STALL_DEADLINE_SECONDS,
+            )
+            os._exit(1)
+        _watchdog_wakeup.wait(min(FLUSH_INTERVAL or 1, 5))
 
 
 def evict_oldest_traces() -> int:
@@ -213,8 +321,11 @@ def _process_event_otel(event: dict, data: dict) -> None:
                 "langfuse.observation.usage_details",
                 json.dumps(data["usage"]),
             )
-    elif as_type == "retriever":
-        otel_span.set_attribute("langfuse.observation.type", "retriever")
+    elif as_type in ("retriever", "agent", "tool", "chain"):
+        # G3 (BP-169): agent/tool/chain make the agent-graph view trigger; the
+        # graph renders only when a trace has an observation whose type is not
+        # span/event/generation.
+        otel_span.set_attribute("langfuse.observation.type", as_type)
 
     span_metadata = dict(data.get("metadata") or {})
     if data.get("start_time"):
@@ -238,8 +349,10 @@ def _process_event_otel(event: dict, data: dict) -> None:
         if event.get("session_id"):
             # Langfuse SDK v4 expects "session.id" (not "langfuse.trace.session_id")
             otel_span.set_attribute("session.id", event["session_id"])
-        # Trace flush worker is a system service — user.id is always "system"
-        otel_span.set_attribute("user.id", "system")
+        # G1 (BP-169): agent identity comes from the buffered event, not a
+        # hardcoded "system" — agent:<name> for agent-attributable events,
+        # system:unknown when the event carries none.
+        otel_span.set_attribute("user.id", _resolve_user_id(span_metadata))
         if data.get("input") is not None:
             val = data["input"]
             otel_span.set_attribute(
@@ -252,14 +365,21 @@ def _process_event_otel(event: dict, data: dict) -> None:
                 "langfuse.trace.output",
                 json.dumps(val) if not isinstance(val, str) else val,
             )
-        otel_span.set_attribute(
-            "langfuse.trace.metadata",
-            json.dumps(
-                {"project_id": event.get("project_id"), "source": "trace_buffer"}
-            ),
-        )
-        if event.get("tags"):
-            otel_span.set_attribute("langfuse.trace.tags", event["tags"])
+        trace_metadata = {
+            "project_id": event.get("project_id"),
+            "source": "trace_buffer",
+        }
+        # G2 (BP-169): role is propagated trace-level metadata (+ a role:<role>
+        # tag below), not identity.
+        if span_metadata.get("agent_role"):
+            trace_metadata["agent_role"] = str(span_metadata["agent_role"])[:200]
+        otel_span.set_attribute("langfuse.trace.metadata", json.dumps(trace_metadata))
+        trace_tags = list(event.get("tags") or [])
+        role_tag = _resolve_role_tag(span_metadata)
+        if role_tag:
+            trace_tags.append(role_tag)
+        if trace_tags:
+            otel_span.set_attribute("langfuse.trace.tags", trace_tags)
 
     if end_ns is not None:
         otel_span.end(end_time=end_ns)
@@ -288,13 +408,22 @@ def _process_event_sdk(event: dict, data: dict, langfuse) -> None:
 
     # Set trace-level attributes via propagate_attributes (V4 pattern).
     # Falls back to nullcontext if langfuse not installed (degraded mode).
+    # G1/G2 (BP-169): identity → user_id (agent:<name>/system:unknown);
+    # role → propagated metadata.agent_role + a role:<role> tag.
+    trace_metadata = {"project_id": event.get("project_id"), "source": "trace_buffer"}
+    if span_metadata.get("agent_role"):
+        trace_metadata["agent_role"] = str(span_metadata["agent_role"])[:200]
+    trace_tags = list(event.get("tags") or [])
+    role_tag = _resolve_role_tag(span_metadata)
+    if role_tag:
+        trace_tags.append(role_tag)
     _prop_ctx = (
         _langfuse_propagate_attributes(
             trace_name=f"hook_pipeline_{event.get('project_id', 'unknown')}",
             session_id=event.get("session_id") or None,
-            user_id="system",
-            metadata={"project_id": event.get("project_id"), "source": "trace_buffer"},
-            tags=event.get("tags") or None,
+            user_id=_resolve_user_id(span_metadata),
+            metadata=trace_metadata,
+            tags=trace_tags or None,
         )
         if _langfuse_propagate_attributes is not None
         else contextlib.nullcontext()
@@ -302,8 +431,13 @@ def _process_event_sdk(event: dict, data: dict, langfuse) -> None:
     with _prop_ctx:
         observation = langfuse.start_observation(
             name=event_type,
+            # G3 (BP-169): pass agent/tool/chain through so the agent-graph view
+            # triggers; unknown types still fall back to span.
             as_type=(
-                as_type if as_type in ("generation", "span", "retriever") else "span"
+                as_type
+                if as_type
+                in ("generation", "span", "retriever", "agent", "tool", "chain")
+                else "span"
             ),
             trace_context={"trace_id": trace_id} if trace_id else None,
         )
@@ -328,11 +462,18 @@ def _process_event_sdk(event: dict, data: dict, langfuse) -> None:
             observation.end()
 
 
-def process_buffer_files(langfuse) -> tuple[int, int]:
-    """Read *.json files from buffer dir, create Langfuse traces+spans, delete processed.
+def process_buffer_files(langfuse, limit: int = FLUSH_BATCH_MAX) -> tuple[int, int]:
+    """Drain up to ``limit`` *.json buffer files to Langfuse, deleting processed.
 
     Uses raw OTel spans when available (ISSUE-183: accurate timing via start_time).
     Falls back to Langfuse SDK when OTel is not installed.
+
+    BUG-315: the batch is bounded (``limit``) so one slow flush cannot wedge an
+    unbounded pass over a large backlog — the caller loops, refreshing the
+    heartbeat and re-checking connectivity between batches. The drain is
+    loss-safe: a file is unlinked only AFTER ``flush()`` confirms the batch is
+    enqueued. A crash between enqueue and unlink replays the batch on restart
+    (at-least-once; a duplicate is preferred over a dropped trace).
 
     Returns:
         Tuple of (processed_count, error_count).
@@ -342,8 +483,9 @@ def process_buffer_files(langfuse) -> tuple[int, int]:
 
     processed = 0
     errors = 0
+    enqueued: list[Path] = []
 
-    for json_file in list(BUFFER_DIR.glob("*.json")):
+    for json_file in list(BUFFER_DIR.glob("*.json"))[:limit]:
         try:
             with open(json_file) as f:
                 event = json.load(f)
@@ -362,18 +504,35 @@ def process_buffer_files(langfuse) -> tuple[int, int]:
                 _process_event_otel(event, data)
             else:
                 _process_event_sdk(event, data, langfuse)
-            json_file.unlink()
-            processed += 1
+            enqueued.append(json_file)
         except Exception as e:
             logger.error("Failed to process buffer file %s: %s", json_file.name, e)
             errors += 1
+
+    # Loss-safe: flush the batch before unlinking so files are removed only once
+    # their spans are confirmed enqueued (flush() blocks until queues drain).
+    if enqueued:
+        try:
+            langfuse.flush()
+        except Exception as e:
+            logger.warning("Langfuse flush failed: %s", e)
+        for json_file in enqueued:
+            with contextlib.suppress(OSError):
+                json_file.unlink()
+            processed += 1
 
     return processed, errors
 
 
 def main():
-    """Main flush loop: evict → process → flush → push metrics → sleep."""
-    global shutdown_requested
+    """Main flush loop: heartbeat → evict → preflight → drain batch → metrics → sleep.
+
+    BUG-315: the heartbeat is touched at the TOP of each iteration (liveness =
+    loop cycling, decoupled from a blocking flush); a TCP preflight skips the
+    drain when the backend is unreachable; and a watchdog thread hard-exits the
+    process if the loop wedges so Docker restarts it.
+    """
+    global shutdown_requested, _last_loop_progress
 
     langfuse = get_langfuse_client()
     degraded = langfuse is None
@@ -387,31 +546,44 @@ def main():
         )
     else:
         logger.info(
-            "Trace flush worker started (buffer=%s, interval=%ss, max_buffer=%sMB)",
+            "Trace flush worker started (buffer=%s, interval=%ss, max_buffer=%sMB, batch=%s)",
             BUFFER_DIR,
             FLUSH_INTERVAL,
             MAX_BUFFER_MB,
+            FLUSH_BATCH_MAX,
         )
+
+    # Start the stall watchdog (BUG-315). Daemon thread so it never blocks exit.
+    _last_loop_progress = time.monotonic()
+    threading.Thread(target=_watchdog_loop, name="flush-watchdog", daemon=True).start()
 
     total_processed = 0
     total_errors = 0
 
     while not shutdown_requested:
+        # TD-182 / BUG-315: heartbeat at the TOP of the loop so liveness reflects
+        # the loop cycling, not a long/blocking flush completing.
+        with contextlib.suppress(OSError):
+            HEARTBEAT_FILE.touch()
+
         evicted = evict_oldest_traces()
 
         processed = 0
         errors = 0
         if not degraded:
-            processed, errors = process_buffer_files(langfuse)
-
-            total_errors += errors
-            if processed > 0:
-                try:
-                    langfuse.flush()
-                except Exception as e:
-                    logger.warning("Langfuse flush failed: %s", e)
+            # Preflight: flush() blocks (never throws) on an unreachable backend,
+            # so skip the drain when it cannot connect and keep cycling.
+            if _backend_reachable():
+                processed, errors = process_buffer_files(langfuse)
+                total_errors += errors
                 total_processed += processed
-                logger.info("Flushed %s events (%s errors)", processed, errors)
+                if processed > 0:
+                    logger.info("Flushed %s events (%s errors)", processed, errors)
+            else:
+                logger.debug(
+                    "Langfuse backend unreachable (%s) — skipping flush this cycle",
+                    LANGFUSE_BASE_URL,
+                )
 
         # Push metrics regardless of degraded state (M-1: keep observability when
         # Langfuse is down — evictions still happen and buffer still grows)
@@ -428,11 +600,14 @@ def main():
                 flush_errors=errors,
             )
 
-        # TD-182: Touch heartbeat file for Docker healthcheck (file-based liveness probe)
-        with contextlib.suppress(OSError):
-            HEARTBEAT_FILE.touch()
+        # Mark forward progress (a full iteration completed) for the stall
+        # watchdog — a loop wedged inside flush never reaches this point.
+        _last_loop_progress = time.monotonic()
 
         time.sleep(FLUSH_INTERVAL)
+
+    # Wake the watchdog so it re-checks shutdown_requested and exits promptly.
+    _watchdog_wakeup.set()
 
     # Graceful shutdown — flush remaining buffer
     logger.info(
@@ -440,16 +615,13 @@ def main():
         total_processed,
     )
 
-    if not degraded:
+    # Best-effort bounded drain on shutdown (loss-safe: process_buffer_files
+    # flushes before unlinking; any remainder persists for the next start).
+    if not degraded and _backend_reachable():
         evict_oldest_traces()
         processed, errors = process_buffer_files(langfuse)
         total_errors += errors
-        if processed > 0:
-            try:
-                langfuse.flush()
-            except Exception as e:
-                logger.warning("Langfuse flush failed during shutdown: %s", e)
-            total_processed += processed
+        total_processed += processed
 
     logger.info(
         "Trace flush worker stopped (total_processed=%s, total_errors=%s)",

--- a/src/memory/trace_flush_worker.py
+++ b/src/memory/trace_flush_worker.py
@@ -11,6 +11,15 @@ SPEC-020 §5 / PLAN-008 / DEC-PLAN008-004
 # TD-372: OTel scope "ai-memory.flush-worker" requires should_export_span in langfuse_config.py.
 # OTel path (_process_event_otel): Uses raw OTel spans — DO NOT change attribute names.
 # SDK path (_process_event_sdk): Fallback when OTel unavailable — uses start_observation().
+#
+# BUG-315 residual risk: the preflight HTTP /api/public/health probe skips the flush
+# when the backend is unreachable or app-hung, and processing is bounded per batch, so
+# the stall watchdog should only ever see a genuinely-slow-but-progressing drain. The
+# one case it can still hard-exit is a backend that passes the health probe but then
+# hangs mid-flush-request past LANGFUSE_STALL_DEADLINE_SECONDS — the watchdog restarts
+# the worker, which replays the un-unlinked batch (loss-safe). Operators running a large
+# LANGFUSE_FLUSH_AT against a slow backend should raise LANGFUSE_STALL_DEADLINE_SECONDS
+# (a startup WARNING flags this; see _stall_deadline_warning).
 
 import contextlib
 import json
@@ -18,14 +27,14 @@ import logging
 import os
 import random
 import signal
-import socket
 import stat
 import sys
 import threading
 import time
+import urllib.error
+import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
-from urllib.parse import urlparse
 
 try:
     from opentelemetry import trace as otel_trace_api
@@ -108,11 +117,20 @@ HEARTBEAT_FILE = BUFFER_DIR / ".heartbeat"
 # unbounded pass over a large backlog. Aligned with LANGFUSE_FLUSH_AT (max events
 # the SDK batches per send) so each pass enqueues at most one batch before the
 # loop cycles (refreshing the heartbeat and re-checking connectivity).
-FLUSH_BATCH_MAX = int(os.environ.get("LANGFUSE_FLUSH_AT", "500"))
+_DEFAULT_FLUSH_BATCH_MAX = 500
+FLUSH_BATCH_MAX = int(
+    os.environ.get("LANGFUSE_FLUSH_AT", str(_DEFAULT_FLUSH_BATCH_MAX))
+)
+
+# Best-effort wall-clock budget for the graceful-shutdown drain loop. Kept under
+# Docker's default 10s stop-grace so SIGKILL does not interrupt mid-flush; if it
+# does, the drain is loss-safe (process_buffer_files unlinks only after flush
+# confirms enqueue) so any remainder replays on next start.
+SHUTDOWN_DRAIN_SECONDS = float(os.environ.get("LANGFUSE_SHUTDOWN_DRAIN_SECONDS", "5"))
 
 # Backend the worker flushes to. flush() blocks (never throws) when this is
-# unreachable, so the loop preflights a TCP probe here and skips the flush when
-# it cannot connect (the container has no wget/curl).
+# unreachable, so the loop preflights an HTTP /api/public/health probe here and
+# skips the flush when it cannot connect (the container has no wget/curl).
 LANGFUSE_BASE_URL = os.environ.get("LANGFUSE_BASE_URL", "http://langfuse-web:3000")
 PREFLIGHT_TIMEOUT_SECONDS = float(
     os.environ.get("LANGFUSE_PREFLIGHT_TIMEOUT_SECONDS", "3")
@@ -153,22 +171,27 @@ signal.signal(signal.SIGINT, _handle_signal)
 
 
 def _backend_reachable() -> bool:
-    """Return True if a TCP connection to the Langfuse backend can be opened.
+    """Return True if the Langfuse backend answers an HTTP readiness probe with 200.
 
-    The worker container ships without wget/curl, so connectivity is probed with
-    a short-timeout socket connect. flush() blocks (and never throws) against an
-    unreachable backend, so the loop uses this to skip the flush and keep cycling
-    (evict + heartbeat) instead of wedging inside a doomed retry (BUG-315).
+    The worker container ships without wget/curl, so connectivity is probed with a
+    short-timeout stdlib HTTP GET to Langfuse's ``/api/public/health`` endpoint (the
+    self-hosted health check — it confirms the web app is alive and its API is
+    functioning, not merely that the TCP port is open). A bare TCP connect would pass
+    against a TCP-up-but-app-hung backend; the HTTP probe instead times out or returns
+    non-200, so such a backend is correctly reported unreachable. flush() blocks (and
+    never throws) against an unreachable or hung backend, so the loop uses this to skip
+    the flush and keep cycling (evict + heartbeat) instead of wedging inside a doomed
+    retry (BUG-315).
     """
-    parsed = urlparse(LANGFUSE_BASE_URL)
-    host = parsed.hostname
-    if not host:
+    if not LANGFUSE_BASE_URL:
         return False
-    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    health_url = LANGFUSE_BASE_URL.rstrip("/") + "/api/public/health"
     try:
-        with socket.create_connection((host, port), timeout=PREFLIGHT_TIMEOUT_SECONDS):
-            return True
-    except OSError:
+        with urllib.request.urlopen(
+            health_url, timeout=PREFLIGHT_TIMEOUT_SECONDS
+        ) as resp:
+            return resp.status == 200
+    except (urllib.error.URLError, OSError):
         return False
 
 
@@ -200,12 +223,41 @@ def _is_stalled(last_progress: float, now: float) -> bool:
     return (now - last_progress) > STALL_DEADLINE_SECONDS
 
 
+def _stall_deadline_warning() -> str | None:
+    """Return a startup warning if the batch cap is large but the stall deadline
+    was left at its default, else None.
+
+    A large ``LANGFUSE_FLUSH_AT`` flushing against a slow backend can take longer
+    than the default ``LANGFUSE_STALL_DEADLINE_SECONDS``, so a legitimately-slow
+    bounded flush could trip the watchdog. The deadline is NOT auto-derived from the
+    batch size (there is no reliable per-event flush-latency model); instead this
+    flags the risky configuration shape — operator raised the batch cap above the
+    default without raising the deadline — and tells them to raise the deadline.
+    """
+    flush_at_raised = FLUSH_BATCH_MAX > _DEFAULT_FLUSH_BATCH_MAX
+    deadline_left_default = "LANGFUSE_STALL_DEADLINE_SECONDS" not in os.environ
+    if flush_at_raised and deadline_left_default:
+        return (
+            f"LANGFUSE_FLUSH_AT={FLUSH_BATCH_MAX} exceeds the default "
+            f"({_DEFAULT_FLUSH_BATCH_MAX}) but LANGFUSE_STALL_DEADLINE_SECONDS is unset "
+            f"(default {STALL_DEADLINE_SECONDS}s): a single large batch flushing against "
+            "a slow backend may exceed the stall deadline and trigger a watchdog restart "
+            "mid-flush. Raise LANGFUSE_STALL_DEADLINE_SECONDS to accommodate the larger "
+            "batch."
+        )
+    return None
+
+
 def _watchdog_loop() -> None:
     """Background watchdog: hard-exit the process if the main loop wedges.
 
     Measures drain progress via ``_last_loop_progress`` (advanced at the bottom of
     every main-loop iteration), so a slow-but-progressing backlog drain is never
-    killed — only a loop stuck inside a blocking flush/process pass trips it.
+    killed — only a loop stuck inside a blocking flush/process pass trips it. With the
+    HTTP preflight skipping unreachable/hung backends and processing bounded per batch,
+    the only residual trip is a backend that passes the health probe but hangs
+    mid-flush-request past STALL_DEADLINE_SECONDS; the restart replays the
+    un-unlinked batch (loss-safe).
 
     Uses ``os._exit`` (not ``sys.exit``): when the main thread is wedged in a
     blocking flush, a SystemExit raised in this thread cannot terminate the
@@ -218,6 +270,10 @@ def _watchdog_loop() -> None:
                 "Self-exiting so Docker restarts the worker into a draining state.",
                 STALL_DEADLINE_SECONDS,
             )
+            # Flush logging handlers so the stall diagnostic is not lost on hard exit.
+            for _handler in logging.getLogger().handlers:
+                with contextlib.suppress(Exception):
+                    _handler.flush()
             os._exit(1)
         _watchdog_wakeup.wait(min(FLUSH_INTERVAL or 1, 5))
 
@@ -470,10 +526,13 @@ def process_buffer_files(langfuse, limit: int = FLUSH_BATCH_MAX) -> tuple[int, i
 
     BUG-315: the batch is bounded (``limit``) so one slow flush cannot wedge an
     unbounded pass over a large backlog — the caller loops, refreshing the
-    heartbeat and re-checking connectivity between batches. The drain is
-    loss-safe: a file is unlinked only AFTER ``flush()`` confirms the batch is
-    enqueued. A crash between enqueue and unlink replays the batch on restart
-    (at-least-once; a duplicate is preferred over a dropped trace).
+    heartbeat and re-checking connectivity between batches. Files are drained
+    oldest-first (by mtime) to align with ``evict_oldest_traces`` (which evicts
+    oldest-first), so an oldest un-flushed trace reaches the batch before eviction
+    can drop it. The drain is loss-safe: a file is unlinked only AFTER ``flush()``
+    confirms the batch is enqueued (and only if it did not raise). A crash between
+    enqueue and unlink replays the batch on restart (at-least-once; a duplicate is
+    preferred over a dropped trace).
 
     Returns:
         Tuple of (processed_count, error_count).
@@ -485,7 +544,28 @@ def process_buffer_files(langfuse, limit: int = FLUSH_BATCH_MAX) -> tuple[int, i
     errors = 0
     enqueued: list[Path] = []
 
-    for json_file in list(BUFFER_DIR.glob("*.json"))[:limit]:
+    # F-2/F-3 (BUG-315): drain oldest-first to align with evict_oldest_traces (which
+    # drops oldest-first) — an oldest un-flushed trace must reach the batch before
+    # eviction can drop it. Oldest-first requires every file's mtime, so this is a
+    # single os.scandir pass collecting (mtime, path), sorted, then capped at ``limit``
+    # — not the old list(glob) that materialized every Path only to slice most away.
+    # The scan is O(n) in backlog size per pass (the same cost evict_oldest_traces
+    # already pays each iteration; ~22K transient (mtime, path) tuples at the BUG-315
+    # backlog). The wedge fix is the bounded *processing* (``limit``), which is
+    # independent of backlog size — see the watchdog/main loop.
+    try:
+        scanned: list[tuple[float, Path]] = []
+        with os.scandir(BUFFER_DIR) as it:
+            for entry in it:
+                st = entry.stat()
+                if stat.S_ISREG(st.st_mode) and entry.name.endswith(".json"):
+                    scanned.append((st.st_mtime, Path(entry.path)))
+    except OSError as e:
+        logger.warning("Failed to scan buffer dir: %s", e)
+        return 0, 0
+    scanned.sort(key=lambda x: x[0])
+
+    for json_file in [path for _mtime, path in scanned[:limit]]:
         try:
             with open(json_file) as f:
                 event = json.load(f)
@@ -510,16 +590,27 @@ def process_buffer_files(langfuse, limit: int = FLUSH_BATCH_MAX) -> tuple[int, i
             errors += 1
 
     # Loss-safe: flush the batch before unlinking so files are removed only once
-    # their spans are confirmed enqueued (flush() blocks until queues drain).
+    # their spans are confirmed enqueued (flush() blocks until queues drain). Per
+    # BP-168, flush() logs+retries and never throws on network error, so the except
+    # is a defensive backstop; if it does raise, the files are retained (not unlinked)
+    # so the batch replays next pass rather than dropping traces (F-5).
     if enqueued:
+        flush_ok = False
         try:
             langfuse.flush()
+            flush_ok = True
         except Exception as e:
             logger.warning("Langfuse flush failed: %s", e)
-        for json_file in enqueued:
-            with contextlib.suppress(OSError):
-                json_file.unlink()
-            processed += 1
+        if flush_ok:
+            for json_file in enqueued:
+                with contextlib.suppress(OSError):
+                    json_file.unlink()
+                processed += 1
+        else:
+            logger.warning(
+                "Retaining %s buffered file(s) for retry — flush did not confirm enqueue",
+                len(enqueued),
+            )
 
     return processed, errors
 
@@ -528,9 +619,9 @@ def main():
     """Main flush loop: heartbeat → evict → preflight → drain batch → metrics → sleep.
 
     BUG-315: the heartbeat is touched at the TOP of each iteration (liveness =
-    loop cycling, decoupled from a blocking flush); a TCP preflight skips the
-    drain when the backend is unreachable; and a watchdog thread hard-exits the
-    process if the loop wedges so Docker restarts it.
+    loop cycling, decoupled from a blocking flush); an HTTP /api/public/health
+    preflight skips the drain when the backend is unreachable or app-hung; and a
+    watchdog thread hard-exits the process if the loop wedges so Docker restarts it.
     """
     global shutdown_requested, _last_loop_progress
 
@@ -552,6 +643,9 @@ def main():
             MAX_BUFFER_MB,
             FLUSH_BATCH_MAX,
         )
+        _deadline_warning = _stall_deadline_warning()
+        if _deadline_warning:
+            logger.warning(_deadline_warning)
 
     # Start the stall watchdog (BUG-315). Daemon thread so it never blocks exit.
     _last_loop_progress = time.monotonic()
@@ -615,13 +709,21 @@ def main():
         total_processed,
     )
 
-    # Best-effort bounded drain on shutdown (loss-safe: process_buffer_files
-    # flushes before unlinking; any remainder persists for the next start).
-    if not degraded and _backend_reachable():
-        evict_oldest_traces()
-        processed, errors = process_buffer_files(langfuse)
-        total_errors += errors
-        total_processed += processed
+    # Best-effort bounded drain on shutdown: keep draining batches until the buffer
+    # is empty OR the SHUTDOWN_DRAIN_SECONDS budget elapses OR the backend stops
+    # responding. Loss-safe (process_buffer_files flushes before unlinking; any
+    # remainder persists for the next start). The watchdog was already signalled
+    # (_watchdog_wakeup.set + shutdown_requested True) above, so it cannot os._exit
+    # during this drain.
+    if not degraded:
+        drain_deadline = time.monotonic() + SHUTDOWN_DRAIN_SECONDS
+        while time.monotonic() < drain_deadline and _backend_reachable():
+            evict_oldest_traces()
+            processed, errors = process_buffer_files(langfuse)
+            total_errors += errors
+            total_processed += processed
+            if processed == 0 and errors == 0:
+                break  # buffer drained (or nothing left to process)
 
     logger.info(
         "Trace flush worker stopped (total_processed=%s, total_errors=%s)",

--- a/src/memory/trace_flush_worker.py
+++ b/src/memory/trace_flush_worker.py
@@ -287,12 +287,18 @@ def evict_oldest_traces() -> int:
     if not BUFFER_DIR.exists():
         return 0
 
+    # Single stat call per file via os.scandir for efficiency
+    entries = []
     try:
-        # Single stat call per file via os.scandir for efficiency
-        entries = []
         with os.scandir(BUFFER_DIR) as it:
             for entry in it:
-                st = entry.stat()
+                try:
+                    st = entry.stat()
+                except OSError as e:
+                    logger.debug(
+                        "Skipping unreadable buffer entry %s: %s", entry.name, e
+                    )
+                    continue
                 if stat.S_ISREG(st.st_mode) and entry.name.endswith(".json"):
                     entries.append((st.st_mtime, st.st_size, Path(entry.path)))
     except OSError as e:
@@ -553,11 +559,17 @@ def process_buffer_files(langfuse, limit: int = FLUSH_BATCH_MAX) -> tuple[int, i
     # already pays each iteration; ~22K transient (mtime, path) tuples at the BUG-315
     # backlog). The wedge fix is the bounded *processing* (``limit``), which is
     # independent of backlog size — see the watchdog/main loop.
+    scanned: list[tuple[float, Path]] = []
     try:
-        scanned: list[tuple[float, Path]] = []
         with os.scandir(BUFFER_DIR) as it:
             for entry in it:
-                st = entry.stat()
+                try:
+                    st = entry.stat()
+                except OSError as e:
+                    logger.debug(
+                        "Skipping unreadable buffer entry %s: %s", entry.name, e
+                    )
+                    continue
                 if stat.S_ISREG(st.st_mode) and entry.name.endswith(".json"):
                     scanned.append((st.st_mtime, Path(entry.path)))
     except OSError as e:

--- a/tests/test_langfuse_config.py
+++ b/tests/test_langfuse_config.py
@@ -127,3 +127,79 @@ class TestKillSwitchHelpers:
         monkeypatch.setenv("LANGFUSE_ENABLED", "false")
         monkeypatch.setenv("LANGFUSE_TRACE_HOOKS", "true")
         assert is_hook_tracing_enabled() is False
+
+
+class TestTracingEnvironmentValidation:
+    """G4 (BP-169): LANGFUSE_TRACING_ENVIRONMENT validation + wiring."""
+
+    def setup_method(self):
+        reset_langfuse_client()
+
+    def teardown_method(self):
+        reset_langfuse_client()
+
+    def test_validate_accepts_valid_values(self):
+        from memory.langfuse_config import validate_tracing_environment as v
+
+        assert v("testv2") == "testv2"
+        assert v("prod-install_1") == "prod-install_1"
+        assert v("a" * 40) == "a" * 40
+
+    def test_validate_rejects_invalid_values(self):
+        from memory.langfuse_config import validate_tracing_environment as v
+
+        assert v("langfuse-reserved") is None  # negative lookahead on "langfuse"
+        assert v("UPPER") is None
+        assert v("has space") is None
+        assert v("a" * 41) is None  # >40 chars
+        assert v("") is None
+        assert v(None) is None
+
+    def _enabled_env(self, monkeypatch):
+        monkeypatch.setenv("LANGFUSE_ENABLED", "true")
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-lf-test")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-lf-test")
+
+    def _mock_langfuse(self):
+        mock_span_filter = MagicMock()
+        mock_span_filter.is_default_export_span = MagicMock()
+        return patch.dict(
+            "sys.modules",
+            {
+                "langfuse": MagicMock(Langfuse=MagicMock(return_value=MagicMock())),
+                "langfuse.span_filter": mock_span_filter,
+            },
+        )
+
+    def test_invalid_environment_is_dropped(self, monkeypatch):
+        """An invalid LANGFUSE_TRACING_ENVIRONMENT is removed so the SDK ignores it."""
+        import os
+
+        self._enabled_env(monkeypatch)
+        monkeypatch.setenv("LANGFUSE_TRACING_ENVIRONMENT", "Invalid Env!")
+        with self._mock_langfuse():
+            reset_langfuse_client()
+            get_langfuse_client()
+        assert "LANGFUSE_TRACING_ENVIRONMENT" not in os.environ
+
+    def test_valid_environment_is_preserved(self, monkeypatch):
+        """A valid LANGFUSE_TRACING_ENVIRONMENT is left in env for the SDK to read."""
+        import os
+
+        self._enabled_env(monkeypatch)
+        monkeypatch.setenv("LANGFUSE_TRACING_ENVIRONMENT", "testv2")
+        with self._mock_langfuse():
+            reset_langfuse_client()
+            get_langfuse_client()
+        assert os.environ.get("LANGFUSE_TRACING_ENVIRONMENT") == "testv2"
+
+    def test_no_hardcoded_environment_when_unset(self, monkeypatch):
+        """When unset, the config does NOT inject any environment value."""
+        import os
+
+        self._enabled_env(monkeypatch)
+        monkeypatch.delenv("LANGFUSE_TRACING_ENVIRONMENT", raising=False)
+        with self._mock_langfuse():
+            reset_langfuse_client()
+            get_langfuse_client()
+        assert "LANGFUSE_TRACING_ENVIRONMENT" not in os.environ

--- a/tests/test_trace_flush_worker.py
+++ b/tests/test_trace_flush_worker.py
@@ -389,22 +389,63 @@ def test_process_buffer_files_flushes_before_unlink(tmp_path, monkeypatch):
     assert not path.exists()  # removed only after flush confirmed enqueue
 
 
-# --- R1(c): backend preflight -------------------------------------------------
+def test_process_buffer_files_retains_files_when_flush_raises(tmp_path, monkeypatch):
+    """F-5: if flush() raises (theoretical per BP-168), files are retained, not dropped."""
+    mod, buffer_dir = _load_module(tmp_path, monkeypatch)
+    path = _write_event(buffer_dir, "flush_raises")
+
+    mock_langfuse = MagicMock()
+    mock_langfuse.start_observation.return_value = MagicMock()
+    mock_langfuse.flush.side_effect = RuntimeError("flush blew up")
+
+    processed, _ = mod.process_buffer_files(mock_langfuse)
+
+    assert processed == 0
+    assert (
+        path.exists()
+    ), "File must be retained for retry when flush raises (loss-safe)"
 
 
-def test_backend_reachable_true(tmp_path, monkeypatch):
+# --- R1(c): backend preflight (HTTP /api/public/health probe) -----------------
+
+
+class _FakeHealthResp:
+    """Minimal context-manager stand-in for urllib's urlopen response."""
+
+    def __init__(self, status=200):
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_backend_reachable_true_on_200(tmp_path, monkeypatch):
     mod, _ = _load_module(tmp_path, monkeypatch)
-    monkeypatch.setattr(mod.socket, "create_connection", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(
+        mod.urllib.request, "urlopen", lambda *a, **k: _FakeHealthResp(200)
+    )
     assert mod._backend_reachable() is True
 
 
-def test_backend_reachable_false_on_oserror(tmp_path, monkeypatch):
+def test_backend_reachable_false_on_non_200(tmp_path, monkeypatch):
+    """A TCP-up-but-app-hung backend answers non-200 → treated as unreachable."""
+    mod, _ = _load_module(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        mod.urllib.request, "urlopen", lambda *a, **k: _FakeHealthResp(503)
+    )
+    assert mod._backend_reachable() is False
+
+
+def test_backend_reachable_false_on_urlerror(tmp_path, monkeypatch):
     mod, _ = _load_module(tmp_path, monkeypatch)
 
     def boom(*a, **k):
-        raise OSError("no route to host")
+        raise mod.urllib.error.URLError("connection refused")
 
-    monkeypatch.setattr(mod.socket, "create_connection", boom)
+    monkeypatch.setattr(mod.urllib.request, "urlopen", boom)
     assert mod._backend_reachable() is False
 
 
@@ -487,6 +528,127 @@ def test_watchdog_does_not_exit_when_progressing(tmp_path, monkeypatch):
     t.join(timeout=2)
 
     assert calls == [], "Watchdog must not exit while the loop is progressing"
+
+
+# --- F-1(a): watchdog-deadline configuration warning -------------------------
+
+
+def test_stall_deadline_warning_fires_on_large_batch_default_deadline(
+    tmp_path, monkeypatch
+):
+    mod, _ = _load_module(tmp_path, monkeypatch)
+    monkeypatch.delenv("LANGFUSE_STALL_DEADLINE_SECONDS", raising=False)
+    monkeypatch.setattr(mod, "FLUSH_BATCH_MAX", mod._DEFAULT_FLUSH_BATCH_MAX * 10)
+    assert mod._stall_deadline_warning() is not None
+
+
+def test_stall_deadline_no_warning_when_deadline_explicitly_set(tmp_path, monkeypatch):
+    mod, _ = _load_module(tmp_path, monkeypatch)
+    monkeypatch.setenv("LANGFUSE_STALL_DEADLINE_SECONDS", "3600")
+    monkeypatch.setattr(mod, "FLUSH_BATCH_MAX", mod._DEFAULT_FLUSH_BATCH_MAX * 10)
+    assert mod._stall_deadline_warning() is None
+
+
+def test_stall_deadline_no_warning_at_default_batch(tmp_path, monkeypatch):
+    mod, _ = _load_module(tmp_path, monkeypatch)
+    monkeypatch.delenv("LANGFUSE_STALL_DEADLINE_SECONDS", raising=False)
+    monkeypatch.setattr(mod, "FLUSH_BATCH_MAX", mod._DEFAULT_FLUSH_BATCH_MAX)
+    assert mod._stall_deadline_warning() is None
+
+
+# --- F-4: watchdog x slow-but-progressing bounded drain through real main() ---
+
+
+def test_bug315_watchdog_survives_slow_progressing_multibatch_drain(
+    tmp_path, monkeypatch
+):
+    """F-1 x F-4: a slow-but-progressing drain over MANY bounded batches, run through
+    the real main()/process_buffer_files path with the live watchdog, must NOT trip
+    the stall watchdog. The watchdog kills only a zero-progress wedge; each bounded
+    batch advances _last_loop_progress, so a deadline sized for one bounded batch is
+    independent of the total backlog size (scale-independence)."""
+    mod, buffer_dir = _load_module(tmp_path, monkeypatch)
+    monkeypatch.setattr(mod, "MAX_BUFFER_MB", 1000)
+    # Force a small batch so the backlog drains over MANY main() iterations (real
+    # process_buffer_files logic runs; only the per-pass cap is pinned for the test).
+    real_process = mod.process_buffer_files
+    monkeypatch.setattr(
+        mod, "process_buffer_files", lambda lf, limit=5: real_process(lf, limit)
+    )
+    # Deadline comfortably larger than one bounded-batch flush; the WHOLE drain takes
+    # longer, proving progress (not total time) is what the watchdog measures.
+    monkeypatch.setattr(mod, "STALL_DEADLINE_SECONDS", 2.0)
+    for i in range(40):
+        _write_agent_event(buffer_dir, f"evt{i}")
+
+    fake = MagicMock()
+    fake.start_observation.return_value = MagicMock()
+    # Slow-but-progressing: each bounded batch's flush blocks briefly, then returns.
+    fake.flush.side_effect = lambda: time.sleep(0.02)
+
+    monkeypatch.setattr(mod, "shutdown_requested", False)
+    monkeypatch.setattr(mod, "_langfuse_propagate_attributes", MagicMock())
+    monkeypatch.setattr(mod, "_backend_reachable", lambda: True)
+
+    exits = []
+    monkeypatch.setattr(mod.os, "_exit", lambda code: exits.append(code))
+
+    with patch.object(mod, "get_langfuse_client", return_value=fake):
+        t = threading.Thread(target=mod.main, daemon=True)
+        t.start()
+        try:
+            deadline = time.time() + 8
+            while time.time() < deadline and list(buffer_dir.glob("*.json")):
+                time.sleep(0.05)
+        finally:
+            mod.shutdown_requested = True
+            mod._watchdog_wakeup.set()
+            t.join(timeout=5)
+
+    assert list(buffer_dir.glob("*.json")) == [], "Backlog must fully drain"
+    assert exits == [], "Watchdog must not hard-exit a slow-but-progressing drain"
+
+
+# --- F-7: graceful shutdown drains multiple batches until empty (bounded) -----
+
+
+def test_shutdown_drains_multiple_batches_within_budget(tmp_path, monkeypatch):
+    """F-7: graceful shutdown drains MORE than one batch (until empty or time budget),
+    not just a single FLUSH_BATCH_MAX batch."""
+    mod, buffer_dir = _load_module(tmp_path, monkeypatch)
+    monkeypatch.setattr(mod, "MAX_BUFFER_MB", 1000)
+    real_process = mod.process_buffer_files
+    monkeypatch.setattr(
+        mod, "process_buffer_files", lambda lf, limit=5: real_process(lf, limit)
+    )
+    monkeypatch.setattr(mod, "SHUTDOWN_DRAIN_SECONDS", 5.0)
+    monkeypatch.setattr(mod, "_backend_reachable", lambda: True)
+    monkeypatch.setattr(mod, "_langfuse_propagate_attributes", MagicMock())
+    monkeypatch.setattr(mod, "shutdown_requested", False)
+
+    exits = []
+    monkeypatch.setattr(mod.os, "_exit", lambda code: exits.append(code))
+
+    for i in range(12):
+        _write_event(buffer_dir, f"sd{i}")
+
+    fake = MagicMock()
+    fake.start_observation.return_value = MagicMock()
+
+    # Stop the main loop on its first sleep; the shutdown drain then empties the rest.
+    def stop(_):
+        mod.shutdown_requested = True
+
+    with (
+        patch.object(mod, "get_langfuse_client", return_value=fake),
+        patch("time.sleep", side_effect=stop),
+    ):
+        mod.main()
+
+    assert (
+        list(buffer_dir.glob("*.json")) == []
+    ), "Shutdown must drain all batches within the time budget"
+    assert exits == []
 
 
 # --- G1/G2/G3: identity, role, agent-graph type (BP-169) ----------------------

--- a/tests/test_trace_flush_worker.py
+++ b/tests/test_trace_flush_worker.py
@@ -734,6 +734,94 @@ def test_sdk_path_identityless_event_uses_system_unknown(tmp_path, monkeypatch):
     assert captured["user_id"] == "system:unknown"
 
 
+# --- R1/R2: per-entry scandir resilience (fix-r2 LOW) -------------------------
+
+
+def test_process_buffer_files_skips_poison_scandir_entry(tmp_path, monkeypatch):
+    """A scandir entry whose stat() raises OSError is skipped; good files still drain.
+
+    Verifies the per-entry try/except in process_buffer_files: a single bad entry
+    must not abort the pass or discard already-collected entries (must not return (0,0)).
+    """
+    mod, buffer_dir = _load_module(tmp_path, monkeypatch)
+    _write_event(buffer_dir, "drain_ok1")
+    _write_event(buffer_dir, "drain_ok2")
+
+    poison = MagicMock()
+    poison.name = "poison.json"
+    poison.path = str(buffer_dir / "poison.json")
+    poison.stat.side_effect = OSError("simulated FS error")
+
+    real_scandir = os.scandir
+
+    class _InjectedScandir:
+        def __init__(self, path):
+            self._real = real_scandir(path)
+
+        def __enter__(self):
+            self._real.__enter__()
+            return self
+
+        def __exit__(self, *a):
+            return self._real.__exit__(*a)
+
+        def __iter__(self):
+            yield poison
+            yield from self._real
+
+    monkeypatch.setattr(mod.os, "scandir", _InjectedScandir)
+
+    mock_langfuse = MagicMock()
+    mock_langfuse.start_observation.return_value = MagicMock()
+
+    processed, errors = mod.process_buffer_files(mock_langfuse)
+
+    assert processed == 2, "Good files must drain despite poison entry"
+    assert errors == 0
+    assert not (buffer_dir / "drain_ok1.json").exists()
+    assert not (buffer_dir / "drain_ok2.json").exists()
+
+
+def test_evict_oldest_traces_skips_poison_scandir_entry(tmp_path, monkeypatch):
+    """A scandir entry whose stat() raises OSError is skipped; good files still evict.
+
+    Verifies the per-entry try/except in evict_oldest_traces: a single bad entry
+    must not abort the eviction scan or return 0 evictions.
+    """
+    mod, buffer_dir = _load_module(tmp_path, monkeypatch)
+    monkeypatch.setattr(mod, "MAX_BUFFER_MB", 0.000001)
+    _write_event(buffer_dir, "evict_ok1")
+    _write_event(buffer_dir, "evict_ok2")
+
+    poison = MagicMock()
+    poison.name = "poison.json"
+    poison.path = str(buffer_dir / "poison.json")
+    poison.stat.side_effect = OSError("simulated FS error")
+
+    real_scandir = os.scandir
+
+    class _InjectedScandir:
+        def __init__(self, path):
+            self._real = real_scandir(path)
+
+        def __enter__(self):
+            self._real.__enter__()
+            return self
+
+        def __exit__(self, *a):
+            return self._real.__exit__(*a)
+
+        def __iter__(self):
+            yield poison
+            yield from self._real
+
+    monkeypatch.setattr(mod.os, "scandir", _InjectedScandir)
+
+    evicted = mod.evict_oldest_traces()
+
+    assert evicted >= 1, "Good files must evict despite poison entry"
+
+
 def test_otel_path_emits_agent_identity_role_and_type(tmp_path, monkeypatch):
     mod, _ = _load_module(tmp_path, monkeypatch)
     monkeypatch.setattr(mod, "OTEL_AVAILABLE", True)

--- a/tests/test_trace_flush_worker.py
+++ b/tests/test_trace_flush_worker.py
@@ -11,6 +11,40 @@ import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _join_leaked_flush_watchdog():
+    """Stop any flush-watchdog daemon a test started, before it can leak.
+
+    Several tests run main() (directly or in a thread), which starts the
+    flush-watchdog daemon. If a test ends before that daemon observes
+    shutdown_requested, monkeypatch reverts the flag to False and the orphaned
+    daemon keeps looping until its stall deadline, then calls os._exit(1) —
+    hard-killing a later, unrelated test (the CI-3.10 crash after test_bug314).
+
+    This teardown force-signals shutdown and joins every flush-watchdog thread,
+    independent of the test's own monkeypatch finalizer ordering, then asserts
+    none survived (loud per-test attribution if a leak is ever reintroduced).
+    """
+    yield
+    mod = sys.modules.get("memory.trace_flush_worker")
+    if mod is not None:
+        mod.shutdown_requested = True
+        with contextlib.suppress(Exception):
+            mod._watchdog_wakeup.set()
+    deadline = time.monotonic() + 10
+    for thread in threading.enumerate():
+        if thread.name == "flush-watchdog" and thread.is_alive():
+            thread.join(timeout=max(0.0, deadline - time.monotonic()))
+    leaked = [
+        thread.name
+        for thread in threading.enumerate()
+        if thread.name == "flush-watchdog" and thread.is_alive()
+    ]
+    assert not leaked, f"flush-watchdog daemon leaked past the test: {leaked}"
+
 
 def _load_module(tmp_path, monkeypatch):
     """Import trace_flush_worker with BUFFER_DIR patched to tmp_path.

--- a/tests/test_trace_flush_worker.py
+++ b/tests/test_trace_flush_worker.py
@@ -1,10 +1,12 @@
-"""Unit tests for memory.trace_flush_worker — SPEC-020 §9.1 (9 test cases)."""
+"""Unit tests for memory.trace_flush_worker — SPEC-020 §9.1 + BUG-315 / BP-169 (P4 L1)."""
 
+import contextlib
 import hashlib
 import json
 import os
 import signal
 import sys
+import threading
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -163,6 +165,8 @@ def test_pushes_prometheus_metrics(tmp_path, monkeypatch):
 
     mock_push = MagicMock()
     monkeypatch.setattr(mod, "push_metrics_fn", mock_push)
+    # Backend reachable so the drain path runs (preflight gate, BUG-315).
+    monkeypatch.setattr(mod, "_backend_reachable", lambda: True)
 
     # Stop main loop after one iteration
     def stop_after_one(_):
@@ -268,3 +272,338 @@ def test_buffer_size_metric_reflects_post_eviction_size(tmp_path, monkeypatch):
 
     size_after = sum(f.stat().st_size for f in buffer_dir.glob("*.json"))
     assert size_after < size_before
+
+
+# ===========================================================================
+# BUG-315 (PLAN-028 P4 L1) — wedge fix: bounded batch, heartbeat decoupling,
+# backend preflight, stall watchdog, loss-safe drain.
+# ===========================================================================
+
+
+def _write_agent_event(buffer_dir: Path, name: str, **data_extra) -> Path:
+    """Write a buffer event whose data.metadata carries agent identity/role."""
+    hex_id = hashlib.md5(name.encode()).hexdigest()
+    data = {
+        "start_time": "2026-02-23T10:00:00+00:00",
+        "end_time": "2026-02-23T10:00:01+00:00",
+        "input": "i",
+        "output": "o",
+        "metadata": {"agent_name": "dev-w1", "agent_role": "worker"},
+    }
+    data.update(data_extra)
+    event = {
+        "event_type": "1_capture",
+        "trace_id": hex_id,
+        "span_id": hex_id[:16],
+        "parent_span_id": None,
+        "session_id": "sess001",
+        "project_id": "test-project",
+        "data": data,
+    }
+    path = buffer_dir / f"{name}.json"
+    path.write_text(json.dumps(event))
+    return path
+
+
+# --- R1(b): heartbeat decoupled from a blocking flush (the BUG-315 regression) --
+
+
+def test_bug315_heartbeat_refreshed_despite_blocking_flush(tmp_path, monkeypatch):
+    """Realistic-size repro: heartbeat must refresh even while flush() blocks.
+
+    Pre-fix the heartbeat was touched AFTER the flush, so a flush that blocked on
+    an unreachable backend left the heartbeat stale and wedged the loop. The fix
+    touches the heartbeat at the top of the loop (decoupled from flush).
+    """
+    mod, buffer_dir = _load_module(tmp_path, monkeypatch)
+    monkeypatch.setattr(mod, "MAX_BUFFER_MB", 1000)
+    # Realistic backlog (not a 3-file synthetic).
+    for i in range(600):
+        _write_agent_event(buffer_dir, f"evt{i}")
+
+    blocked = threading.Event()
+    fake = MagicMock()
+    fake.start_observation.return_value = MagicMock()
+    # Models flush() blocking on an unreachable backend (never throws).
+    fake.flush.side_effect = lambda: blocked.wait(timeout=30)
+
+    monkeypatch.setattr(mod, "shutdown_requested", False)
+    monkeypatch.setattr(mod, "_langfuse_propagate_attributes", MagicMock())
+    monkeypatch.setattr(mod, "_backend_reachable", lambda: True)
+
+    hb = mod.HEARTBEAT_FILE
+    with patch.object(mod, "get_langfuse_client", return_value=fake):
+        t = threading.Thread(target=mod.main, daemon=True)
+        t.start()
+        try:
+            # Heartbeat must appear quickly even though flush is blocking.
+            deadline = time.time() + 5
+            while not hb.exists() and time.time() < deadline:
+                time.sleep(0.05)
+            assert hb.exists(), "Heartbeat must refresh while flush blocks (decoupled)"
+        finally:
+            mod.shutdown_requested = True
+            blocked.set()
+            t.join(timeout=5)
+
+
+# --- R1(a): bounded batch per pass --------------------------------------------
+
+
+def test_process_buffer_files_bounded_batch(tmp_path, monkeypatch):
+    mod, buffer_dir = _load_module(tmp_path, monkeypatch)
+    for i in range(5):
+        _write_event(buffer_dir, f"b{i}")
+
+    mock_langfuse = MagicMock()
+    mock_langfuse.start_observation.return_value = MagicMock()
+
+    processed, errors = mod.process_buffer_files(mock_langfuse, limit=2)
+
+    assert processed == 2
+    assert errors == 0
+    assert len(list(buffer_dir.glob("*.json"))) == 3  # remainder left for next pass
+
+
+# --- R1(e): loss-safe drain — flush before unlink -----------------------------
+
+
+def test_process_buffer_files_flushes_before_unlink(tmp_path, monkeypatch):
+    mod, buffer_dir = _load_module(tmp_path, monkeypatch)
+    path = _write_event(buffer_dir, "lossafe")
+
+    seen = {}
+    mock_langfuse = MagicMock()
+    mock_langfuse.start_observation.return_value = MagicMock()
+
+    def flush_side_effect():
+        seen["file_exists_at_flush"] = path.exists()
+
+    mock_langfuse.flush.side_effect = flush_side_effect
+
+    processed, _ = mod.process_buffer_files(mock_langfuse)
+
+    assert processed == 1
+    mock_langfuse.flush.assert_called_once()
+    assert seen["file_exists_at_flush"] is True  # not yet unlinked when flush ran
+    assert not path.exists()  # removed only after flush confirmed enqueue
+
+
+# --- R1(c): backend preflight -------------------------------------------------
+
+
+def test_backend_reachable_true(tmp_path, monkeypatch):
+    mod, _ = _load_module(tmp_path, monkeypatch)
+    monkeypatch.setattr(mod.socket, "create_connection", lambda *a, **k: MagicMock())
+    assert mod._backend_reachable() is True
+
+
+def test_backend_reachable_false_on_oserror(tmp_path, monkeypatch):
+    mod, _ = _load_module(tmp_path, monkeypatch)
+
+    def boom(*a, **k):
+        raise OSError("no route to host")
+
+    monkeypatch.setattr(mod.socket, "create_connection", boom)
+    assert mod._backend_reachable() is False
+
+
+def test_backend_reachable_false_on_empty_url(tmp_path, monkeypatch):
+    mod, _ = _load_module(tmp_path, monkeypatch)
+    monkeypatch.setattr(mod, "LANGFUSE_BASE_URL", "")
+    assert mod._backend_reachable() is False
+
+
+def test_preflight_skips_drain_when_unreachable(tmp_path, monkeypatch):
+    mod, buffer_dir = _load_module(tmp_path, monkeypatch)
+    _write_event(buffer_dir, "pf1")
+
+    monkeypatch.setattr(mod, "_backend_reachable", lambda: False)
+    monkeypatch.setattr(mod, "shutdown_requested", False)
+
+    called = []
+
+    def fake_process(*a, **k):
+        called.append(1)
+        return (0, 0)
+
+    monkeypatch.setattr(mod, "process_buffer_files", fake_process)
+
+    def stop(_):
+        mod.shutdown_requested = True
+
+    with (
+        patch.object(mod, "get_langfuse_client", return_value=MagicMock()),
+        patch("time.sleep", side_effect=stop),
+    ):
+        mod.main()
+
+    assert called == [], "Drain must be skipped when backend is unreachable"
+    assert mod.HEARTBEAT_FILE.exists(), "Heartbeat must still refresh during outage"
+
+
+# --- R1(d): stall watchdog ----------------------------------------------------
+
+
+def test_is_stalled(tmp_path, monkeypatch):
+    mod, _ = _load_module(tmp_path, monkeypatch)
+    now = 10_000.0
+    assert mod._is_stalled(now - mod.STALL_DEADLINE_SECONDS - 1, now) is True
+    assert mod._is_stalled(now - 1, now) is False
+
+
+def test_watchdog_exits_when_stalled(tmp_path, monkeypatch):
+    mod, _ = _load_module(tmp_path, monkeypatch)
+    monkeypatch.setattr(mod, "shutdown_requested", False)
+    mod._last_loop_progress = time.monotonic() - (mod.STALL_DEADLINE_SECONDS + 5)
+
+    calls = []
+
+    def fake_exit(code):
+        calls.append(code)
+        mod.shutdown_requested = True  # break the watchdog loop
+        mod._watchdog_wakeup.set()
+
+    monkeypatch.setattr(mod.os, "_exit", fake_exit)
+    mod._watchdog_loop()
+
+    assert calls == [1], "Watchdog must hard-exit(1) on a wedged loop"
+
+
+def test_watchdog_does_not_exit_when_progressing(tmp_path, monkeypatch):
+    mod, _ = _load_module(tmp_path, monkeypatch)
+    monkeypatch.setattr(mod, "shutdown_requested", False)
+    mod._last_loop_progress = time.monotonic()  # fresh progress
+
+    calls = []
+    monkeypatch.setattr(mod.os, "_exit", lambda code: calls.append(code))
+
+    # Run the watchdog briefly then stop it.
+    t = threading.Thread(target=mod._watchdog_loop, daemon=True)
+    t.start()
+    time.sleep(0.2)
+    mod.shutdown_requested = True
+    mod._watchdog_wakeup.set()
+    t.join(timeout=2)
+
+    assert calls == [], "Watchdog must not exit while the loop is progressing"
+
+
+# --- G1/G2/G3: identity, role, agent-graph type (BP-169) ----------------------
+
+
+def test_resolve_user_id_and_role():
+    from memory.trace_flush_worker import _resolve_role_tag, _resolve_user_id
+
+    assert _resolve_user_id({"agent_name": "parzival"}) == "agent:parzival"
+    assert _resolve_user_id({}) == "system:unknown"
+    assert _resolve_role_tag({"agent_role": "worker"}) == "role:worker"
+    assert _resolve_role_tag({}) is None
+
+
+def test_sdk_path_emits_agent_identity_role_and_type(tmp_path, monkeypatch):
+    mod, _ = _load_module(tmp_path, monkeypatch)  # OTEL_AVAILABLE False
+
+    captured = {}
+
+    def fake_propagate(**kw):
+        captured.update(kw)
+        return contextlib.nullcontext()
+
+    monkeypatch.setattr(mod, "_langfuse_propagate_attributes", fake_propagate)
+
+    mock_langfuse = MagicMock()
+    mock_langfuse.start_observation.return_value = MagicMock()
+
+    event = {
+        "event_type": "orchestrate",
+        "trace_id": "a" * 32,
+        "parent_span_id": None,
+        "session_id": "s",
+        "project_id": "p",
+        "as_type": "agent",
+        "tags": ["pipeline"],
+    }
+    data = {
+        "start_time": "2026-02-23T10:00:00+00:00",
+        "end_time": "2026-02-23T10:00:01+00:00",
+        "metadata": {"agent_name": "dev-w1", "agent_role": "worker"},
+    }
+
+    mod._process_event_sdk(event, data, mock_langfuse)
+
+    # G1: identity
+    assert captured["user_id"] == "agent:dev-w1"
+    # G2: role in propagated metadata + tag
+    assert captured["metadata"]["agent_role"] == "worker"
+    assert "role:worker" in captured["tags"]
+    assert "pipeline" in captured["tags"]
+    # G3: agent type passed through (not collapsed to span)
+    assert mock_langfuse.start_observation.call_args.kwargs["as_type"] == "agent"
+
+
+def test_sdk_path_identityless_event_uses_system_unknown(tmp_path, monkeypatch):
+    mod, _ = _load_module(tmp_path, monkeypatch)
+
+    captured = {}
+
+    def fake_propagate(**kw):
+        captured.update(kw)
+        return contextlib.nullcontext()
+
+    monkeypatch.setattr(mod, "_langfuse_propagate_attributes", fake_propagate)
+    mock_langfuse = MagicMock()
+    mock_langfuse.start_observation.return_value = MagicMock()
+
+    event = {
+        "event_type": "1_capture",
+        "trace_id": "b" * 32,
+        "parent_span_id": None,
+        "session_id": "s",
+        "project_id": "p",
+    }
+    data = {
+        "start_time": "2026-02-23T10:00:00+00:00",
+        "end_time": "2026-02-23T10:00:01+00:00",
+        "metadata": {},
+    }
+
+    mod._process_event_sdk(event, data, mock_langfuse)
+    assert captured["user_id"] == "system:unknown"
+
+
+def test_otel_path_emits_agent_identity_role_and_type(tmp_path, monkeypatch):
+    mod, _ = _load_module(tmp_path, monkeypatch)
+    monkeypatch.setattr(mod, "OTEL_AVAILABLE", True)
+
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+    monkeypatch.setattr(mod.otel_trace_api, "get_tracer", lambda name: fake_tracer)
+    monkeypatch.setattr(mod, "_make_parent_context", lambda *a, **k: None)
+
+    event = {
+        "event_type": "1_capture",
+        "trace_id": "a" * 32,
+        "parent_span_id": None,
+        "session_id": "s",
+        "project_id": "p",
+        "as_type": "agent",
+        "tags": ["pipeline"],
+    }
+    data = {
+        "start_time": "2026-02-23T10:00:00+00:00",
+        "end_time": "2026-02-23T10:00:01+00:00",
+        "metadata": {"agent_name": "dev-w1", "agent_role": "worker"},
+    }
+
+    mod._process_event_otel(event, data)
+
+    attrs = {c.args[0]: c.args[1] for c in fake_span.set_attribute.call_args_list}
+    # G1: identity from buffer, not hardcoded "system"
+    assert attrs["user.id"] == "agent:dev-w1"
+    # G3: agent observation type triggers the graph view
+    assert attrs["langfuse.observation.type"] == "agent"
+    # G2: role tag + trace metadata
+    assert "role:worker" in attrs["langfuse.trace.tags"]
+    assert json.loads(attrs["langfuse.trace.metadata"])["agent_role"] == "worker"

--- a/tests/unit/test_trace_flush_degraded.py
+++ b/tests/unit/test_trace_flush_degraded.py
@@ -114,6 +114,7 @@ class TestDegradedMode:
                 return_value=mock_client,
             ),
             patch("memory.trace_flush_worker.evict_oldest_traces", return_value=0),
+            patch("memory.trace_flush_worker._backend_reachable", return_value=True),
             patch(
                 "memory.trace_flush_worker.process_buffer_files", return_value=(0, 0)
             ) as mock_process,

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "ai-memory"
-version = "2.4.3"
+version = "2.4.5"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -81,8 +81,8 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.0.0,<7.0.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.13.0,<9.0.0" },
-    { name = "langfuse", marker = "extra == 'dev'", specifier = ">=4.0.6,<4.1.0" },
-    { name = "langfuse", marker = "extra == 'observability'", specifier = ">=4.0.6,<4.1.0" },
+    { name = "langfuse", marker = "extra == 'dev'", specifier = ">=4.7.0,<4.8.0" },
+    { name = "langfuse", marker = "extra == 'observability'", specifier = ">=4.7.0,<4.8.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.20.0,<2.0.0" },
     { name = "numpy", specifier = ">=1.26.0,<3.0.0" },
     { name = "opentelemetry-instrumentation-anthropic", specifier = ">=0.1,<1.0.0" },
@@ -1216,7 +1216,7 @@ wheels = [
 
 [[package]]
 name = "langfuse"
-version = "4.0.6"
+version = "4.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
@@ -1228,9 +1228,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/d0/6d79ed5614f86f27f5df199cf10c6facf6874ff6f91b828ae4dad90aa86d/langfuse-4.0.6.tar.gz", hash = "sha256:83a6f8cc8f1431fa2958c91e2673bc4179f993297e9b1acd1dbf001785e6cf83", size = 274094, upload-time = "2026-04-01T20:04:15.153Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/74/a6f1a99893ee6d1a69439ae7eb92f8fe8806103492dc26531d5942dbd3bf/langfuse-4.7.1.tar.gz", hash = "sha256:f9e262eceedb353b191c1da1f8452d1e8ebf52297ca20e160cda0206608e3a40", size = 320620, upload-time = "2026-05-29T18:06:22.435Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/b4/088048e37b6d7ec1b52c6a11bc33101454285a22eaab8303dcccfd78344d/langfuse-4.0.6-py3-none-any.whl", hash = "sha256:0562b1dcf83247f9d8349f0f755eaed9a7f952fee67e66580970f0738bf3adbf", size = 472841, upload-time = "2026-04-01T20:04:16.451Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/9a/bd3368f46b6c72ee2068b80536826b02ae86df53eff1c79941344503098f/langfuse-4.7.1-py3-none-any.whl", hash = "sha256:a4e59c81ad5e5b16a65d3849f4923ebc3ad6e67ec803ada83d50c0cb66149490", size = 562571, upload-time = "2026-05-29T18:06:20.517Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Hardens the Langfuse trace-flush worker against the stall that left a multi-thousand-trace backlog undelivered for ~32h (BUG-315), brings the trace-emit path to the multi-agent trace-organization standard, and bumps the Langfuse SDK pin to 4.7.x with a V3→V4 governance-comment sweep.

## Trace-flush worker (BUG-315)
The worker could wedge indefinitely: an unbounded per-iteration drain plus a heartbeat touched only after a blocking `flush()` meant a slow or unreachable backend stalled the loop for hours while the file-based healthcheck stayed green.

- Bounded per-iteration batch (`LANGFUSE_FLUSH_AT`, default 500); oldest-first drain via a single `os.scandir` pass aligned with buffer eviction.
- Heartbeat moved to the top of the loop, so liveness reflects the loop cycling rather than a long/blocking flush completing.
- HTTP readiness preflight (`GET /api/public/health`) — the flush is skipped when the backend is unreachable or app-level hung, instead of blocking inside a doomed retry.
- Stall watchdog that self-exits (`os._exit`) so Docker restarts a genuinely wedged worker (an "unhealthy" healthcheck alone does not). Startup warning when the batch size is raised without raising the stall deadline.
- Loss-safe drain: buffer files are unlinked only after `flush()` confirms the batch is enqueued (at-least-once); a per-entry `scandir`/`stat` error skips that file instead of aborting the whole pass.
- Bounded best-effort drain on shutdown (`LANGFUSE_SHUTDOWN_DRAIN_SECONDS`, default 5s).

## Agent trace organization
- `user_id` carries agent identity (`agent:<name>` / `system:<service>`) read from the buffered event, instead of a hardcoded `system`.
- Agent role propagated as trace metadata plus a `role:<role>` tag.
- `agent`/`tool`/`chain` observation types passed through so the agent-graph view renders.
- `LANGFUSE_TRACING_ENVIRONMENT` validated (env-driven; malformed values dropped so the SDK does not silently ignore them).

## SDK version
- `langfuse` pinned to `>=4.7.0,<4.8.0` across all four pin sites (reconciles a previously divergent floor). 4.7.0 carries the EventSerializer depth-limit fix relevant to BUG-315. Supersedes Dependabot #129.
- V3→V4 governance header/comment sweep across hook, worker, and script files; `TRACE_CONTENT_MAX` applied at the genuine `emit_trace_event` call sites.

## Testing
- Local gates green: black, ruff, isort, and the trace-flush/langfuse-config module test suites.
- Pending before merge: runtime live-test under langfuse 4.7.x (worker backlog drain + self-restart on a simulated wedge), and a lockfile refresh to 4.7.x.
