### PR TITLE
docs: CHANGELOG currency for TASK-071 (#167/#169) + Langfuse SDK v4 disambiguation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Companion unit tests in `tests/unit/test_store_best_practice_script.py`
   (importlib + sys.modules patching, mocked resolver at call boundary per DEC-109).
 
+- **TASK-071 Items 13–14 (#167)** — Standalone scripts externalize the inline
+  Qdrant query blocks from the GitHub and Jira search skills into
+  `_ai-memory/skills/aim-github-search/scripts/query.py` and
+  `_ai-memory/skills/aim-jira-search/scripts/query.py`, and the
+  GitHubSyncEngine invoker from `aim-github-sync` into
+  `scripts/memory/github_sync_runner.py`. All scripts are behavior-preserving
+  and invoked via `scripts/memory/run-with-env.sh` (BP-013 Pattern B).
+
+- **TASK-071 Groups 1–2 (#169)** — Standalone scripts externalize the inline
+  programs from four core maintenance skills into
+  `scripts/memory/purge_collections.py` (aim-purge),
+  `scripts/memory/freshness_report.py` (aim-freshness-report),
+  `scripts/memory/pause_updates.py` (aim-pause-updates), and
+  `scripts/memory/refresh.py` (aim-refresh). Four reusable Bash helpers
+  (`check_api_key.sh`, `cwd_sentinel.sh`, `inbox_inject.sh`,
+  `validate_model.sh`) added under
+  `_ai-memory/skills/aim-model-dispatch/scripts/lib/` replace duplicated
+  inline blocks across `aim-model-dispatch` step files. All behavior-preserving;
+  invoked via `scripts/memory/run-with-env.sh`.
+
 ### Changed
 
 - **RISK-021 — Deliberate behaviour change (DEC-108 C-1 / DEC-106

--- a/docs/LANGFUSE-INTEGRATION.md
+++ b/docs/LANGFUSE-INTEGRATION.md
@@ -2,7 +2,7 @@
 
 Langfuse integration for the AI Memory Module. Traces every memory pipeline operation — from hook capture through LLM classification — so you can see exactly what your memory system is doing, how long each step takes, and where issues occur.
 
-Uses [Langfuse v3](https://langfuse.com/) self-hosted with the Python SDK for trace ingestion.
+Uses the [Langfuse](https://langfuse.com/) Python SDK v4 (OTel-based) for trace ingestion. The self-hosted server runs Langfuse v3, which is OTel-compatible with the v4 SDK.
 
 ---
 
@@ -202,6 +202,8 @@ All Langfuse services use the `langfuse` profile and join the existing `ai-memor
 | `langfuse-minio` | `cgr.dev/chainguard/minio` | S3-compatible blob storage for event upload |
 | `trace-flush-worker` | Custom (Dockerfile.worker) | Reads trace buffer, flushes to Langfuse |
 | `evaluator-scheduler` | Custom (Dockerfile.evaluator-scheduler) | Cron-based LLM-as-judge evaluation runner |
+
+> **Note:** The server images (`langfuse/langfuse:3`, `langfuse/langfuse-worker:3`) use the Langfuse v3 server tag. Langfuse v3 server is OTel-compatible with the v4 Python SDK used by AI Memory for trace ingestion.
 
 ---
 


### PR DESCRIPTION
## Summary

- **CHANGELOG.md**: Adds two `[Unreleased] / Added` bullets documenting the TASK-071 script-externalization work shipped in PRs #167 and #169. Filenames verified from `git show` on commits `3457cad` and `1b7c195`.
  - #167 (Items 13–14): `_ai-memory/skills/aim-github-search/scripts/query.py`, `_ai-memory/skills/aim-jira-search/scripts/query.py`, `scripts/memory/github_sync_runner.py`
  - #169 (Groups 1–2): `scripts/memory/purge_collections.py`, `freshness_report.py`, `pause_updates.py`, `refresh.py`; plus four `aim-model-dispatch` Bash helpers under `scripts/lib/`
- **docs/LANGFUSE-INTEGRATION.md**: Disambiguates Python SDK v4 (OTel-based) from the self-hosted Langfuse server (v3). Opening line updated; image tags remain `:3` with an added note that Langfuse server v3 is OTel-compatible with the v4 SDK. The "Langfuse v3 Headless Init" heading (server-side, correct) is unchanged.

## Notes

- Footer version marker (`v2.0.7`) left unchanged — correct target version unclear without reviewer input; flagged for follow-up.

## Test plan

- [ ] Review CHANGELOG bullets match existing bullet style; filenames are real paths from merged PRs
- [ ] Confirm LANGFUSE-INTEGRATION.md line 5 reflects SDK v4 / server v3 split
- [ ] Confirm image tags still `:3` with OTel-compatibility note present
- [ ] Confirm "Langfuse v3 Headless Init" heading (env-config section) untouched
- [ ] CI green