### PR TITLE
test(trace-flush-worker): prevent a leaked watchdog os._exit from killing the test run (TD-612)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   GitHub content lives. The as-documented invocation (no `--collection` flag) returns
   results instead of zero; `--collection` remains supported for cross-collection queries.
 
+- **TD-612** — Removed a source of intermittent CI failures in which a leaked
+  `flush-watchdog` daemon thread (started by `trace_flush_worker` tests) could reach its
+  stall deadline and call `os._exit`, hard-killing an already-passing `pytest` run with
+  no failing test, assertion, or traceback. A session-wide test guard now neutralizes the
+  watchdog's process-exit in-process — so an orphaned daemon bound to any re-imported
+  module generation can no longer terminate the runner — and still asserts that no
+  `flush-watchdog` thread leaks past a test, turning a leak into a loud, attributable
+  failure rather than a silent kill. The watchdog's production stall-restart behavior is
+  unchanged (test-only fix).
+
 ## [2.5.0] - 2026-06-03
 
 ### Added

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ import contextlib
 import os
 import socket
 import sys
+import threading
 import time
 from collections.abc import Callable, Generator
 from pathlib import Path
@@ -281,6 +282,72 @@ def reset_logging():
 
     logger.handlers.clear()
     logger.propagate = True
+
+
+# =============================================================================
+# Flush-watchdog kill-vector neutralization + leak tripwire (TD-612)
+# =============================================================================
+
+
+@pytest.fixture(autouse=True)
+def _neutralize_and_join_flush_watchdog(monkeypatch):
+    """Stop a leaked trace-flush-worker watchdog daemon from killing the test runner.
+
+    ``memory.trace_flush_worker._watchdog_loop`` calls the real ``os._exit(1)`` from a
+    daemon thread named ``flush-watchdog`` so Docker restarts a wedged worker in
+    production. Several worker tests start that daemon via ``main()``. A daemon that
+    outlives the test that started it — e.g. one bound to a superseded, re-imported
+    module object whose globals a module-local teardown can no longer signal — later
+    reaches its stall deadline and fires ``os._exit(1)`` in-process, hard-killing an
+    already-green run with no traceback (TD-612). A module-scoped guard could not
+    cover this: the victim is a different test module, and a stale-bound daemon never
+    observes a signal sent to the current module object.
+
+    This guard runs for every test under ``tests/`` and does two independent things:
+
+    1. **Neutralize the kill vector.** Patch the process-wide ``os._exit`` to a
+       recorder. Every re-imported worker-module generation shares the one ``os``
+       module, so an orphaned daemon bound to any generation resolves ``os._exit`` to
+       this recorder and can never terminate the runner.
+    2. **Keep loud leak attribution.** After the test, signal shutdown to any loaded
+       worker module, join every ``flush-watchdog`` thread, and assert none leaked —
+       so neutralizing the exit never silently masks a thread leak; a leak still fails
+       a test loudly, it just can no longer kill the process.
+
+    Tests that assert on the exit path (e.g. the direct watchdog tests) patch
+    ``mod.os._exit`` themselves; that patch is applied after this one on the same
+    function-scoped ``monkeypatch`` and therefore wins for that test. Yields the
+    recorder list so a test can assert a neutralized exit was caught.
+    """
+    exit_calls: list[int] = []
+
+    def _record_exit(code):
+        exit_calls.append(code)
+
+    monkeypatch.setattr(os, "_exit", _record_exit)
+
+    yield exit_calls
+
+    # Signal shutdown to a loaded worker module so its watchdog can observe it.
+    mod = sys.modules.get("memory.trace_flush_worker")
+    if mod is not None:
+        with contextlib.suppress(Exception):
+            mod.shutdown_requested = True
+        with contextlib.suppress(Exception):
+            mod._watchdog_wakeup.set()
+
+    # Join any flush-watchdog daemon, then assert none survived (loud per-test
+    # attribution if a leak is ever reintroduced).
+    deadline = time.monotonic() + 10
+    for thread in threading.enumerate():
+        if thread.name == "flush-watchdog" and thread.is_alive():
+            thread.join(timeout=max(0.0, deadline - time.monotonic()))
+    leaked = [
+        thread.name
+        for thread in threading.enumerate()
+        if thread.name == "flush-watchdog" and thread.is_alive()
+    ]
+    assert not leaked, f"flush-watchdog daemon leaked past the test: {leaked}"
 
 
 # =============================================================================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -287,54 +287,88 @@ def reset_logging():
 # =============================================================================
 # Flush-watchdog kill-vector neutralization + leak tripwire (TD-612)
 # =============================================================================
+#
+# ``memory.trace_flush_worker._watchdog_loop`` calls the real ``os._exit(1)`` from a
+# daemon thread named ``flush-watchdog`` so Docker restarts a wedged worker in
+# production. Several worker tests start that daemon via ``main()``. A daemon that
+# outlives the test that started it — e.g. one bound to a superseded, re-imported
+# module object whose globals a module-local teardown can no longer signal — later
+# reaches its stall deadline and fires ``os._exit(1)`` in-process, hard-killing an
+# already-green run with no traceback (TD-612).
+#
+# Neutralization is split across two complementary fixtures:
+#   * a SESSION-scoped recorder that owns ``os._exit`` continuously, so there is no
+#     inter-test gap where the real ``os._exit`` is live for a stale-bound daemon to
+#     fire into, and
+#   * a function-scoped fixture that points the recorder at a fresh per-test sink (so a
+#     test can assert its own neutralized exit was caught) and keeps the loud per-test
+#     leak tripwire (join + assert no leak).
+
+# Currently-active per-test exit sink. The session recorder always routes here, so
+# rebinding this name per test swaps the sink without ever restoring the real os._exit.
+_active_exit_calls: list[int] = []
+
+
+def _session_record_exit(code):
+    """Process-wide ``os._exit`` replacement installed for the whole session (TD-612).
+
+    Routes a neutralized exit into the currently-active per-test sink so a leaked
+    flush-watchdog daemon can never terminate the runner — whether it fires during a
+    test or in the gap between tests.
+    """
+    _active_exit_calls.append(code)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _neutralize_flush_watchdog_exit_session():
+    """Own ``os._exit`` for the entire session so neutralization is continuous (TD-612).
+
+    A function-scoped patch is undone by pytest at each test teardown, leaving the real
+    ``os._exit`` live between tests — a window in which a stale-bound flush-watchdog
+    daemon could still real-``os._exit(1)`` and hard-kill the runner. A raw session
+    ``MonkeyPatch`` set up once and never undone mid-run closes that gap; the real
+    ``os._exit`` is restored only at session end.
+
+    Tests that assert on the exit path (the direct watchdog tests) patch ``mod.os._exit``
+    on their own function-scoped ``monkeypatch``; that patch is applied over this session
+    recorder and wins for the test body, then pytest restores it back to this recorder
+    (never to the real ``os._exit``) at teardown.
+    """
+    session_patch = pytest.MonkeyPatch()
+    session_patch.setattr(os, "_exit", _session_record_exit)
+    yield
+    session_patch.undo()
 
 
 @pytest.fixture(autouse=True)
-def _neutralize_and_join_flush_watchdog(monkeypatch):
-    """Stop a leaked trace-flush-worker watchdog daemon from killing the test runner.
+def _neutralize_and_join_flush_watchdog():
+    """Per-test sink for the session ``os._exit`` recorder + loud leak tripwire (TD-612).
 
-    ``memory.trace_flush_worker._watchdog_loop`` calls the real ``os._exit(1)`` from a
-    daemon thread named ``flush-watchdog`` so Docker restarts a wedged worker in
-    production. Several worker tests start that daemon via ``main()``. A daemon that
-    outlives the test that started it — e.g. one bound to a superseded, re-imported
-    module object whose globals a module-local teardown can no longer signal — later
-    reaches its stall deadline and fires ``os._exit(1)`` in-process, hard-killing an
-    already-green run with no traceback (TD-612). A module-scoped guard could not
-    cover this: the victim is a different test module, and a stale-bound daemon never
-    observes a signal sent to the current module object.
-
-    This guard runs for every test under ``tests/`` and does two independent things:
-
-    1. **Neutralize the kill vector.** Patch the process-wide ``os._exit`` to a
-       recorder. Every re-imported worker-module generation shares the one ``os``
-       module, so an orphaned daemon bound to any generation resolves ``os._exit`` to
-       this recorder and can never terminate the runner.
-    2. **Keep loud leak attribution.** After the test, signal shutdown to any loaded
-       worker module, join every ``flush-watchdog`` thread, and assert none leaked —
-       so neutralizing the exit never silently masks a thread leak; a leak still fails
-       a test loudly, it just can no longer kill the process.
-
-    Tests that assert on the exit path (e.g. the direct watchdog tests) patch
-    ``mod.os._exit`` themselves; that patch is applied after this one on the same
-    function-scoped ``monkeypatch`` and therefore wins for that test. Yields the
-    recorder list so a test can assert a neutralized exit was caught.
+    The session-scoped fixture keeps ``os._exit`` neutralized continuously; this fixture
+    points that recorder at a fresh per-test list (yielded so a test can assert its own
+    neutralized exit was caught), then after the test joins every ``flush-watchdog``
+    thread and asserts none leaked — so neutralizing the exit never silently masks a
+    thread leak; a leak still fails a test loudly, it just can no longer kill the process.
     """
+    global _active_exit_calls
     exit_calls: list[int] = []
-
-    def _record_exit(code):
-        exit_calls.append(code)
-
-    monkeypatch.setattr(os, "_exit", _record_exit)
+    _active_exit_calls = exit_calls
 
     yield exit_calls
 
-    # Signal shutdown to a loaded worker module so its watchdog can observe it.
+    # Signal shutdown to a loaded worker module so its watchdog can observe it. A daemon
+    # bound to a superseded module generation can't observe this signal; the
+    # session-scoped os._exit recorder neutralizes its exit and the join + assert below
+    # still reports the leak loudly.
     mod = sys.modules.get("memory.trace_flush_worker")
     if mod is not None:
-        with contextlib.suppress(Exception):
-            mod.shutdown_requested = True
+        mod.shutdown_requested = True
         with contextlib.suppress(Exception):
             mod._watchdog_wakeup.set()
+
+    # Route any post-test stray exit (e.g. from a daemon firing during teardown) into a
+    # throwaway sink rather than the test's now-yielded list.
+    _active_exit_calls = []
 
     # Join any flush-watchdog daemon, then assert none survived (loud per-test
     # attribution if a leak is ever reintroduced).

--- a/tests/test_td612_watchdog_isolation.py
+++ b/tests/test_td612_watchdog_isolation.py
@@ -1,12 +1,12 @@
 """TD-612 adversarial isolation tests — a leaked flush-watchdog daemon's real
 os._exit must never kill the test runner.
 
-These exercise the session-wide guard in tests/conftest.py
-(_neutralize_and_join_flush_watchdog): even a watchdog bound to a superseded,
+These exercise the session-wide guard in tests/conftest.py (the session-scoped
+_neutralize_flush_watchdog_exit_session recorder plus the per-test
+_neutralize_and_join_flush_watchdog sink): even a watchdog bound to a superseded,
 re-imported module object — the TD-612 root cause — resolves os._exit to the
-shared recorder and so cannot terminate the process. Under -p no:randomly the
-module keeps its definition order, so the second test demonstrates that a
-subsequent test survives a prior leak.
+shared recorder and so cannot terminate the process. The second test confirms an
+armed watchdog fires into the recorder rather than the real process exit.
 """
 
 import sys
@@ -80,12 +80,12 @@ def test_stale_bound_watchdog_real_exit_is_neutralized(
     assert not watchdog.is_alive()
 
 
-def test_following_test_survives_prior_leak(
+def test_armed_watchdog_fires_into_recorder_not_process(
     tmp_path, monkeypatch, _neutralize_and_join_flush_watchdog
 ):
-    """The next test (definition order under -p no:randomly) runs to completion: its
-    own armed watchdog fires past the deadline into the recorder, and the parent
-    process survives."""
+    """An armed watchdog that trips its stall deadline calls os._exit, which the
+    session recorder captures instead of terminating the runner — so the test runs
+    to completion and the neutralized exit is recorded."""
     exit_calls = _neutralize_and_join_flush_watchdog
 
     mod = _import_worker(monkeypatch, tmp_path)
@@ -95,8 +95,8 @@ def test_following_test_survives_prior_leak(
     )
     watchdog.start()
 
-    time.sleep(0.4)  # sleep past the 0.1s deadline; the watchdog fires meanwhile
-    assert 1 in exit_calls, "watchdog exit not neutralized in the following test"
+    _wait_for_exit_capture(exit_calls)
+    assert 1 in exit_calls, "armed watchdog exit was not neutralized into the recorder"
 
     _stop_watchdog(mod, watchdog)
     assert not watchdog.is_alive()

--- a/tests/test_td612_watchdog_isolation.py
+++ b/tests/test_td612_watchdog_isolation.py
@@ -1,0 +1,102 @@
+"""TD-612 adversarial isolation tests — a leaked flush-watchdog daemon's real
+os._exit must never kill the test runner.
+
+These exercise the session-wide guard in tests/conftest.py
+(_neutralize_and_join_flush_watchdog): even a watchdog bound to a superseded,
+re-imported module object — the TD-612 root cause — resolves os._exit to the
+shared recorder and so cannot terminate the process. Under -p no:randomly the
+module keeps its definition order, so the second test demonstrates that a
+subsequent test survives a prior leak.
+"""
+
+import sys
+import threading
+import time
+
+
+def _import_worker(monkeypatch, tmp_path):
+    """Import a fresh memory.trace_flush_worker bound to an isolated buffer dir."""
+    monkeypatch.setenv("AI_MEMORY_INSTALL_DIR", str(tmp_path))
+    monkeypatch.setenv("LANGFUSE_FLUSH_INTERVAL", "0")
+    for key in list(sys.modules):
+        if "trace_flush_worker" in key:
+            del sys.modules[key]
+
+    import memory.trace_flush_worker as mod
+
+    return mod
+
+
+def _arm_stalled_watchdog(mod):
+    """Configure a worker module so its watchdog trips its stall deadline at once."""
+    mod.STALL_DEADLINE_SECONDS = 0.1
+    mod.shutdown_requested = False
+    mod._last_loop_progress = time.monotonic() - 5  # already past the deadline
+
+
+def _stop_watchdog(mod, thread):
+    """Signal shutdown on the daemon's own module object and join it."""
+    mod.shutdown_requested = True
+    mod._watchdog_wakeup.set()
+    thread.join(timeout=5)
+
+
+def _wait_for_exit_capture(exit_calls, timeout=3.0):
+    """Wait until the neutralized os._exit(1) is recorded (or time out)."""
+    deadline = time.time() + timeout
+    while 1 not in exit_calls and time.time() < deadline:
+        time.sleep(0.02)
+
+
+def test_stale_bound_watchdog_real_exit_is_neutralized(
+    tmp_path, monkeypatch, _neutralize_and_join_flush_watchdog
+):
+    """Root-cause reproduction: a watchdog bound to a re-imported (stale) module
+    object fires the real os._exit on its stall deadline; the guard must capture it
+    instead of letting it hard-kill the runner."""
+    exit_calls = _neutralize_and_join_flush_watchdog
+
+    mod1 = _import_worker(monkeypatch, tmp_path)
+    _arm_stalled_watchdog(mod1)
+    # Do NOT patch os._exit here — the watchdog must reach the conftest recorder.
+    watchdog = threading.Thread(
+        target=mod1._watchdog_loop, name="flush-watchdog", daemon=True
+    )
+    watchdog.start()
+
+    # Re-import the module (as _load_module does between tests) so the live daemon is
+    # now bound to a superseded module object — the exact TD-612 escape that a
+    # module-scoped guard could not signal.
+    _import_worker(monkeypatch, tmp_path)
+
+    # The stale-bound daemon trips its 0.1s deadline and calls the real os._exit; the
+    # process must survive (we keep executing) and the recorder must have caught it.
+    _wait_for_exit_capture(exit_calls)
+    assert (
+        1 in exit_calls
+    ), "neutralized os._exit(1) from a stale-bound watchdog was not captured"
+
+    _stop_watchdog(mod1, watchdog)
+    assert not watchdog.is_alive()
+
+
+def test_following_test_survives_prior_leak(
+    tmp_path, monkeypatch, _neutralize_and_join_flush_watchdog
+):
+    """The next test (definition order under -p no:randomly) runs to completion: its
+    own armed watchdog fires past the deadline into the recorder, and the parent
+    process survives."""
+    exit_calls = _neutralize_and_join_flush_watchdog
+
+    mod = _import_worker(monkeypatch, tmp_path)
+    _arm_stalled_watchdog(mod)
+    watchdog = threading.Thread(
+        target=mod._watchdog_loop, name="flush-watchdog", daemon=True
+    )
+    watchdog.start()
+
+    time.sleep(0.4)  # sleep past the 0.1s deadline; the watchdog fires meanwhile
+    assert 1 in exit_calls, "watchdog exit not neutralized in the following test"
+
+    _stop_watchdog(mod, watchdog)
+    assert not watchdog.is_alive()

--- a/tests/test_trace_flush_worker.py
+++ b/tests/test_trace_flush_worker.py
@@ -11,39 +11,10 @@ import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
-
-@pytest.fixture(autouse=True)
-def _join_leaked_flush_watchdog():
-    """Stop any flush-watchdog daemon a test started, before it can leak.
-
-    Several tests run main() (directly or in a thread), which starts the
-    flush-watchdog daemon. If a test ends before that daemon observes
-    shutdown_requested, monkeypatch reverts the flag to False and the orphaned
-    daemon keeps looping until its stall deadline, then calls os._exit(1) —
-    hard-killing a later, unrelated test (the CI-3.10 crash after test_bug314).
-
-    This teardown force-signals shutdown and joins every flush-watchdog thread,
-    independent of the test's own monkeypatch finalizer ordering, then asserts
-    none survived (loud per-test attribution if a leak is ever reintroduced).
-    """
-    yield
-    mod = sys.modules.get("memory.trace_flush_worker")
-    if mod is not None:
-        mod.shutdown_requested = True
-        with contextlib.suppress(Exception):
-            mod._watchdog_wakeup.set()
-    deadline = time.monotonic() + 10
-    for thread in threading.enumerate():
-        if thread.name == "flush-watchdog" and thread.is_alive():
-            thread.join(timeout=max(0.0, deadline - time.monotonic()))
-    leaked = [
-        thread.name
-        for thread in threading.enumerate()
-        if thread.name == "flush-watchdog" and thread.is_alive()
-    ]
-    assert not leaked, f"flush-watchdog daemon leaked past the test: {leaked}"
+# Note: a leaked flush-watchdog daemon can no longer kill the test runner — the
+# session-wide autouse guard in tests/conftest.py neutralizes the watchdog's real
+# os._exit across all modules and asserts no flush-watchdog thread leaks past a
+# test (TD-612). It supersedes the former module-scoped teardown here.
 
 
 def _load_module(tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem

`main`'s Test Suite intermittently fails: a single Unit Tests (Python 3.x) job exits 1 **after every test has passed** — `[100%]` reached, then a bare `Process completed with exit code 1` with no failing test, assertion, or traceback. It is non-deterministic (one Python version at a time) and clears on re-run, which masks genuine failures and erodes trust in the gate.

## Root cause

`trace_flush_worker` starts a daemon thread named `flush-watchdog` that calls the real `os._exit(1)` on a stall, so Docker restarts a wedged worker **in production**. Several worker tests start that daemon via `main()`. The worker module is deleted and re-imported per test, so a daemon that outlives its test can be bound to a **superseded module object** whose globals a module-scoped teardown can no longer signal. That orphaned daemon later reaches its stall deadline and fires `os._exit(1)` in-process — hard-killing an already-green pytest run.

The previous module-scoped guard could not cover this: the victim is a *different* test module, and a stale-bound daemon never observes a shutdown signal sent to the current module generation.

## Fix (test-only)

A session-wide guard in `tests/conftest.py`:

- A **session-scoped** autouse fixture owns `os._exit` continuously for the whole test session (records the call instead of exiting). Because every re-imported module generation shares the one `os` module, an orphaned daemon bound to *any* generation is neutralized — and there is no inter-test gap where the real `os._exit` is live.
- A **per-test** fixture points that recorder at a fresh per-test sink and, after each test, joins every `flush-watchdog` thread and asserts none leaked — so neutralizing the exit never silently hides a thread leak; a leak still fails a test loudly, it just can no longer kill the process.

The old module-scoped guard is removed (now subsumed). New adversarial tests reproduce the stale-bound-module path directly and assert the runner survives.

**No production behavior change** — `src/` is untouched; the watchdog still calls the real `os._exit(1)` on a genuine stall in the container. The recorder exists only within the pytest process.

## Verification

- The watchdog exit-assertion tests still pass (their local `os._exit` patch wins during the test body and is restored to the recorder, never the real `os._exit`).
- 10/10 consecutive clean runs of the CI unit command (`pytest tests/ --ignore=tests/e2e --ignore=tests/integration -m "not quarantine" -p no:randomly`); adversarial isolation tests pass; `black`/`ruff`/`isort` clean.

Closes TD-612.
