### PR TITLE
fix(github-search): default to the github collection (BUG-318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **BUG-318** — `aim-github-search` now defaults to the `github` Qdrant collection where
+  GitHub content lives. The as-documented invocation (no `--collection` flag) returns
+  results instead of zero; `--collection` remains supported for cross-collection queries.
+
 ## [2.5.0] - 2026-06-03
 
 ### Added

--- a/_ai-memory/skills/aim-github-search/SKILL.md
+++ b/_ai-memory/skills/aim-github-search/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Read, Bash
 
 # Search GitHub - Semantic Search for GitHub Content
 
-Search the discussions collection for GitHub-sourced content using semantic similarity with advanced filtering.
+Search the github collection for GitHub-sourced content using semantic similarity with advanced filtering.
 
 ## Activation
 
@@ -43,21 +43,21 @@ Each result includes:
 
 ## Qdrant Connection Details
 
-GitHub content is stored in the discussions collection:
+GitHub content is stored in the github collection:
 
 | Parameter | Value |
 |-----------|-------|
 | **Host** | `localhost` |
 | **Port** | `26350` (NOT the default 6333) |
 | **API Key** | Required. Read from env: `QDRANT_API_KEY` |
-| **Collection** | `discussions` |
+| **Collection** | `github` |
 | **URL** | `http://localhost:26350` |
 
 ---
 
 ## Qdrant Payload Schema
 
-Every GitHub point in `discussions` has the following payload fields. Use these **exact names** for filtering.
+Every GitHub point in `github` has the following payload fields. Use these **exact names** for filtering.
 
 ### Common Fields (all GitHub points)
 
@@ -87,9 +87,10 @@ and accepts optional `--type`, `--state`, `--limit`, and `--format` flags.
 
 ```bash
 # Replace "owner/repo-name" with your GITHUB_REPO value (e.g., "hidden-history/ai-memory")
+# --collection defaults to github; omit it for the standard case
 bash "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh" \
   "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/_ai-memory/skills/aim-github-search/scripts/query.py" \
-  --group-id "owner/repo-name" --collection github
+  --group-id "owner/repo-name"
 ```
 
 ### Filter by type and state
@@ -98,7 +99,7 @@ bash "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh"
 # Replace "owner/repo-name" with your GITHUB_REPO value
 bash "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh" \
   "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/_ai-memory/skills/aim-github-search/scripts/query.py" \
-  --group-id "owner/repo-name" --type github_pr --state merged --limit 20 --collection github
+  --group-id "owner/repo-name" --type github_pr --state merged --limit 20
 ```
 
 ### Count GitHub points in collection
@@ -107,7 +108,7 @@ bash "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh"
 # Returns the exact count via the Qdrant count endpoint (exact=true)
 bash "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh" \
   "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/_ai-memory/skills/aim-github-search/scripts/query.py" \
-  --group-id "owner/repo-name" --format count --collection github
+  --group-id "owner/repo-name" --format count
 ```
 
 ---
@@ -126,7 +127,7 @@ python3 query.py \
   [--state STATE]              # open | closed | merged
   [--limit N]                  # default: 10
   [--format table|json|count]  # default: table; count uses Qdrant count endpoint (exact=true)
-  [--collection COLL]          # default: discussions
+  [--collection COLL]          # default: github; use to query a different collection
 ```
 
 Run via `run-with-env.sh` so `memory.*` imports and `QDRANT_API_KEY` are resolved automatically:
@@ -134,7 +135,7 @@ Run via `run-with-env.sh` so `memory.*` imports and `QDRANT_API_KEY` are resolve
 ```bash
 bash "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh" \
   "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/_ai-memory/skills/aim-github-search/scripts/query.py" \
-  --group-id "hidden-history/ai-memory" --type github_pr --state merged --collection github
+  --group-id "hidden-history/ai-memory" --type github_pr --state merged
 ```
 
 ## Technical Details
@@ -142,7 +143,7 @@ bash "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh"
 - **Semantic Search**: Uses jina-embeddings-v2-base-en for vector similarity
 - **Tenant Isolation**: Mandatory group_id filter prevents cross-repo leakage
 - **Performance**: < 2s for typical searches
-- **Collection**: discussions (GitHub content stored alongside conversation data)
+- **Collection**: github (dedicated collection for GitHub-sourced content, per PLAN-010)
 - **Score Threshold**: Configurable via SIMILARITY_THRESHOLD (default 0.7)
 - **Port**: 26350 (NOT the Qdrant default of 6333)
 - **API Key**: Required -- stored in `~/.ai-memory/docker/.env` as `QDRANT_API_KEY`

--- a/_ai-memory/skills/aim-github-search/scripts/query.py
+++ b/_ai-memory/skills/aim-github-search/scripts/query.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Query GitHub content from the Qdrant discussions collection.
+"""Query GitHub content from the Qdrant github collection.
 
 Parameterized replacement for the inline Python blocks in aim-github-search/SKILL.md.
 Always applies source=github + group_id filters; optional type/state/limit/format.
@@ -29,16 +29,16 @@ sys.path.insert(0, os.path.join(INSTALL_DIR, "src"))
 
 from qdrant_client.models import FieldCondition, Filter, MatchValue  # noqa: E402
 
-from memory.config import get_config  # noqa: E402
+from memory.config import COLLECTION_GITHUB, get_config  # noqa: E402
 from memory.qdrant_client import get_qdrant_client  # noqa: E402
 
-_DEFAULT_COLLECTION = "discussions"
+_DEFAULT_COLLECTION = COLLECTION_GITHUB
 _DEFAULT_LIMIT = 10
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Query GitHub content from Qdrant discussions collection.",
+        description="Query GitHub content from Qdrant github collection.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(

--- a/tests/integration/test_github_search_default_collection.py
+++ b/tests/integration/test_github_search_default_collection.py
@@ -154,9 +154,10 @@ class TestGithubSearchDefaultCollection:
         assert rc == 0
 
         out = capsys.readouterr().out
-        # Table format prints "Found N points"; seeded exactly 1 point
-        assert "Found 1 points" in out, (
-            f"Expected 'Found 1 points' in output but got:\n{out}\n"
-            "Possible cause: query.py is still routing to 'discussions' instead of "
-            f"the 'github' collection (BUG-318). Seeded point id={seeded_github_point}"
+        # Table format prints "Found N points"; assert >0 results (not exactly 1,
+        # to tolerate orphaned points from a prior run's failed teardown).
+        assert "Found 0 points" not in out, (
+            "query.py returned zero results — possible BUG-318 regression "
+            "(still routing to 'discussions' instead of 'github'). "
+            f"Seeded point id={seeded_github_point}"
         )

--- a/tests/integration/test_github_search_default_collection.py
+++ b/tests/integration/test_github_search_default_collection.py
@@ -68,10 +68,25 @@ def seeded_github_point(qdrant_client):
     Yields the point ID (UUID string) so the test can reference it if needed.
     Cleanup is attempted unconditionally via contextlib.suppress so a test
     failure never orphans the point.
+
+    The fixture ensures the `github` collection exists before upserting.  On CI
+    the collection does not exist yet; on a dev stack it may already hold real
+    data.  Only a collection created HERE is dropped in teardown — a pre-existing
+    collection is left intact.
     """
-    from qdrant_client.models import PointStruct
+    from qdrant_client.models import Distance, PointStruct, VectorParams
 
     from memory.config import COLLECTION_GITHUB
+
+    # Ensure the github collection exists; track whether we created it so we
+    # can clean it up in teardown without touching pre-existing collections.
+    created = False
+    if not qdrant_client.collection_exists(COLLECTION_GITHUB):
+        qdrant_client.create_collection(
+            collection_name=COLLECTION_GITHUB,
+            vectors_config=VectorParams(size=768, distance=Distance.COSINE),
+        )
+        created = True
 
     point_id = str(uuid.uuid4())
     qdrant_client.upsert(
@@ -93,7 +108,8 @@ def seeded_github_point(qdrant_client):
     )
     yield point_id
 
-    # Teardown: delete only the seeded test point
+    # Teardown: always delete the seeded test point; only drop the collection
+    # if this fixture created it (never drop a pre-existing collection).
     with contextlib.suppress(Exception):
         from qdrant_client.models import PointIdsList
 
@@ -102,6 +118,9 @@ def seeded_github_point(qdrant_client):
             points_selector=PointIdsList(points=[point_id]),
             wait=True,
         )
+    if created:
+        with contextlib.suppress(Exception):
+            qdrant_client.delete_collection(COLLECTION_GITHUB)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_github_search_default_collection.py
+++ b/tests/integration/test_github_search_default_collection.py
@@ -1,0 +1,162 @@
+"""Integration test for aim-github-search default collection routing (BUG-318).
+
+Non-mocked: seeds one point with source=github into the live `github` Qdrant
+collection, runs query.py with NO --collection flag, asserts >0 rows returned.
+
+Auto-marked @pytest.mark.integration by tests/integration/conftest.py.
+Skipped automatically when Qdrant is not reachable.
+
+Seed/teardown pattern follows test_collection_statistics.py (qdrant_client fixture)
+and test_monitoring.py (upsert + cleanup in yield fixture).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_WORKTREE_ROOT = Path(__file__).parent.parent.parent
+_QUERY_PY = (
+    _WORKTREE_ROOT
+    / "_ai-memory"
+    / "skills"
+    / "aim-github-search"
+    / "scripts"
+    / "query.py"
+)
+
+_TEST_GROUP_ID = "bug318-integration-test/ai-memory"
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def qdrant_client():
+    """Provide QdrantClient connected to the live Qdrant stack.
+
+    Uses get_qdrant_client() — the same call path as query.py — so the
+    fixture exercises the identical config/auth resolution.
+    Skips the entire module if Qdrant is not reachable.
+    """
+    from memory.config import get_config
+    from memory.qdrant_client import get_qdrant_client
+
+    try:
+        config = get_config()
+        client = get_qdrant_client(config)
+        client.get_collections()  # connectivity check
+        return client
+    except Exception as exc:
+        pytest.skip(f"Qdrant not reachable: {exc}")
+
+
+@pytest.fixture
+def seeded_github_point(qdrant_client):
+    """Seed one source=github point into the github collection; remove it in teardown.
+
+    Yields the point ID (UUID string) so the test can reference it if needed.
+    Cleanup is attempted unconditionally via contextlib.suppress so a test
+    failure never orphans the point.
+    """
+    from qdrant_client.models import PointStruct
+
+    from memory.config import COLLECTION_GITHUB
+
+    point_id = str(uuid.uuid4())
+    qdrant_client.upsert(
+        collection_name=COLLECTION_GITHUB,
+        points=[
+            PointStruct(
+                id=point_id,
+                vector=[0.1] * 768,
+                payload={
+                    "source": "github",
+                    "type": "github_issue",
+                    "group_id": _TEST_GROUP_ID,
+                    "content": "BUG-318 integration test: default collection routing",
+                    "state": "open",
+                },
+            )
+        ],
+        wait=True,
+    )
+    yield point_id
+
+    # Teardown: delete only the seeded test point
+    with contextlib.suppress(Exception):
+        from qdrant_client.models import PointIdsList
+
+        qdrant_client.delete(
+            collection_name=COLLECTION_GITHUB,
+            points_selector=PointIdsList(points=[point_id]),
+            wait=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_query_module():
+    """Load query.py via importlib so tests exercise the real module without mocks.
+
+    Sets AI_MEMORY_INSTALL_DIR to the worktree root so query.py's sys.path
+    insertion resolves to the worktree src/ (same directory pytest adds via
+    pythonpath config).  Purges any cached 'query' module between loads.
+    """
+    import os
+
+    os.environ.setdefault("AI_MEMORY_INSTALL_DIR", str(_WORKTREE_ROOT))
+    sys.modules.pop("query", None)
+
+    spec = importlib.util.spec_from_file_location("query", _QUERY_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGithubSearchDefaultCollection:
+    """Verify that query.py routes to the github collection when --collection is absent."""
+
+    def test_default_collection_returns_seeded_point(
+        self, seeded_github_point, monkeypatch, capsys
+    ):
+        """No --collection flag → scroll targets github collection → >0 rows returned.
+
+        This is the canonical BUG-318 regression guard: the as-documented
+        invocation must return results.
+        """
+        mod = _load_query_module()
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["query.py", "--group-id", _TEST_GROUP_ID],
+        )
+
+        rc = mod.main()
+        assert rc == 0
+
+        out = capsys.readouterr().out
+        # Table format prints "Found N points"; seeded exactly 1 point
+        assert "Found 1 points" in out, (
+            f"Expected 'Found 1 points' in output but got:\n{out}\n"
+            "Possible cause: query.py is still routing to 'discussions' instead of "
+            f"the 'github' collection (BUG-318). Seeded point id={seeded_github_point}"
+        )

--- a/tests/test_github_search_query.py
+++ b/tests/test_github_search_query.py
@@ -69,6 +69,7 @@ def query_module(monkeypatch):
     # Stub memory.config
     config_mod = ModuleType("memory.config")
     config_mod.get_config = MagicMock(return_value=MagicMock())
+    config_mod.COLLECTION_GITHUB = "github"
     monkeypatch.setitem(sys.modules, "memory.config", config_mod)
 
     # Stub memory.qdrant_client
@@ -208,12 +209,12 @@ class TestParseArgs:
         assert exc_info.value.code == 2
 
     def test_defaults(self, query_module, monkeypatch):
-        """Defaults: collection=discussions, limit=10, format=table, no type/state."""
+        """Defaults: collection=github, limit=10, format=table, no type/state."""
         mod, _ = query_module
         monkeypatch.setattr(sys, "argv", ["query.py", "--group-id", "owner/repo"])
         args = mod.parse_args()
         assert args.group_id == "owner/repo"
-        assert args.collection == "discussions"
+        assert args.collection == "github"
         assert args.limit == 10
         assert args.output_format == "table"
         assert args.type_filter is None
@@ -279,7 +280,7 @@ class TestMain:
         assert rc == 0
         mock_client.scroll.assert_called_once()
         call_kwargs = mock_client.scroll.call_args.kwargs
-        assert call_kwargs["collection_name"] == "discussions"
+        assert call_kwargs["collection_name"] == "github"
         assert call_kwargs["limit"] == 10
         assert call_kwargs["with_payload"] is True
         assert call_kwargs["with_vectors"] is False
@@ -306,7 +307,7 @@ class TestMain:
         assert rc == 0
         mock_client.count.assert_called_once()
         call_kwargs = mock_client.count.call_args.kwargs
-        assert call_kwargs["collection_name"] == "discussions"
+        assert call_kwargs["collection_name"] == "github"
         assert call_kwargs["exact"] is True
         # Verify filter
         filt = call_kwargs["count_filter"]


### PR DESCRIPTION
## Summary
`aim-github-search` defaulted to the `discussions` Qdrant collection, where the `source=github` count is **0**. As a result, the as-documented invocation returned `GitHub points: 0` even though GitHub content (15,534 points) lives in the dedicated `github` collection (split out in PLAN-010). The skill was usable only via an undocumented `--collection github` flag.

This changes the default collection to `github` so the documented invocation works out of the box.

## Changes
- **`query.py`**: default collection now resolves to the canonical `COLLECTION_GITHUB` constant (imported from `memory.config`, mirroring how `aim-jira-search` imports `COLLECTION_JIRA_DATA`). Module docstring corrected.
- **`SKILL.md`**: documents `github` as the default; `--collection` is now documented as the override for cross-collection queries. Removed the now-redundant `--collection github` from examples.
- **Unit tests**: default-collection assertions updated to `github`; the explicit `--collection discussions` override test is preserved.
- **New integration test**: non-mocked guard that seeds a `source=github` point and asserts the default invocation returns results — this exercises the production path that mocked tests never covered, and fails if the default ever regresses to `discussions`.
- **CHANGELOG**: `[Unreleased] / Fixed` entry.

`aim-jira-search` was checked and is unaffected (already defaults to `jira-data`).

## Verification
- Unit: `pytest tests/test_github_search_query.py` — 18 passed.
- Integration (live stack): `pytest tests/integration/test_github_search_default_collection.py --run-integration` — 1 passed.
- Lint: black, ruff, isort all clean.

Fixes BUG-318.