### PR TITLE
feat(constraints): externalize aim-parzival-constraints to scripts/constraints.py (TASK-071 Item 7)

### DIFF
--- a/_ai-memory/pov/skills/aim-parzival-constraints/SKILL.md
+++ b/_ai-memory/pov/skills/aim-parzival-constraints/SKILL.md
@@ -10,87 +10,15 @@ Load Parzival's behavioral constraints from `_ai-memory/pov/constraints/`. Used 
 
 ## Steps
 
-1. Run the following Python script to load constraints:
+1. Run the constraints script via `run-with-env.sh`:
 
-```python
-import sys
-import os
-import time
-
-# Set up import path for ai-memory source
-_install_dir = os.path.expanduser("~/.ai-memory")
-sys.path.insert(0, os.path.join(_install_dir, "src"))
-
-start_ms = time.perf_counter()
-
-try:
-    from memory.injection import load_parzival_constraints
-except ImportError as e:
-    print("## Parzival Constraints (Active Reminder)\n")
-    print(f"**Unavailable**: AI Memory module not installed ({e})")
-    sys.exit(0)
-
-# Optional: Prometheus metrics (best-effort)
-try:
-    from memory.metrics_push import push_skill_metrics_async
-except ImportError:
-    push_skill_metrics_async = None
-
-# Optional: Langfuse trace events (best-effort, never blocks)
-# LANGFUSE: V3 ONLY. See LANGFUSE-INTEGRATION-SPEC.md
-try:
-    from memory.trace_buffer import emit_trace_event
-except ImportError:
-    emit_trace_event = None
-
-project_root = os.getcwd()
-
-# Check for --phase argument
-phase = None
-for i, arg in enumerate(sys.argv):
-    if arg == "--phase" and i + 1 < len(sys.argv):
-        phase = sys.argv[i + 1]
-
-# Load constraints
-constraints = load_parzival_constraints(project_root, phase=phase)
-elapsed_ms = int((time.perf_counter() - start_ms) * 1000)
-
-print("## Parzival Constraints (Active Reminder)\n")
-
-if not constraints:
-    print("No constraint files found at `_ai-memory/pov/constraints/`.\n")
-    print("Ensure Parzival v2 is installed with constraint files.")
-    print(f"\n---\nConstraints: 0 loaded | {elapsed_ms}ms")
-    if push_skill_metrics_async:
-        try:
-            push_skill_metrics_async("aim-parzival-constraints", "empty", time.perf_counter() - start_ms)
-        except Exception:
-            pass
-else:
-    print(constraints)
-    if push_skill_metrics_async:
-        try:
-            push_skill_metrics_async("aim-parzival-constraints", "success", time.perf_counter() - start_ms)
-        except Exception:
-            pass
-
-# Skill tracing (PLAN-014 G-06)
-# LANGFUSE: V3 trace buffer pattern. See LANGFUSE-INTEGRATION-SPEC.md §3.1
-if emit_trace_event:
-    try:
-        emit_trace_event(
-            event_type="skill_execution",
-            data={
-                "input": f"Skill: aim-parzival-constraints"[:10000],
-                "output": f"Result: completed"[:10000],
-                "metadata": {"skill_name": "aim-parzival-constraints"},
-            },
-            session_id=os.environ.get("CLAUDE_SESSION_ID", "unknown"),
-            tags=["skill"],
-        )
-    except Exception:
-        pass  # Tracing failures never break skill execution
+```bash
+"${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh" \
+  "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/pov/skills/aim-parzival-constraints/scripts/constraints.py" \
+  --phase <phase>
 ```
+
+Note: `--phase <phase>` is optional — omit if no phase context is available.
 
 2. Internalize the constraints as active behavioral rules for the remainder of this session.
 

--- a/_ai-memory/pov/skills/aim-parzival-constraints/SKILL.md
+++ b/_ai-memory/pov/skills/aim-parzival-constraints/SKILL.md
@@ -14,7 +14,7 @@ Load Parzival's behavioral constraints from `_ai-memory/pov/constraints/`. Used 
 
 ```bash
 "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh" \
-  "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/pov/skills/aim-parzival-constraints/scripts/constraints.py" \
+  "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/_ai-memory/pov/skills/aim-parzival-constraints/scripts/constraints.py" \
   --phase <phase>
 ```
 

--- a/_ai-memory/pov/skills/aim-parzival-constraints/scripts/constraints.py
+++ b/_ai-memory/pov/skills/aim-parzival-constraints/scripts/constraints.py
@@ -1,0 +1,77 @@
+import sys
+import os
+import time
+
+# Set up import path for ai-memory source
+_install_dir = os.path.expanduser("~/.ai-memory")
+sys.path.insert(0, os.path.join(_install_dir, "src"))
+
+start_ms = time.perf_counter()
+
+try:
+    from memory.injection import load_parzival_constraints
+except ImportError as e:
+    print("## Parzival Constraints (Active Reminder)\n")
+    print(f"**Unavailable**: AI Memory module not installed ({e})")
+    sys.exit(0)
+
+# Optional: Prometheus metrics (best-effort)
+try:
+    from memory.metrics_push import push_skill_metrics_async
+except ImportError:
+    push_skill_metrics_async = None
+
+# Optional: Langfuse trace events (best-effort, never blocks)
+# LANGFUSE: V3 ONLY. See LANGFUSE-INTEGRATION-SPEC.md
+try:
+    from memory.trace_buffer import emit_trace_event
+except ImportError:
+    emit_trace_event = None
+
+project_root = os.getcwd()
+
+# Check for --phase argument
+phase = None
+for i, arg in enumerate(sys.argv):
+    if arg == "--phase" and i + 1 < len(sys.argv):
+        phase = sys.argv[i + 1]
+
+# Load constraints
+constraints = load_parzival_constraints(project_root, phase=phase)
+elapsed_ms = int((time.perf_counter() - start_ms) * 1000)
+
+print("## Parzival Constraints (Active Reminder)\n")
+
+if not constraints:
+    print("No constraint files found at `_ai-memory/pov/constraints/`.\n")
+    print("Ensure Parzival v2 is installed with constraint files.")
+    print(f"\n---\nConstraints: 0 loaded | {elapsed_ms}ms")
+    if push_skill_metrics_async:
+        try:
+            push_skill_metrics_async("aim-parzival-constraints", "empty", time.perf_counter() - start_ms)
+        except Exception:
+            pass
+else:
+    print(constraints)
+    if push_skill_metrics_async:
+        try:
+            push_skill_metrics_async("aim-parzival-constraints", "success", time.perf_counter() - start_ms)
+        except Exception:
+            pass
+
+# Skill tracing (PLAN-014 G-06)
+# LANGFUSE: V3 trace buffer pattern. See LANGFUSE-INTEGRATION-SPEC.md §3.1
+if emit_trace_event:
+    try:
+        emit_trace_event(
+            event_type="skill_execution",
+            data={
+                "input": f"Skill: aim-parzival-constraints"[:10000],
+                "output": f"Result: completed"[:10000],
+                "metadata": {"skill_name": "aim-parzival-constraints"},
+            },
+            session_id=os.environ.get("CLAUDE_SESSION_ID", "unknown"),
+            tags=["skill"],
+        )
+    except Exception:
+        pass  # Tracing failures never break skill execution

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -32,7 +32,7 @@ def _record(name, args, kwargs):
         data = json.loads(p.read_text())
     except Exception:
         data = {}
-    data[name] = {"args": list(args), "kwargs": kwargs}
+    data.setdefault(name, []).append({"args": list(args), "kwargs": kwargs})
     p.write_text(json.dumps(data))
 
 
@@ -53,7 +53,7 @@ def push_skill_metrics_async(*args, **kwargs):
         data = json.loads(p.read_text())
     except Exception:
         data = {}
-    data["push"] = {"args": list(args), "kwargs": kwargs}
+    data.setdefault("push", []).append({"args": list(args), "kwargs": kwargs})
     p.write_text(json.dumps(data))
 """
 
@@ -69,7 +69,7 @@ def emit_trace_event(*args, **kwargs):
         data = json.loads(p.read_text())
     except Exception:
         data = {}
-    data["emit"] = {"args": list(args), "kwargs": kwargs}
+    data.setdefault("emit", []).append({"args": list(args), "kwargs": kwargs})
     p.write_text(json.dumps(data))
 """
 
@@ -124,8 +124,9 @@ class TestKnownPhase:
             load_return="## Constraint A\n## Constraint B",
         )
         assert result.returncode == 0
-        assert calls["load"]["kwargs"]["phase"] == "init"
-        assert isinstance(calls["load"]["args"][0], str)
+        assert len(calls["load"]) == 1
+        assert calls["load"][0]["kwargs"]["phase"] == "init"
+        assert isinstance(calls["load"][0]["args"][0], str)
 
     def test_known_phase_output_printed(self, tmp_path):
         result, _ = _run_constraints(
@@ -144,7 +145,8 @@ class TestNoPhase:
     def test_no_phase_passes_none_to_load(self, tmp_path):
         result, calls = _run_constraints(tmp_path, args=[], load_return="")
         assert result.returncode == 0
-        assert calls["load"]["kwargs"]["phase"] is None
+        assert len(calls["load"]) == 1
+        assert calls["load"][0]["kwargs"]["phase"] is None
 
     def test_empty_constraints_prints_not_found(self, tmp_path):
         result, _ = _run_constraints(tmp_path, args=[], load_return="")
@@ -154,8 +156,11 @@ class TestNoPhase:
     def test_empty_constraints_metric_label_empty(self, tmp_path):
         result, calls = _run_constraints(tmp_path, args=[], load_return="")
         assert result.returncode == 0
-        assert calls["push"]["args"][:2] == ["aim-parzival-constraints", "empty"]
+        assert len(calls["push"]) == 1
+        assert calls["push"][0]["args"][:2] == ["aim-parzival-constraints", "empty"]
+        assert len(calls["push"][0]["args"]) == 3
         assert "emit" in calls
+        assert len(calls["emit"]) == 1
 
 
 class TestTelemetryShim:
@@ -166,14 +171,17 @@ class TestTelemetryShim:
             tmp_path, args=[], load_return="## Some constraint"
         )
         assert result.returncode == 0
-        assert calls["push"]["args"][:2] == ["aim-parzival-constraints", "success"]
+        assert len(calls["push"]) == 1
+        assert calls["push"][0]["args"][:2] == ["aim-parzival-constraints", "success"]
+        assert len(calls["push"][0]["args"]) == 3
 
     def test_emit_trace_event_kwargs(self, tmp_path):
         result, calls = _run_constraints(
             tmp_path, args=[], load_return="## Some constraint"
         )
         assert result.returncode == 0
-        emit_kw = calls["emit"]["kwargs"]
+        assert len(calls["emit"]) == 1
+        emit_kw = calls["emit"][0]["kwargs"]
         assert emit_kw["event_type"] == "skill_execution"
         assert emit_kw["data"] == {
             "input": "Skill: aim-parzival-constraints"[:10000],
@@ -191,4 +199,5 @@ class TestImportError:
         result, calls = _run_constraints(tmp_path, args=[], import_fail=True)
         assert result.returncode == 0
         assert "**Unavailable**" in result.stdout
+        assert "Traceback" not in result.stderr
         assert calls == {}

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,0 +1,129 @@
+"""Tests for aim-parzival-constraints/scripts/constraints.py.
+
+Script loaded via importlib.util.spec_from_file_location, fresh per test.
+memory.* modules mocked via monkeypatch.setitem(sys.modules) — no real package needed.
+AI_MEMORY_PROJECT_ID unset; plugin-free.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import ANY, MagicMock
+
+SCRIPT_PATH = (
+    Path(__file__).parent.parent
+    / "_ai-memory/pov/skills/aim-parzival-constraints/scripts/constraints.py"
+)
+
+
+def _exec_constraints(monkeypatch, argv, load_return_value):
+    """Exec constraints.py with controlled argv and mocked memory.* modules.
+
+    Returns (mock_load, mock_push, mock_emit).
+    """
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.delenv("AI_MEMORY_PROJECT_ID", raising=False)
+
+    mock_load = MagicMock(return_value=load_return_value)
+    mock_push = MagicMock()
+    mock_emit = MagicMock()
+
+    mem_injection = MagicMock()
+    mem_injection.load_parzival_constraints = mock_load
+
+    mem_metrics = MagicMock()
+    mem_metrics.push_skill_metrics_async = mock_push
+
+    mem_trace = MagicMock()
+    mem_trace.emit_trace_event = mock_emit
+
+    monkeypatch.setitem(sys.modules, "memory", MagicMock())
+    monkeypatch.setitem(sys.modules, "memory.injection", mem_injection)
+    monkeypatch.setitem(sys.modules, "memory.metrics_push", mem_metrics)
+    monkeypatch.setitem(sys.modules, "memory.trace_buffer", mem_trace)
+
+    spec = importlib.util.spec_from_file_location("constraints", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    return mock_load, mock_push, mock_emit
+
+
+class TestKnownPhase:
+    """Case 1: --phase <value> → load called with that phase, stdout shows constraints."""
+
+    def test_known_phase_passed_to_load(self, monkeypatch, capsys):
+        mock_load, _, _ = _exec_constraints(
+            monkeypatch,
+            argv=["constraints.py", "--phase", "init"],
+            load_return_value="## Constraint A\n## Constraint B",
+        )
+        mock_load.assert_called_once_with(ANY, phase="init")
+
+    def test_known_phase_output_printed(self, monkeypatch, capsys):
+        _exec_constraints(
+            monkeypatch,
+            argv=["constraints.py", "--phase", "init"],
+            load_return_value="## Constraint A\n## Constraint B",
+        )
+        out = capsys.readouterr().out
+        assert "## Constraint A" in out
+        assert "## Constraint B" in out
+
+
+class TestNoPhase:
+    """Case 2: no --phase → phase=None, graceful handling of empty result."""
+
+    def test_no_phase_passes_none_to_load(self, monkeypatch, capsys):
+        mock_load, _, _ = _exec_constraints(
+            monkeypatch,
+            argv=["constraints.py"],
+            load_return_value="",
+        )
+        mock_load.assert_called_once_with(ANY, phase=None)
+
+    def test_empty_constraints_prints_not_found(self, monkeypatch, capsys):
+        _exec_constraints(
+            monkeypatch,
+            argv=["constraints.py"],
+            load_return_value="",
+        )
+        out = capsys.readouterr().out
+        assert "No constraint files found" in out
+
+    def test_empty_constraints_metric_label_empty(self, monkeypatch, capsys):
+        _, mock_push, _ = _exec_constraints(
+            monkeypatch,
+            argv=["constraints.py"],
+            load_return_value="",
+        )
+        mock_push.assert_called_once_with("aim-parzival-constraints", "empty", ANY)
+
+
+class TestTelemetryShim:
+    """Case 3: telemetry shim integration — callables invoked with exact args."""
+
+    def test_push_metrics_success_label(self, monkeypatch, capsys):
+        _, mock_push, _ = _exec_constraints(
+            monkeypatch,
+            argv=["constraints.py"],
+            load_return_value="## Some constraint",
+        )
+        mock_push.assert_called_once_with("aim-parzival-constraints", "success", ANY)
+
+    def test_emit_trace_event_kwargs(self, monkeypatch, capsys):
+        _, _, mock_emit = _exec_constraints(
+            monkeypatch,
+            argv=["constraints.py"],
+            load_return_value="## Some constraint",
+        )
+        mock_emit.assert_called_once_with(
+            event_type="skill_execution",
+            data={
+                "input": "Skill: aim-parzival-constraints"[:10000],
+                "output": "Result: completed"[:10000],
+                "metadata": {"skill_name": "aim-parzival-constraints"},
+            },
+            session_id=ANY,
+            tags=["skill"],
+        )

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,158 +1,194 @@
 """Tests for aim-parzival-constraints/scripts/constraints.py.
 
-Script loaded via importlib.util.spec_from_file_location, fresh per test.
-memory.* modules mocked via monkeypatch.setitem(sys.modules) — no real package needed.
-AI_MEMORY_PROJECT_ID unset; plugin-free.
+Script invoked via stdlib subprocess (BP-016 DOMAIN 2). A hermetic fake memory
+package is written to tmp_path/.ai-memory/src/ so the script's hardcoded
+sys.path.insert(0, ~/.ai-memory/src) resolves to our stubs. plugin-free;
+AI_MEMORY_PROJECT_ID unset.
 """
 
-import importlib.util
+import json
+import os
+import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import ANY, MagicMock
-
-import pytest
 
 SCRIPT_PATH = (
     Path(__file__).parent.parent
     / "_ai-memory/pov/skills/aim-parzival-constraints/scripts/constraints.py"
 )
 
+_INJECTION_STUB = """\
+import json
+import os
+import pathlib
 
-def _exec_constraints(monkeypatch, argv, load_return_value):
-    """Exec constraints.py with controlled argv and mocked memory.* modules.
+if os.environ.get("FAKE_INJECTION_FAIL", "0") == "1":
+    raise ImportError("test-induced failure")
 
-    Returns (mock_load, mock_push, mock_emit).
-    """
-    monkeypatch.setattr(sys, "argv", argv)
-    monkeypatch.delenv("AI_MEMORY_PROJECT_ID", raising=False)
 
-    mock_load = MagicMock(return_value=load_return_value)
-    mock_push = MagicMock()
-    mock_emit = MagicMock()
+def _record(name, args, kwargs):
+    p = pathlib.Path(os.getcwd()) / "calls.json"
+    try:
+        data = json.loads(p.read_text())
+    except Exception:
+        data = {}
+    data[name] = {"args": list(args), "kwargs": kwargs}
+    p.write_text(json.dumps(data))
 
-    mem_injection = MagicMock()
-    mem_injection.load_parzival_constraints = mock_load
 
-    mem_metrics = MagicMock()
-    mem_metrics.push_skill_metrics_async = mock_push
+def load_parzival_constraints(*args, **kwargs):
+    _record("load", args, kwargs)
+    return os.environ.get("FAKE_LOAD_RETURN", "")
+"""
 
-    mem_trace = MagicMock()
-    mem_trace.emit_trace_event = mock_emit
+_METRICS_STUB = """\
+import json
+import os
+import pathlib
 
-    monkeypatch.setitem(sys.modules, "memory", MagicMock())
-    monkeypatch.setitem(sys.modules, "memory.injection", mem_injection)
-    monkeypatch.setitem(sys.modules, "memory.metrics_push", mem_metrics)
-    monkeypatch.setitem(sys.modules, "memory.trace_buffer", mem_trace)
 
-    spec = importlib.util.spec_from_file_location("constraints", SCRIPT_PATH)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+def push_skill_metrics_async(*args, **kwargs):
+    p = pathlib.Path(os.getcwd()) / "calls.json"
+    try:
+        data = json.loads(p.read_text())
+    except Exception:
+        data = {}
+    data["push"] = {"args": list(args), "kwargs": kwargs}
+    p.write_text(json.dumps(data))
+"""
 
-    return mock_load, mock_push, mock_emit
+_TRACE_STUB = """\
+import json
+import os
+import pathlib
+
+
+def emit_trace_event(*args, **kwargs):
+    p = pathlib.Path(os.getcwd()) / "calls.json"
+    try:
+        data = json.loads(p.read_text())
+    except Exception:
+        data = {}
+    data["emit"] = {"args": list(args), "kwargs": kwargs}
+    p.write_text(json.dumps(data))
+"""
+
+
+def _build_fake_memory(tmp_path: Path) -> None:
+    mem_dir = tmp_path / ".ai-memory" / "src" / "memory"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "__init__.py").write_text("")
+    (mem_dir / "injection.py").write_text(_INJECTION_STUB)
+    (mem_dir / "metrics_push.py").write_text(_METRICS_STUB)
+    (mem_dir / "trace_buffer.py").write_text(_TRACE_STUB)
+
+
+def _run_constraints(
+    tmp_path: Path,
+    args: list,
+    load_return: str = "",
+    import_fail: bool = False,
+) -> tuple:
+    """Run constraints.py out-of-process; return (CompletedProcess, calls dict)."""
+    _build_fake_memory(tmp_path)
+    env: dict = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "LC_ALL": "C",
+        "HOME": str(tmp_path),
+        "FAKE_LOAD_RETURN": load_return,
+    }
+    if import_fail:
+        env["FAKE_INJECTION_FAIL"] = "1"
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(tmp_path),
+        env=env,
+    )
+
+    calls_path = tmp_path / "calls.json"
+    calls = json.loads(calls_path.read_text()) if calls_path.exists() else {}
+    return result, calls
 
 
 class TestKnownPhase:
     """Case 1: --phase <value> → load called with that phase, stdout shows constraints."""
 
-    def test_known_phase_passed_to_load(self, monkeypatch):
-        mock_load, _, _ = _exec_constraints(
-            monkeypatch,
-            argv=["constraints.py", "--phase", "init"],
-            load_return_value="## Constraint A\n## Constraint B",
+    def test_known_phase_passed_to_load(self, tmp_path):
+        result, calls = _run_constraints(
+            tmp_path,
+            args=["--phase", "init"],
+            load_return="## Constraint A\n## Constraint B",
         )
-        mock_load.assert_called_once_with(ANY, phase="init")
+        assert result.returncode == 0
+        assert calls["load"]["kwargs"]["phase"] == "init"
+        assert isinstance(calls["load"]["args"][0], str)
 
-    def test_known_phase_output_printed(self, monkeypatch, capsys):
-        _exec_constraints(
-            monkeypatch,
-            argv=["constraints.py", "--phase", "init"],
-            load_return_value="## Constraint A\n## Constraint B",
+    def test_known_phase_output_printed(self, tmp_path):
+        result, _ = _run_constraints(
+            tmp_path,
+            args=["--phase", "init"],
+            load_return="## Constraint A\n## Constraint B",
         )
-        out = capsys.readouterr().out
-        assert "## Constraint A" in out
-        assert "## Constraint B" in out
+        assert result.returncode == 0
+        assert "## Constraint A" in result.stdout
+        assert "## Constraint B" in result.stdout
 
 
 class TestNoPhase:
     """Case 2: no --phase → phase=None, graceful handling of empty result."""
 
-    def test_no_phase_passes_none_to_load(self, monkeypatch):
-        mock_load, _, _ = _exec_constraints(
-            monkeypatch,
-            argv=["constraints.py"],
-            load_return_value="",
-        )
-        mock_load.assert_called_once_with(ANY, phase=None)
+    def test_no_phase_passes_none_to_load(self, tmp_path):
+        result, calls = _run_constraints(tmp_path, args=[], load_return="")
+        assert result.returncode == 0
+        assert calls["load"]["kwargs"]["phase"] is None
 
-    def test_empty_constraints_prints_not_found(self, monkeypatch, capsys):
-        _exec_constraints(
-            monkeypatch,
-            argv=["constraints.py"],
-            load_return_value="",
-        )
-        out = capsys.readouterr().out
-        assert "No constraint files found" in out
+    def test_empty_constraints_prints_not_found(self, tmp_path):
+        result, _ = _run_constraints(tmp_path, args=[], load_return="")
+        assert result.returncode == 0
+        assert "No constraint files found" in result.stdout
 
-    def test_empty_constraints_metric_label_empty(self, monkeypatch):
-        _, mock_push, mock_emit = _exec_constraints(
-            monkeypatch,
-            argv=["constraints.py"],
-            load_return_value="",
-        )
-        mock_push.assert_called_once_with("aim-parzival-constraints", "empty", ANY)
-        mock_emit.assert_called_once()
+    def test_empty_constraints_metric_label_empty(self, tmp_path):
+        result, calls = _run_constraints(tmp_path, args=[], load_return="")
+        assert result.returncode == 0
+        assert calls["push"]["args"][:2] == ["aim-parzival-constraints", "empty"]
+        assert "emit" in calls
 
 
 class TestTelemetryShim:
     """Case 3: telemetry shim integration — callables invoked with exact args."""
 
-    def test_push_metrics_success_label(self, monkeypatch):
-        _, mock_push, _ = _exec_constraints(
-            monkeypatch,
-            argv=["constraints.py"],
-            load_return_value="## Some constraint",
+    def test_push_metrics_success_label(self, tmp_path):
+        result, calls = _run_constraints(
+            tmp_path, args=[], load_return="## Some constraint"
         )
-        mock_push.assert_called_once_with("aim-parzival-constraints", "success", ANY)
+        assert result.returncode == 0
+        assert calls["push"]["args"][:2] == ["aim-parzival-constraints", "success"]
 
-    def test_emit_trace_event_kwargs(self, monkeypatch, capsys):
-        _, _, mock_emit = _exec_constraints(
-            monkeypatch,
-            argv=["constraints.py"],
-            load_return_value="## Some constraint",
+    def test_emit_trace_event_kwargs(self, tmp_path):
+        result, calls = _run_constraints(
+            tmp_path, args=[], load_return="## Some constraint"
         )
-        mock_emit.assert_called_once_with(
-            event_type="skill_execution",
-            data={
-                "input": "Skill: aim-parzival-constraints"[:10000],
-                "output": "Result: completed"[:10000],
-                "metadata": {"skill_name": "aim-parzival-constraints"},
-            },
-            session_id=ANY,
-            tags=["skill"],
-        )
+        assert result.returncode == 0
+        emit_kw = calls["emit"]["kwargs"]
+        assert emit_kw["event_type"] == "skill_execution"
+        assert emit_kw["data"] == {
+            "input": "Skill: aim-parzival-constraints"[:10000],
+            "output": "Result: completed"[:10000],
+            "metadata": {"skill_name": "aim-parzival-constraints"},
+        }
+        assert isinstance(emit_kw["session_id"], str)
+        assert emit_kw["tags"] == ["skill"]
 
 
 class TestImportError:
-    """Safety-critical early-exit: ImportError on memory.injection → exit 0 + Unavailable message."""
+    """Safety-critical early-exit: ImportError on memory.injection → exit 0 + Unavailable."""
 
-    def test_import_error_exits_zero_with_unavailable_message(
-        self, monkeypatch, capsys
-    ):
-        monkeypatch.setattr(sys, "argv", ["constraints.py"])
-        monkeypatch.delenv("AI_MEMORY_PROJECT_ID", raising=False)
-
-        # Mark memory.injection absent via the None sentinel — Python raises ImportError
-        # immediately without any filesystem lookup, regardless of sys.path.
-        monkeypatch.setitem(sys.modules, "memory.injection", None)
-
-        spec = importlib.util.spec_from_file_location(
-            "constraints_importerror", SCRIPT_PATH
-        )
-        module = importlib.util.module_from_spec(spec)
-
-        with pytest.raises(SystemExit) as exc_info:
-            spec.loader.exec_module(module)
-
-        assert exc_info.value.code == 0
-        out = capsys.readouterr().out
-        assert "**Unavailable**" in out
+    def test_import_error_exits_zero_with_unavailable_message(self, tmp_path):
+        result, calls = _run_constraints(tmp_path, args=[], import_fail=True)
+        assert result.returncode == 0
+        assert "**Unavailable**" in result.stdout
+        assert calls == {}

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -10,6 +10,8 @@ import sys
 from pathlib import Path
 from unittest.mock import ANY, MagicMock
 
+import pytest
+
 SCRIPT_PATH = (
     Path(__file__).parent.parent
     / "_ai-memory/pov/skills/aim-parzival-constraints/scripts/constraints.py"
@@ -52,7 +54,7 @@ def _exec_constraints(monkeypatch, argv, load_return_value):
 class TestKnownPhase:
     """Case 1: --phase <value> → load called with that phase, stdout shows constraints."""
 
-    def test_known_phase_passed_to_load(self, monkeypatch, capsys):
+    def test_known_phase_passed_to_load(self, monkeypatch):
         mock_load, _, _ = _exec_constraints(
             monkeypatch,
             argv=["constraints.py", "--phase", "init"],
@@ -74,7 +76,7 @@ class TestKnownPhase:
 class TestNoPhase:
     """Case 2: no --phase → phase=None, graceful handling of empty result."""
 
-    def test_no_phase_passes_none_to_load(self, monkeypatch, capsys):
+    def test_no_phase_passes_none_to_load(self, monkeypatch):
         mock_load, _, _ = _exec_constraints(
             monkeypatch,
             argv=["constraints.py"],
@@ -91,19 +93,20 @@ class TestNoPhase:
         out = capsys.readouterr().out
         assert "No constraint files found" in out
 
-    def test_empty_constraints_metric_label_empty(self, monkeypatch, capsys):
-        _, mock_push, _ = _exec_constraints(
+    def test_empty_constraints_metric_label_empty(self, monkeypatch):
+        _, mock_push, mock_emit = _exec_constraints(
             monkeypatch,
             argv=["constraints.py"],
             load_return_value="",
         )
         mock_push.assert_called_once_with("aim-parzival-constraints", "empty", ANY)
+        mock_emit.assert_called_once()
 
 
 class TestTelemetryShim:
     """Case 3: telemetry shim integration — callables invoked with exact args."""
 
-    def test_push_metrics_success_label(self, monkeypatch, capsys):
+    def test_push_metrics_success_label(self, monkeypatch):
         _, mock_push, _ = _exec_constraints(
             monkeypatch,
             argv=["constraints.py"],
@@ -127,3 +130,29 @@ class TestTelemetryShim:
             session_id=ANY,
             tags=["skill"],
         )
+
+
+class TestImportError:
+    """Safety-critical early-exit: ImportError on memory.injection → exit 0 + Unavailable message."""
+
+    def test_import_error_exits_zero_with_unavailable_message(
+        self, monkeypatch, capsys
+    ):
+        monkeypatch.setattr(sys, "argv", ["constraints.py"])
+        monkeypatch.delenv("AI_MEMORY_PROJECT_ID", raising=False)
+
+        # Mark memory.injection absent via the None sentinel — Python raises ImportError
+        # immediately without any filesystem lookup, regardless of sys.path.
+        monkeypatch.setitem(sys.modules, "memory.injection", None)
+
+        spec = importlib.util.spec_from_file_location(
+            "constraints_importerror", SCRIPT_PATH
+        )
+        module = importlib.util.module_from_spec(spec)
+
+        with pytest.raises(SystemExit) as exc_info:
+            spec.loader.exec_module(module)
+
+        assert exc_info.value.code == 0
+        out = capsys.readouterr().out
+        assert "**Unavailable**" in out


### PR DESCRIPTION
## TASK-071 Item 7 — Externalize `aim-parzival-constraints`

Externalizes the inline Python program embedded in `_ai-memory/pov/skills/aim-parzival-constraints/SKILL.md` into a standalone script invoked via `run-with-env.sh`, with a companion pytest. **Behavior-preserving** (DEC-105 HARD RAIL).

Independent of the #163/#164/#166/#167 stack (different surface: a pov skill). Branched off `main` post-#165.

### Changes
- **NEW** `_ai-memory/pov/skills/aim-parzival-constraints/scripts/constraints.py` — extracted program, **byte-for-byte identical** to the inline block (verified by diff / MD5).
- **NEW** `tests/test_constraints.py` — 8 hermetic tests (known-phase, no-phase, empty, telemetry shim, degraded-env ImportError STOP path); plugin-free, mocked `memory.*`, `AI_MEMORY_PROJECT_ID` unset.
- **EDIT** `SKILL.md` — thinned to a full-path `run-with-env.sh` invoker; steps 2-3 (internalize / STOP-on-failure) retained verbatim. `.claude/skills/` sync deferred to Item 16.

### Decisions (behavior-preserving)
- Telemetry shim preserved inline (bare `memory.metrics_push` + guarded `emit_trace_event`) — **not** `optional_telemetry.py`.
- `--phase` manual `sys.argv` scan preserved (not argparse) to keep extra-args-ignored parity.
- Stale `# LANGFUSE: V3 ONLY` comments preserved verbatim (V3→V4 sweep deferred per #165).

### Verification
- Parity: inline vs `constraints.py` diff IDENTICAL (77=77).
- Dual code review (Sonnet + Opus): zero defects in code; 3 LOW test-quality items applied.
- 8/8 tests pass CI-exact (`-p no:randomly`); zero regressions by base-isolation (`f9a72cd` baseline); ruff/black/isort clean on `src/ tests/`.