### PR TITLE
ci: prebuild embedding image to GHCR to eliminate HuggingFace 429 flake

### DIFF
--- a/.github/workflows/publish-embedding-image.yml
+++ b/.github/workflows/publish-embedding-image.yml
@@ -50,6 +50,7 @@ jobs:
   publish:
     name: Build and push embedding image
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/publish-embedding-image.yml
+++ b/.github/workflows/publish-embedding-image.yml
@@ -1,0 +1,74 @@
+name: Publish embedding image
+
+# TD-626: prebuild the embedding image once and publish it to GHCR so that CI,
+# `docker compose`, and `scripts/install.sh` PULL the image instead of baking the
+# Jina v2 + bm25 models from HuggingFace on every push. The bake downloads the
+# models from HF, which rate-limits (429) shared GitHub-runner egress IPs and
+# flaked the build on both the install and E2E jobs. Running the bake here, once,
+# moves HuggingFace off every consumer's hot path.
+#
+# Tag scheme:
+#   - latest        — moving tag the compose/install path resolves by default
+#   - sha-<short>   — immutable per-commit tag for pinning via EMBEDDING_IMAGE_TAG
+#
+# Note: the image also COPYs application `src/` at build time, but the model bake
+# (the 429 hot path) depends only on docker/embedding/**. Use workflow_dispatch to
+# republish after an unrelated src/ change that needs to reach the image.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - docker/embedding/**
+      - .github/workflows/publish-embedding-image.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/hidden-history/ai-memory-embedding
+
+jobs:
+  publish:
+    name: Build and push embedding image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=sha-,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/embedding/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # HF_TOKEN (optional repo secret) is delivered as a BuildKit secret and
+          # raises the HuggingFace API rate limit during the one-time model bake,
+          # adding defense-in-depth against 429 throttling. Absent secret → the
+          # bake downloads anonymously (Dockerfile guards on a non-empty secret).
+          secrets: |
+            hf_token=${{ secrets.HF_TOKEN }}

--- a/.github/workflows/publish-embedding-image.yml
+++ b/.github/workflows/publish-embedding-image.yml
@@ -11,17 +11,33 @@ name: Publish embedding image
 #   - latest        — moving tag the compose/install path resolves by default
 #   - sha-<short>   — immutable per-commit tag for pinning via EMBEDDING_IMAGE_TAG
 #
-# Note: the image also COPYs application `src/` at build time, but the model bake
-# (the 429 hot path) depends only on docker/embedding/**. Use workflow_dispatch to
-# republish after an unrelated src/ change that needs to reach the image.
+# The image also COPYs application `src/` at build time (docker/embedding/main.py loads
+# memory.metrics from it), so a src/ change can make the published image stale. The
+# transitive imports of memory.metrics are impractical to pin precisely, so the push
+# trigger watches the whole `src/**` subtree. The expensive model-bake layer depends only
+# on docker/embedding/**, so a src-only change republishes cheaply off the type=gha cache
+# without re-hitting HuggingFace.
+#
+# RELEASE GATE — package visibility: GITHUB_TOKEN can push to GHCR but cannot set package
+# visibility. After the FIRST publish, a maintainer must set the `ai-memory-embedding`
+# package to **Public** (GitHub → repo → Packages → the package → Package settings →
+# Change visibility) so anonymous `scripts/install.sh` pulls on operator machines succeed
+# without GHCR auth. Until then, unauthenticated pulls fall back to a local source build
+# (the HuggingFace bake) — functional but slower and 429-exposed. This step is NOT
+# automated here because the workflow token lacks the permission to flip visibility.
 
 on:
   push:
     branches: [main]
     paths:
       - docker/embedding/**
+      - src/**
       - .github/workflows/publish-embedding-image.yml
   workflow_dispatch:
+
+concurrency:
+  group: publish-embedding
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -36,6 +52,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      # QEMU registers binfmt handlers so the amd64 runner can emulate the
+      # linux/arm64 build (Apple-Silicon native image). Required for the multi-arch
+      # build below — setup-buildx-action alone does not provide cross-arch emulation.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -62,6 +84,10 @@ jobs:
           context: .
           file: docker/embedding/Dockerfile
           push: true
+          # Multi-arch so Apple-Silicon (arm64) operators get a native image instead
+          # of an emulated amd64 one. arm64 is built under QEMU emulation on the amd64
+          # runner; the model bake runs once per publish and is type=gha cached.
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -226,6 +226,11 @@ jobs:
       - name: Start Docker services
         working-directory: docker
         run: |
+          # TD-626: pull the prebuilt embedding image from GHCR so the HuggingFace
+          # model bake (429-prone) stays off the E2E hot path. Fall back to a local
+          # source build if the pull fails (image not yet published / not public).
+          echo "Pulling prebuilt embedding image (building from source on miss)..."
+          docker compose pull embedding || docker compose build embedding
           echo "Starting E2E services with docker-compose..."
           docker compose --profile monitoring up -d qdrant embedding prometheus grafana monitoring-api
           echo "Services started. Waiting for health checks..."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,6 +191,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: integration-tests
+    # TD-626: packages:read lets GITHUB_TOKEN pull the same-repo GHCR embedding image
+    # even if the package is private; contents:read is required for checkout (job-level
+    # permissions replace the workflow default, so both must be listed here).
+    permissions:
+      contents: read
+      packages: read
     # Run E2E on main push, or when [e2e] in PR title
     if: |
       github.ref == 'refs/heads/main' ||
@@ -198,6 +204,30 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      # TD-626: when this PR/push changes the embedding image's own sources, the
+      # prebuilt GHCR image is stale against the change under test, so the "Start Docker
+      # services" step builds from source instead of pulling. Watched paths: the
+      # embedding build context, and the only src/ subtree the image loads at runtime
+      # (memory.metrics — imported by docker/embedding/main.py).
+      - name: Detect embedding-relevant changes
+        id: embedding-changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            embedding:
+              - docker/embedding/**
+              - src/memory/metrics**
+
+      # TD-626: authenticate to GHCR so the embedding pull works even if the
+      # ai-memory-embedding package is private. GITHUB_TOKEN carries packages:read for
+      # the same-repo image (see job-level permissions above).
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # Create .env file with dummy credentials for CI
       - name: Create Docker environment file
@@ -226,11 +256,20 @@ jobs:
       - name: Start Docker services
         working-directory: docker
         run: |
-          # TD-626: pull the prebuilt embedding image from GHCR so the HuggingFace
-          # model bake (429-prone) stays off the E2E hot path. Fall back to a local
-          # source build if the pull fails (image not yet published / not public).
-          echo "Pulling prebuilt embedding image (building from source on miss)..."
-          docker compose pull embedding || docker compose build embedding
+          # TD-626: keep the HuggingFace model bake (429-prone) off the E2E hot path by
+          # pulling the prebuilt embedding image from GHCR. Two cases force a local source
+          # build instead: (1) embedding-relevant paths changed, so the published image is
+          # stale against the change under test; (2) the pull fails (image not yet
+          # published, private, or registry down).
+          if [ "${{ steps.embedding-changes.outputs.embedding }}" = "true" ]; then
+            echo "::notice::Embedding-relevant paths changed — building embedding from source so E2E tests the change under review (not a stale prebuilt image)"
+            docker compose build embedding
+          elif docker compose pull embedding; then
+            echo "::notice::Using prebuilt GHCR embedding image (TD-626 active — HuggingFace bake skipped)"
+          else
+            echo "::warning::GHCR pull failed — building embedding from source (HuggingFace 429 risk not mitigated for this run)"
+            docker compose build embedding
+          fi
           echo "Starting E2E services with docker-compose..."
           docker compose --profile monitoring up -d qdrant embedding prometheus grafana monitoring-api
           echo "Services started. Waiting for health checks..."
@@ -317,10 +356,10 @@ jobs:
           import sys
 
           url = 'http://localhost:28080/health'
-          max_attempts = 150  # 300s total (embedding needs model download time)
+          max_attempts = 150  # 300s total — generous buffer for ONNX disk-load + a source-build fallback bake
           delay = 2
 
-          print("Waiting for Embedding service (may take up to 5 minutes for first-time model download)...")
+          print("Waiting for Embedding service (models are baked into the image; loads from disk, no runtime download)...")
           for attempt in range(1, max_attempts + 1):
               try:
                   with urllib.request.urlopen(url, timeout=10) as response:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -218,6 +218,7 @@ jobs:
             embedding:
               - docker/embedding/**
               - src/memory/metrics**
+              - src/memory/__version__**
 
       # TD-626: authenticate to GHCR so the embedding pull works even if the
       # ai-memory-embedding package is private. GITHUB_TOKEN carries packages:read for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **TD-626** — The embedding service image is now prebuilt and published to GHCR
+  (`ghcr.io/hidden-history/ai-memory-embedding`) by a new
+  `publish-embedding-image` workflow, and `docker compose` / `scripts/install.sh`
+  pull it instead of baking the Jina v2 + bm25 models from HuggingFace on every
+  run. The bake downloads the models from HuggingFace, which rate-limits (HTTP
+  429) shared CI-runner egress IPs and intermittently failed both the install and
+  E2E jobs. The compose `embedding` service keeps its `build:` block as a
+  source-build fallback (`pull_policy: missing`), so a registry/cache miss still
+  bakes locally. As defense-in-depth for that fallback bake, an optional
+  `HF_TOKEN` BuildKit secret raises the HuggingFace rate limit, and
+  `huggingface_hub` is pinned to `>=1.2.0` so 429 responses are honored with
+  precise backoff.
+
 ### Fixed
 
 - **BUG-318** — `aim-github-search` now defaults to the `github` Qdrant collection where

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   source-build fallback (`pull_policy: missing`), so a registry/cache miss still
   bakes locally. As defense-in-depth for that fallback bake, an optional
   `HF_TOKEN` BuildKit secret raises the HuggingFace rate limit, and
-  `huggingface_hub` is pinned to `>=1.2.0` so 429 responses are honored with
-  precise backoff.
+  `huggingface_hub` is exact-pinned to `1.18.0` so 429 responses are honored with
+  precise backoff. The published image is multi-arch (`linux/amd64,linux/arm64`) so
+  Apple-Silicon operators get a native image. CI builds the embedding image from
+  source (rather than pulling) when a change touches embedding-relevant paths, so
+  the E2E job always tests the code under review rather than a stale prebuilt image.
+
+  **Operator note:** after the first publish, a maintainer must set the
+  `ai-memory-embedding` GHCR package to **Public** (repo → Packages → Package
+  settings → Change visibility) so anonymous `scripts/install.sh` pulls succeed
+  without authentication; until then those pulls fall back to a local source build.
+  A bare `docker compose up` expects the published image and relies on Compose's
+  build fallback to bake locally if it is absent; the scripted paths
+  (`scripts/install.sh`, CI) make that pull→build fallback explicit.
 
 ### Fixed
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -81,6 +81,15 @@ services:
     build:
       context: ..
       dockerfile: docker/embedding/Dockerfile
+    # TD-626: the builder stage downloads the Jina v2 + bm25 models from HuggingFace,
+    # which rate-limits (429) shared CI-runner egress IPs and flaked the bake on every
+    # push. The image is now prebuilt once and published to GHCR by
+    # .github/workflows/publish-embedding-image.yml. With both image: and build: present
+    # and pull_policy: missing, Compose pulls the prebuilt image and only bakes from
+    # source on a registry/cache miss — keeping HuggingFace off the hot path. Override
+    # EMBEDDING_IMAGE_TAG to pin a specific published tag instead of latest.
+    image: ghcr.io/hidden-history/ai-memory-embedding:${EMBEDDING_IMAGE_TAG:-latest}
+    pull_policy: missing
     container_name: ${AI_MEMORY_CONTAINER_PREFIX:-ai-memory}-embedding
     labels:
       <<: *ai-memory-labels

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -88,6 +88,10 @@ services:
     # and pull_policy: missing, Compose pulls the prebuilt image and only bakes from
     # source on a registry/cache miss — keeping HuggingFace off the hot path. Override
     # EMBEDDING_IMAGE_TAG to pin a specific published tag instead of latest.
+    # A bare `docker compose up` (no script) expects the published GHCR image and relies
+    # on Compose's pull_policy: missing + build: fallback to bake locally if it is absent;
+    # the scripted paths (scripts/install.sh, CI) make that pull→build fallback explicit
+    # and surface which path ran.
     image: ghcr.io/hidden-history/ai-memory-embedding:${EMBEDDING_IMAGE_TAG:-latest}
     pull_policy: missing
     container_name: ${AI_MEMORY_CONTAINER_PREFIX:-ai-memory}-embedding
@@ -117,7 +121,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 15
-      start_period: 300s  # BUG-040: Increased for first-time model download (~500MB per model). Total wait: 300s + 30s*15 = 750s (12.5 min)
+      start_period: 120s  # TD-626: models are baked into the image (no runtime HuggingFace download); this only buffers ONNX disk-load + session init on slow disks. retries:15 @30s gives the real ceiling (450s of attempts after start_period).
     deploy:
       resources:
         limits:

--- a/docker/embedding/Dockerfile
+++ b/docker/embedding/Dockerfile
@@ -29,7 +29,13 @@ RUN pip install --upgrade --no-cache-dir -r requirements.txt
 
 # Pre-download both embedding models at build time (BUG-105)
 # Downloads ~500MB each from HuggingFace. Eliminates runtime download dependency.
-RUN python -c "from fastembed import TextEmbedding; TextEmbedding('jinaai/jina-embeddings-v2-base-en')" && \
+# HF_TOKEN (optional) is mounted as a BuildKit secret so the token never persists
+# in an image layer. An authenticated request raises the HuggingFace API rate
+# limit, reducing the 429 throttling that flaked this bake in CI (TD-626). When no
+# secret is mounted the download proceeds anonymously, exactly as before.
+RUN --mount=type=secret,id=hf_token,required=false \
+    if [ -s /run/secrets/hf_token ]; then export HF_TOKEN="$(cat /run/secrets/hf_token)"; fi && \
+    python -c "from fastembed import TextEmbedding; TextEmbedding('jinaai/jina-embeddings-v2-base-en')" && \
     python -c "from fastembed import TextEmbedding; TextEmbedding('jinaai/jina-embeddings-v2-base-code')" && \
     python -c "from fastembed import SparseTextEmbedding; SparseTextEmbedding('Qdrant/bm25')"
 

--- a/docker/embedding/requirements.txt
+++ b/docker/embedding/requirements.txt
@@ -10,6 +10,11 @@ pydantic-settings==2.13.1
 # FastEmbed - ONNX optimized embeddings (replaces sentence-transformers)
 fastembed==0.7.4
 
+# huggingface_hub >=1.x parses the HuggingFace `RateLimit` response header and
+# backs off precisely on HTTP 429 during the model bake (TD-626 defense-in-depth).
+# fastembed 0.7.4 permits hf-hub >=0.20,<2.0; pin the floor to the rate-aware line.
+huggingface_hub>=1.2.0,<2.0
+
 # HTTP client for health checks
 httpx==0.28.1
 

--- a/docker/embedding/requirements.txt
+++ b/docker/embedding/requirements.txt
@@ -10,10 +10,11 @@ pydantic-settings==2.13.1
 # FastEmbed - ONNX optimized embeddings (replaces sentence-transformers)
 fastembed==0.7.4
 
-# huggingface_hub >=1.x parses the HuggingFace `RateLimit` response header and
-# backs off precisely on HTTP 429 during the model bake (TD-626 defense-in-depth).
-# fastembed 0.7.4 permits hf-hub >=0.20,<2.0; pin the floor to the rate-aware line.
-huggingface_hub>=1.2.0,<2.0
+# huggingface_hub 1.x parses the HuggingFace `RateLimit` response header and backs
+# off precisely on HTTP 429 during the model bake (TD-626 defense-in-depth). fastembed
+# 0.7.4 permits hf-hub >=0.20,<2.0; exact-pinned for reproducible builds (ACT-003) and
+# co-resolves cleanly with fastembed==0.7.4.
+huggingface_hub==1.18.0
 
 # HTTP client for health checks
 httpx==0.28.1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3052,9 +3052,13 @@ start_services() {
     # published image; fall back to a local source build only if the pull fails (offline,
     # or image not yet published). The Phase 1 `pull --ignore-buildable` skips embedding
     # because it still declares a build: block, so the pull is issued explicitly here.
-    if ! _compose pull embedding; then
-        log_warning "GHCR pull of embedding image failed — building from source (HuggingFace model bake)."
-        _compose build embedding
+    if _compose pull embedding; then
+        log_info "Using prebuilt GHCR embedding image (TD-626 — HuggingFace model bake skipped)."
+    else
+        log_warning "GHCR pull of embedding image failed — building from source (HuggingFace model bake; 429 risk not mitigated)."
+        # --no-cache for a reproducible fallback bake, matching the sibling build:
+        # services (qdrant, classifier-worker) above.
+        _compose build --no-cache embedding
     fi
     # BUG-289: --no-recreate prevents Compose from restarting an already-running
     # embedding container mid-install, which would reset model_loaded to False and

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3047,7 +3047,15 @@ start_services() {
     log_info "Phase 1/2: Starting core services (qdrant + embedding)..."
     _compose build --no-cache qdrant
     _compose up -d qdrant
-    _compose build --no-cache embedding
+    # TD-626: embedding is delivered as a prebuilt GHCR image so the HuggingFace model
+    # bake (429-prone under CI-runner load) stays off the install hot path. Pull the
+    # published image; fall back to a local source build only if the pull fails (offline,
+    # or image not yet published). The Phase 1 `pull --ignore-buildable` skips embedding
+    # because it still declares a build: block, so the pull is issued explicitly here.
+    if ! _compose pull embedding; then
+        log_warning "GHCR pull of embedding image failed — building from source (HuggingFace model bake)."
+        _compose build embedding
+    fi
     # BUG-289: --no-recreate prevents Compose from restarting an already-running
     # embedding container mid-install, which would reset model_loaded to False and
     # cause the github-sync depends_on healthcheck gate to briefly fail.


### PR DESCRIPTION
## What

Prebuild the embedding service image once, publish it to GHCR, and have `docker compose`, `scripts/install.sh`, and the E2E CI job **pull** the prebuilt image instead of baking the embedding models from HuggingFace on every run.

- **New workflow** `.github/workflows/publish-embedding-image.yml` builds and pushes `ghcr.io/hidden-history/ai-memory-embedding` on changes to `docker/embedding/**` (and via `workflow_dispatch`), using buildx + GHCR login + `build-push-action` with `type=gha` cache. Tags: `latest` (moving) and `sha-<short>` (immutable, for pinning via `EMBEDDING_IMAGE_TAG`).
- **`docker/docker-compose.yml`** — the `embedding` service now declares `image: ghcr.io/hidden-history/ai-memory-embedding:${EMBEDDING_IMAGE_TAG:-latest}` and `pull_policy: missing` alongside its existing `build:` block, so Compose pulls the prebuilt image and only bakes from source on a registry/cache miss.
- **`scripts/install.sh`** — the core-startup phase now pulls the embedding image (`pull || build`) instead of forcing a `build --no-cache`, so a normal install no longer bakes from HuggingFace.
- **`.github/workflows/test.yml`** — the E2E job pulls the embedding image before `compose up`, falling back to a source build on miss.
- **Defense-in-depth for the fallback bake**: an optional `HF_TOKEN` BuildKit secret raises the HuggingFace rate limit, and `huggingface_hub` is pinned to `>=1.2.0,<2.0` so HTTP 429 responses are honored with precise backoff. `fastembed==0.7.4` co-resolves with this pin (verified).

## Why

The embedding image bake runs `fastembed` model pre-downloads (Jina v2 base-en/base-code + `Qdrant/bm25`) from HuggingFace at build time. HuggingFace rate-limits (HTTP 429) the shared GitHub-runner egress IP under load, and `fastembed`'s shallow built-in retry (3 attempts) cannot ride out a sustained throttle window. The bake then fails on both the **Test Installation** and **E2E** jobs, reddening the gate and blocking merges behind manual re-runs (it cost several extra re-run cycles to ship v2.5.0). Because `compose`/`install.sh` use the docker driver rather than buildx, an `actions/cache`-based fix cannot cover those entrypoints — a prebuilt GHCR image is the only approach that removes HuggingFace from the hot path for **all** of CI, compose, and install.

## Operator preconditions

End-to-end verification (a green publish run + pulls without auth) requires, on the repository:
- an `HF_TOKEN` repository secret (optional; the bake works anonymously without it), and
- the GHCR package `ai-memory-embedding` set to **public** visibility so pulls need no authentication.

Until the image is published and public, every consumer transparently falls back to the local source build (current behavior), so this PR is safe to merge ahead of those steps.

## Verification

- `docker compose config` resolves the `embedding` service with `image:` + `pull_policy: missing` + `build:` fallback.
- Compose-structure unit tests pass (`test_compose_bare_up_topology.py`, `test_compose_qdrant_wiring.py`).
- Full local suite: 4215 passed; the only failures are pre-existing environment/test-isolation artifacts (missing local `streamlit`, ordering-dependent project-discovery/github-config tests that pass in isolation) — unrelated to this change, which touches no Python.
- Post-merge gate: ≥10 consecutive install/E2E runs green without manual re-run.