### PR TITLE
feat(skills): add aim-lore-hygiene per-operator lore-file hygiene skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   build fallback to bake locally if it is absent; the scripted paths
   (`scripts/install.sh`, CI) make that pull→build fallback explicit.
 
+  **Upgrade note (existing installs):** `scripts/install.sh` brings services up
+  with `--no-recreate`, so it will not recreate an already-running `embedding`
+  container — an existing install keeps its previous locally-built image. After
+  updating, run `~/.ai-memory/scripts/stack.sh restart` to recreate services and
+  pull the prebuilt GHCR image. (Fresh installs pull it automatically.)
+
 ### Fixed
 
 - **BUG-318** — `aim-github-search` now defaults to the `github` Qdrant collection where

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hot-file pointer (stale-but-meaningful), or deduped. Markers are anchored in the
   **leading position only** (after the bullet/number prefix, or in the first table
   cell), so prose that merely mentions or ends in a marker token is kept, never
-  pruned; partial strikethrough with live un-struck text is kept. Tables are treated
-  as structural: header/separator rows are never deduped, and a marker-tagged table
-  content row is dropped in place (archived rows still reach the cold tier) so the
-  table stays well-formed and no marker/pipe leaks into the hot file. Read-only
+  pruned; partial strikethrough with live un-struck text is kept. The parser is
+  **structure-aware**: only genuine content entries (bullets, paragraphs, table
+  content rows) are ever classified or deduped. Code fences (the whole block, info
+  string and all), thematic breaks (`---`/`***`/`___`), table header+separator
+  rows, and ambiguous constructs (blockquotes, indented code, raw HTML) are opaque
+  passthrough — copied byte-for-byte, never classified, deduped, or split — so a
+  marker token inside a fence or a tagged table header can never corrupt the file
+  (**keep-when-uncertain** is the safety posture: anything not confidently
+  structural-or-content is kept intact). A marker-tagged table content row is dropped
+  in place (archived rows still reach the cold tier) so the table stays well-formed
+  and no marker/pipe leaks into the hot file. Read-only
   **dry-run by default**; `--apply` writes a timestamped backup first and never
   auto-truncates recall-value content (over-cap files with no mechanical actions are
   flagged for a manual/LLM summarization pass). Built as a thin `SKILL.md` over an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`aim-lore-hygiene` skill** — per-operator hygiene for always-injected sanctum
+  files (`LORE.md`, `MEMORY.md`). Enforces the ~200-line cap, flags files crossing
+  the ~80%-of-cap compaction trigger, and applies the prune-vs-archive decision
+  rule: marker-tagged entries are deleted (superseded/contradicted/expired-TTL/
+  strikethrough), archived to a local cold-tier file with a one-line hot-file
+  pointer (stale-but-meaningful), or deduped. Read-only **dry-run by default**;
+  `--apply` writes a timestamped backup first and never auto-truncates recall-value
+  content (over-cap files with no mechanical actions are flagged for a manual/LLM
+  summarization pass). Built as a thin `SKILL.md` over an external, unit-tested
+  `scripts/lore_hygiene.py` invoked by path (W-07 skills-with-scripts standard).
+  This is FILE-content hygiene, distinct from `aim-purge` (Qdrant-point purging).
+
 ### Changed
 
 - **TD-626** — The embedding service image is now prebuilt and published to GHCR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   files (`LORE.md`, `MEMORY.md`). Enforces the ~200-line cap, flags files crossing
   the ~80%-of-cap compaction trigger, and applies the prune-vs-archive decision
   rule: marker-tagged entries are deleted (superseded/contradicted/expired-TTL/
-  strikethrough), archived to a local cold-tier file with a one-line hot-file
-  pointer (stale-but-meaningful), or deduped. Read-only **dry-run by default**;
-  `--apply` writes a timestamped backup first and never auto-truncates recall-value
-  content (over-cap files with no mechanical actions are flagged for a manual/LLM
-  summarization pass). Built as a thin `SKILL.md` over an external, unit-tested
-  `scripts/lore_hygiene.py` invoked by path (W-07 skills-with-scripts standard).
-  This is FILE-content hygiene, distinct from `aim-purge` (Qdrant-point purging).
+  full-entry strikethrough), archived to a local cold-tier file with a one-line
+  hot-file pointer (stale-but-meaningful), or deduped. Markers are anchored in the
+  **leading position only** (after the bullet/number prefix, or in the first table
+  cell), so prose that merely mentions or ends in a marker token is kept, never
+  pruned; partial strikethrough with live un-struck text is kept. Tables are treated
+  as structural: header/separator rows are never deduped, and a marker-tagged table
+  content row is dropped in place (archived rows still reach the cold tier) so the
+  table stays well-formed and no marker/pipe leaks into the hot file. Read-only
+  **dry-run by default**; `--apply` writes a timestamped backup first and never
+  auto-truncates recall-value content (over-cap files with no mechanical actions are
+  flagged for a manual/LLM summarization pass). Built as a thin `SKILL.md` over an
+  external, unit-tested `scripts/lore_hygiene.py` invoked by path (W-07
+  skills-with-scripts standard). This is FILE-content hygiene, distinct from
+  `aim-purge` (Qdrant-point purging).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ python scripts/health-check.py
 
 After installation, start a new Claude Code session in your project — AI Memory injects relevant context automatically on session resume.
 
+### Upgrading an existing install
+
+After pulling a new version and re-running `./scripts/install.sh /path/to/your-project`, run `~/.ai-memory/scripts/stack.sh restart` to apply container/image changes. The installer brings services up with `--no-recreate` and won't restart already-running containers, so image and compose updates (for example, the prebuilt embedding image) take effect only after a restart.
+
 ---
 
 ## Installation

--- a/_ai-memory/pov/skills/aim-lore-hygiene/SKILL.md
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/SKILL.md
@@ -68,7 +68,9 @@ rewritten**:
 - **Thematic breaks** (`---`, `***`, `___`) and other delimiters — structural, never
   deduped.
 - **Anything else not confidently structural-or-content** (blockquotes, indented code,
-  raw HTML, odd constructs) — **kept opaque**. This is the keep-when-uncertain posture:
+  raw HTML, odd constructs) — **kept opaque**. A raw-HTML block is gathered from its
+  start line to the blank-line terminator (inner lines need not start with `<`), so a
+  multi-line `<div>…</div>` stays whole. This is the keep-when-uncertain posture:
   because the skill mutates the operator's own memory, when it cannot confidently
   classify a block it keeps it intact rather than risk corrupting it.
 
@@ -84,9 +86,10 @@ is low-utility):
   one-line pointer is left in the hot file; for a **table content row** the row is
   dropped in place (the table stays well-formed) and its content still moves to the
   cold tier — no inline pointer is injected into the table body.
-- **Dedup:** exact-duplicate entries are collapsed, keeping the first. Table rows
-  (header, separator, content) are never deduped, so a second same-schema table
-  keeps its header and separator.
+- **Dedup:** exact-duplicate entries **within the same `## section`** are collapsed,
+  keeping the first; identical text under different sections is kept (distinct records).
+  Table rows (header, separator, content) are never deduped, so a second same-schema
+  table keeps its header and separator.
 - **Keep:** everything else.
 
 **Markers must be anchored in the LEADING position.** A marker counts only as a

--- a/_ai-memory/pov/skills/aim-lore-hygiene/SKILL.md
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/SKILL.md
@@ -59,11 +59,27 @@ The script is marker-driven (it never guesses an entry is low-utility):
   `[prune]`, a `[expired:YYYY-MM-DD]` TTL that has passed, or strikethrough
   (`~~...~~`).
 - **Archive (cold tier + pointer):** `[stale]`, `[archive]`.
-- **Dedup:** exact-duplicate entries are collapsed, keeping the first.
+- **Dedup:** exact-duplicate entries are collapsed, keeping the first. Table rows
+  (header, separator, content) are never deduped, so a second same-schema table
+  keeps its header and separator.
 - **Keep:** everything else.
 
-Tag entries with these markers (during a Pulse, or when the operator says "that's
-not right anymore") so the next hygiene pass acts on them safely.
+**Markers must be anchored.** A marker counts only in a dedicated position — as a
+**leading tag** right after the bullet/number prefix (`- [superseded] …`,
+recommended) or as a **trailing tag** at the end of the entry
+(`- … reversed [superseded]`). A marker merely *mentioned in prose* (e.g. an entry
+documenting the marker vocabulary — "Tag an entry `[superseded]` when…") is
+**ignored and kept**, never pruned. Tag entries during a Pulse, or when the
+operator says "that's not right anymore", so the next hygiene pass acts on them
+safely.
+
+## `--cap` on a directory (global override)
+
+Scanning a sanctum dir uses each hot file's own cap (LORE.md/MEMORY.md → 200).
+Passing `--cap N` **overrides every file in that dir with the single value N** — a
+global override, not a per-file map (use it to audit one explicit file, e.g.
+`--cap 300` for a project-root `CLAUDE.md`). `--cap` must be a positive integer.
+Per-file caps when scanning a dir remain a possible future option (not built).
 
 ## References
 

--- a/_ai-memory/pov/skills/aim-lore-hygiene/SKILL.md
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/SKILL.md
@@ -51,9 +51,31 @@ This file decides *when* to run, *which* files, and *how to read the plan*.
    explicit residual flag), and each archived entry should have a one-line pointer
    in the hot file. A second `--apply` on an already-clean file is a no-op.
 
+## What the script acts on (structure-aware, keep-when-uncertain)
+
+The script acts **only on genuine content entries** — bullets, paragraphs, and table
+content rows. It is structure-aware: every structural or ambiguous construct is opaque
+passthrough, copied byte-for-byte and **never classified, deduped, split, or
+rewritten**:
+
+- **Code fences** — the entire block (```` ``` ````/`~~~`, including the info string
+  and everything between the delimiters) is one opaque unit. A marker token *inside* a
+  fence is example text, never an entry; an unterminated fence keeps its remainder
+  opaque.
+- **Tables** — the header row and its `|---|` separator are structural (a tagged
+  header is never classified, so a separator is never orphaned). Only the *content*
+  rows below them are classified.
+- **Thematic breaks** (`---`, `***`, `___`) and other delimiters — structural, never
+  deduped.
+- **Anything else not confidently structural-or-content** (blockquotes, indented code,
+  raw HTML, odd constructs) — **kept opaque**. This is the keep-when-uncertain posture:
+  because the skill mutates the operator's own memory, when it cannot confidently
+  classify a block it keeps it intact rather than risk corrupting it.
+
 ## How entries are classified
 
-The script is marker-driven (it never guesses an entry is low-utility):
+Within genuine content entries, the script is marker-driven (it never guesses an entry
+is low-utility):
 
 - **Prune (delete):** `[superseded]`, `[contradicted]`, `[wrong]`, `[obsolete]`,
   `[prune]`, a `[expired:YYYY-MM-DD]` TTL that has passed, or a full-entry

--- a/_ai-memory/pov/skills/aim-lore-hygiene/SKILL.md
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/SKILL.md
@@ -56,22 +56,32 @@ This file decides *when* to run, *which* files, and *how to read the plan*.
 The script is marker-driven (it never guesses an entry is low-utility):
 
 - **Prune (delete):** `[superseded]`, `[contradicted]`, `[wrong]`, `[obsolete]`,
-  `[prune]`, a `[expired:YYYY-MM-DD]` TTL that has passed, or strikethrough
-  (`~~...~~`).
-- **Archive (cold tier + pointer):** `[stale]`, `[archive]`.
+  `[prune]`, a `[expired:YYYY-MM-DD]` TTL that has passed, or a full-entry
+  strikethrough (a single `~~...~~` span covering all of the entry's content).
+- **Archive (cold tier + pointer):** `[stale]`, `[archive]`. For a non-table entry a
+  one-line pointer is left in the hot file; for a **table content row** the row is
+  dropped in place (the table stays well-formed) and its content still moves to the
+  cold tier — no inline pointer is injected into the table body.
 - **Dedup:** exact-duplicate entries are collapsed, keeping the first. Table rows
   (header, separator, content) are never deduped, so a second same-schema table
   keeps its header and separator.
 - **Keep:** everything else.
 
-**Markers must be anchored.** A marker counts only in a dedicated position — as a
-**leading tag** right after the bullet/number prefix (`- [superseded] …`,
-recommended) or as a **trailing tag** at the end of the entry
-(`- … reversed [superseded]`). A marker merely *mentioned in prose* (e.g. an entry
-documenting the marker vocabulary — "Tag an entry `[superseded]` when…") is
-**ignored and kept**, never pruned. Tag entries during a Pulse, or when the
-operator says "that's not right anymore", so the next hygiene pass acts on them
-safely.
+**Markers must be anchored in the LEADING position.** A marker counts only as a
+**leading tag** — right after the bullet/number prefix (`- [superseded] …`) or in the
+first cell of a table row (`| [superseded] row | … |`). A marker merely *mentioned in
+prose* ("Tag an entry `[superseded]` when…") **or one that merely ends a line of
+prose** ("a fact retired at end of life `[obsolete]`") is **ignored and kept**, never
+pruned. (Trailing-tag anchoring was removed in cycle-2 — it pruned prose ending in a
+marker token; leading-only is the single, unambiguous, data-safe convention.) Tag
+entries during a Pulse, or when the operator says "that's not right anymore", so the
+next hygiene pass acts on them safely.
+
+> **Crash-rerun note (TGT-2).** Cold-tier appends are deduplicated by exact block
+> string. A same-day crash-rerun (hot file not yet rewritten) is fully idempotent. A
+> *cross-day* crash-rerun writes a second, differently-dated archive block for the
+> same content — accepted behavior that preserves a per-day audit trail and never
+> loses content.
 
 ## `--cap` on a directory (global override)
 

--- a/_ai-memory/pov/skills/aim-lore-hygiene/SKILL.md
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: aim-lore-hygiene
+description: Enforce hygiene on per-operator sanctum LORE/MEMORY files — line-cap
+  enforcement, anchored-summarization compaction at ~80% of cap, and the
+  prune-vs-archive decision. Use when a sanctum file approaches its size cap, on a
+  scheduled hygiene pass, or when the operator asks to compact or prune lore.
+allowed-tools: Bash, Read
+---
+
+# aim-lore-hygiene — Per-Operator Lore File Hygiene
+
+Compacts always-injected sanctum files (LORE.md, MEMORY.md) under the BP-159
+~200-line cap so rules don't "get lost in the noise" and adherence stays high.
+**FILE-content compaction only** — NOT Qdrant-point purging by age (that is
+`aim-purge`, a different domain — PLAN-028 P0-3).
+
+The deterministic mechanics (line-counting, marker classification, structural
+compaction, archiving) live in `scripts/lore_hygiene.py`, invoked **by path**.
+This file decides *when* to run, *which* files, and *how to read the plan*.
+
+## When to use
+
+- A sanctum file crosses ~80% of its cap (160/200 lines — the compaction trigger).
+- A scheduled hygiene pass (session-stop hook or cron).
+- The operator asks to prune or compact lore, or flags a stale/wrong entry.
+
+## Steps
+
+1. Resolve the sanctum path: `{project-root}/_ai-memory/sanctum/{agent_id}/`.
+   Confirm it contains `LORE.md` and/or `MEMORY.md`.
+
+2. **Dry-run audit (DEFAULT — never mutates):**
+   `python3 scripts/lore_hygiene.py <sanctum-path>`
+   Reports per file: line count, % of cap, and the proposed prune / archive /
+   dedup actions with a projected post-compaction line count.
+
+3. **Review the plan** — the verifiable intermediate output. Confirm prunes are
+   genuinely superseded/contradicted, archives are stale-but-meaningful, and the
+   projected count lands at or under cap. If the plan reports a residual over-cap,
+   a manual/LLM semantic-summarization pass is needed (the script will not
+   auto-truncate recall-value content).
+
+4. **Apply only after review:**
+   `python3 scripts/lore_hygiene.py <sanctum-path> --apply`
+   Each mutated file gets a timestamped `.bak` sidecar first; archived entries
+   move to `references/lore-archive/<FILE>.archive.md` with a one-line pointer
+   left in the hot file. Add `--qdrant --group-id <project>` to also push archived
+   entries to the Qdrant cold tier (best-effort, opt-in).
+
+5. **Verify:** re-run the dry-run audit. Every file should be ≤ cap (or carry an
+   explicit residual flag), and each archived entry should have a one-line pointer
+   in the hot file. A second `--apply` on an already-clean file is a no-op.
+
+## How entries are classified
+
+The script is marker-driven (it never guesses an entry is low-utility):
+
+- **Prune (delete):** `[superseded]`, `[contradicted]`, `[wrong]`, `[obsolete]`,
+  `[prune]`, a `[expired:YYYY-MM-DD]` TTL that has passed, or strikethrough
+  (`~~...~~`).
+- **Archive (cold tier + pointer):** `[stale]`, `[archive]`.
+- **Dedup:** exact-duplicate entries are collapsed, keeping the first.
+- **Keep:** everything else.
+
+Tag entries with these markers (during a Pulse, or when the operator says "that's
+not right anymore") so the next hygiene pass acts on them safely.
+
+## References
+
+- Per-file caps, the ~80% trigger, and the LORE section schema: `references/caps.md`
+- The prune-vs-archive decision rule (BP-159 §6): `references/decision-rule.md`

--- a/_ai-memory/pov/skills/aim-lore-hygiene/references/caps.md
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/references/caps.md
@@ -1,0 +1,50 @@
+# Per-file caps, the compaction trigger, and the LORE section schema
+
+Source of truth: BP-159 (per-operator lore-file hygiene) and BP-165 (this skill's
+architecture). This file is loaded on demand — keep SKILL.md lean.
+
+## Caps
+
+| File | Cap | Rationale |
+|------|-----|-----------|
+| `LORE.md` | 200 lines | BP-159 §2 — always-injected; models follow ~150–200 distinct instructions; the harness consumes ~50 slots. |
+| `MEMORY.md` | 200 lines | BP-159 §2 + Claude Code's undocumented 200-line hard limit (claude-code #25006): content past line 200 is silently truncated and never loaded. |
+| `CLAUDE.md` | 300 lines | BP-165 DELTA-2 — companion cap for project-root rules. Lives at the project root, not the sanctum, so it is **not** scanned by default; pass it explicitly with `--cap 300`. |
+
+The cap counts the **whole file**, frontmatter included — the harness loads the
+first N lines regardless of what they contain.
+
+## Compaction trigger — ~80% of cap
+
+Compaction is triggered at **80% of the cap** (160/200 lines), set by the
+`COMPACT_AT = 0.80` constant. BP-165 DELTA-1: 2026 sources put Claude Code's
+auto-compaction at 83.5% with proactive `/compact` recommended in the 70–90% band
+and context rot observable from ~70%; 0.80 sits safely inside that band.
+
+A file is **actionable** when it is at/over the trigger **or** contains any
+prune/archive marker or duplicate — so a small file with a `[contradicted]` entry
+is still cleaned (correctness), while a clean under-trigger file is left untouched
+(idempotent no-op).
+
+## Anchored summarization — the section schema
+
+Compaction is *anchored* on the shipped `LORE-template.md` section schema, so the
+document's shape is preserved while entries within each section are pruned,
+archived, or deduped:
+
+- **System Architecture**
+- **Key Design Decisions**
+- **Patterns & Conventions**
+- **Things Learned the Hard Way**
+
+`MEMORY.md` is anchored on its own schema (Recent Sessions / Pending Items /
+Insights to Carry). The script never moves an entry across sections and never
+rewrites prose — genuinely semantic summarization (saying the same thing in fewer
+words) is surfaced as a residual-over-cap flag for a human/LLM pass, never
+auto-truncated (the "memory blindness" guard, BP-159 §6).
+
+## Treat the hot file as a curated index, not a log
+
+The hot file should hold identity, durable preferences, and **one-line index
+entries** that point to detail living in the cold tier (`references/lore-archive/`
+or Qdrant). This is the same index-not-log discipline `MEMORY.md` already follows.

--- a/_ai-memory/pov/skills/aim-lore-hygiene/references/decision-rule.md
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/references/decision-rule.md
@@ -17,6 +17,24 @@ The load-bearing distinction in lore hygiene. Two failure modes bound it:
 | Exact duplicate of an earlier entry | **Dedup** (keep the first) | (detected automatically) |
 | High retrieval frequency + still accurate | **Keep** | (no marker) |
 
+## Markers are matched only in an anchored position
+
+A marker classifies an entry **only** when it sits in a dedicated tag position, so
+that an entry which merely *talks about* a marker is never self-destructively pruned:
+
+- **Leading tag** (recommended): immediately after the bullet/number prefix, or the
+  first cell of a table row — `- [superseded] Old belief…`, `| [superseded] row | … |`.
+- **Trailing tag**: at the very end of the entry — `- A belief that was reversed [superseded]`.
+
+A marker appearing **mid-prose** — e.g. an entry documenting the vocabulary itself,
+"Tag an entry `[superseded]` when it is no longer accurate" — is **not** in either
+zone and is therefore **kept**. (Strikethrough `~~…~~` is anchored by definition: it
+wraps the whole entry. `[expired:YYYY-MM-DD]` follows the same leading/trailing rule.)
+
+**Table structural rows are never deduped.** Header and separator (`|---|`) rows are
+preserved, so a second table sharing a column schema keeps its own header and
+separator instead of having them collapsed away as "duplicates".
+
 Two invariants from BP-159 §6:
 
 - **Never silently delete anything with recall value** — archive it. Archive moves

--- a/_ai-memory/pov/skills/aim-lore-hygiene/references/decision-rule.md
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/references/decision-rule.md
@@ -17,23 +17,36 @@ The load-bearing distinction in lore hygiene. Two failure modes bound it:
 | Exact duplicate of an earlier entry | **Dedup** (keep the first) | (detected automatically) |
 | High retrieval frequency + still accurate | **Keep** | (no marker) |
 
-## Markers are matched only in an anchored position
+## Markers are matched only in the LEADING position
 
-A marker classifies an entry **only** when it sits in a dedicated tag position, so
-that an entry which merely *talks about* a marker is never self-destructively pruned:
+A marker classifies an entry **only** when it sits in the single dedicated **leading**
+tag position, so that an entry which merely *talks about* a marker — or merely *ends*
+in one — is never self-destructively pruned:
 
-- **Leading tag** (recommended): immediately after the bullet/number prefix, or the
-  first cell of a table row — `- [superseded] Old belief…`, `| [superseded] row | … |`.
-- **Trailing tag**: at the very end of the entry — `- A belief that was reversed [superseded]`.
+- **Leading tag**: immediately after the bullet/number prefix, or in the first cell
+  of a table row — `- [superseded] Old belief…`, `| [superseded] row | … |`.
 
-A marker appearing **mid-prose** — e.g. an entry documenting the vocabulary itself,
-"Tag an entry `[superseded]` when it is no longer accurate" — is **not** in either
-zone and is therefore **kept**. (Strikethrough `~~…~~` is anchored by definition: it
-wraps the whole entry. `[expired:YYYY-MM-DD]` follows the same leading/trailing rule.)
+A marker appearing **anywhere else** — mid-prose ("Tag an entry `[superseded]` when it
+is no longer accurate") or at the **trailing** end of a line ("A fact retired at end of
+life `[obsolete]`") — is **not** in the leading zone and is therefore **kept**.
+(Strikethrough `~~…~~` is anchored by definition only when a *single* span covers the
+entire entry content; an entry with live un-struck text between spans is kept.
+`[expired:YYYY-MM-DD]` follows the same leading-only rule.)
+
+> **Leading-only (cycle-2).** Earlier drafts also honored a *trailing* tag. That was
+> dropped: it pruned prose that happened to end in a marker token, silently missed a
+> trailing tag on a multi-line entry's first line, and missed trailing punctuation.
+> A single leading convention is unambiguous and data-safe. Place every classification
+> tag at the start of the entry.
 
 **Table structural rows are never deduped.** Header and separator (`|---|`) rows are
 preserved, so a second table sharing a column schema keeps its own header and
 separator instead of having them collapsed away as "duplicates".
+
+**Archiving a tagged table row.** A `[stale]`/`[archive]` (or `[prune]`) tag in a
+table content row drops that row **in place** so the table stays well-formed; for
+archive, the full row content still moves to the cold tier. No inline pointer bullet
+is injected into a table body (that would corrupt the table and leak the row's pipes).
 
 Two invariants from BP-159 §6:
 

--- a/_ai-memory/pov/skills/aim-lore-hygiene/references/decision-rule.md
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/references/decision-rule.md
@@ -1,0 +1,47 @@
+# Prune vs. archive — the decision rule (BP-159 §6)
+
+The load-bearing distinction in lore hygiene. Two failure modes bound it:
+
+- **Over-archiving → "memory blindness":** the agent doesn't know a critical fact
+  exists in cold storage, so it never retrieves it.
+- **Over-retention → context bloat:** degraded adherence and token cost.
+
+## The rule
+
+| Condition | Action | Marker the script reads |
+|-----------|--------|-------------------------|
+| Superseded, contradicted, or proven wrong | **Delete** | `[superseded]`, `[contradicted]`, `[wrong]`, `[obsolete]`, or `~~strikethrough~~` |
+| Low utility: declared no-longer-useful, ephemeral | **Delete** | `[prune]` |
+| Time-bound and expired | **Delete** (it was a TTL entry) | `[expired:YYYY-MM-DD]` past today |
+| Stale-but-historically-meaningful; detail behind an index line | **Archive** to cold tier, keep a one-line pointer | `[stale]`, `[archive]` |
+| Exact duplicate of an earlier entry | **Dedup** (keep the first) | (detected automatically) |
+| High retrieval frequency + still accurate | **Keep** | (no marker) |
+
+Two invariants from BP-159 §6:
+
+- **Never silently delete anything with recall value** — archive it. Archive moves
+  the full entry to `references/lore-archive/<FILE>.archive.md` (the cold tier) and
+  leaves a dated one-line pointer in the hot file.
+- **Never keep anything contradicted** — deleting wrong memory is more valuable than
+  keeping it, because confidently-wrong high-relevance memory is the worst failure
+  mode.
+
+## Why marker-driven, not heuristic
+
+BP-159 §5 prescribes utility = f(recency, retrieval frequency, operator priority)
+with LRU + temporal decay. Those signals require retrieval telemetry this skill
+cannot see. Rather than **guess** that an entry is low-utility (which risks
+memory-blindness), the script acts only on **explicit markers**: the operator, a
+Pulse pass, or an upstream LLM tags entries, and this deterministic core executes
+the tagged decisions safely. The agent-invokable "forget" path (BP-165 DELTA-3) is
+the manual trigger that adds a `[superseded]`/`[stale]` marker when the operator
+says "that's not right anymore."
+
+## The cold tier
+
+BP-159 §3 allows the cold tier to be **a vector DB OR sharded files**. This skill
+uses local archive files as the always-available, testable cold tier. The optional
+`--qdrant --group-id <project>` flag additionally pushes archived blocks to the
+Qdrant `discussions` collection via the runtime `memory.storage.store_agent_memory`
+import path (the same path bootstrap/sanctum-init use), degrading gracefully to the
+local-file-only behavior when the runtime or Qdrant is unavailable.

--- a/_ai-memory/pov/skills/aim-lore-hygiene/references/decision-rule.md
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/references/decision-rule.md
@@ -14,7 +14,7 @@ The load-bearing distinction in lore hygiene. Two failure modes bound it:
 | Low utility: declared no-longer-useful, ephemeral | **Delete** | `[prune]` |
 | Time-bound and expired | **Delete** (it was a TTL entry) | `[expired:YYYY-MM-DD]` past today |
 | Stale-but-historically-meaningful; detail behind an index line | **Archive** to cold tier, keep a one-line pointer | `[stale]`, `[archive]` |
-| Exact duplicate of an earlier entry | **Dedup** (keep the first) | (detected automatically) |
+| Exact duplicate of an earlier entry **in the same section** | **Dedup** (keep the first) | (detected automatically) |
 | High retrieval frequency + still accurate | **Keep** | (no marker) |
 
 ## Markers are matched only in the LEADING position
@@ -59,10 +59,17 @@ identify as *either* a known structural construct *or* a genuine content entry �
 blockquotes (`>`), indented code, raw HTML, nested/odd constructs — is emitted as an
 opaque **keep**. It is never pruned, archived, deduped, or rewritten. Because this skill
 mutates the operator's *own* memory under `--apply`, data-safety beats cleverness: when
-in doubt, keep the block intact.
+in doubt, keep the block intact. A **raw-HTML block** is gathered from its start line to
+the **blank-line terminator** (CommonMark HTML block type 6/7) as one opaque unit — its
+inner lines need not start with `<`, so a `<div>` / inner content / `</div>` block is
+kept whole and inner content can never leak out to be classified; a block running to EOF
+with no trailing blank keeps its remainder opaque.
 
-**Table structural rows are never deduped.** Header and separator (`|---|`) rows are
-preserved, so a second table sharing a column schema keeps its own header and
+**Dedup is section-scoped.** Exact-duplicate collapse (keep-first) acts only within a
+single `## section`: two genuinely distinct entries with identical text under *different*
+sections are both kept, because across-section identical lines are legitimately distinct
+records. **Table structural rows are never deduped.** Header and separator (`|---|`) rows
+are preserved, so a second table sharing a column schema keeps its own header and
 separator instead of having them collapsed away as "duplicates".
 
 **Archiving a tagged table row.** A `[stale]`/`[archive]` (or `[prune]`) tag in a

--- a/_ai-memory/pov/skills/aim-lore-hygiene/references/decision-rule.md
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/references/decision-rule.md
@@ -39,6 +39,28 @@ entire entry content; an entry with live un-struck text between spans is kept.
 > A single leading convention is unambiguous and data-safe. Place every classification
 > tag at the start of the entry.
 
+## The rule acts only on genuine content entries (structure-aware)
+
+The decision rule above is applied **only to genuine content entries** — bullets,
+paragraphs, and table content rows. The parser is structure-aware: every structural or
+ambiguous construct is opaque passthrough, copied byte-for-byte and **never classified,
+deduped, split, or rewritten**:
+
+- **Code fences** (```` ``` ````/`~~~`, info string included) — the whole block is one
+  opaque unit. A `[prune]`/`~~…~~`/marker token *inside* a fence is example text, not an
+  entry, and is kept. An unterminated fence keeps its remainder opaque.
+- **Table header + separator** rows are structural — a tagged header is never classified
+  (so a `|---|` separator is never orphaned). Only the content rows below are classified.
+- **Thematic breaks** (`---`, `***`, `___`) are structural delimiters, never deduped.
+- **Frontmatter** is split off and preserved verbatim.
+
+**Keep-when-uncertain (the safety posture).** Anything the parser cannot confidently
+identify as *either* a known structural construct *or* a genuine content entry —
+blockquotes (`>`), indented code, raw HTML, nested/odd constructs — is emitted as an
+opaque **keep**. It is never pruned, archived, deduped, or rewritten. Because this skill
+mutates the operator's *own* memory under `--apply`, data-safety beats cleverness: when
+in doubt, keep the block intact.
+
 **Table structural rows are never deduped.** Header and separator (`|---|`) rows are
 preserved, so a second table sharing a column schema keeps its own header and
 separator instead of having them collapsed away as "duplicates".

--- a/_ai-memory/pov/skills/aim-lore-hygiene/scripts/lore_hygiene.py
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/scripts/lore_hygiene.py
@@ -1,0 +1,558 @@
+#!/usr/bin/env python3
+"""Per-operator sanctum lore-file hygiene — cap enforcement, anchored compaction,
+and the prune-vs-archive decision rule (BP-159 / BP-165).
+
+FILE-content hygiene for always-injected sanctum files (LORE.md, MEMORY.md): keep
+each under the ~200-line cap so rules don't "get lost in the noise" and adherence
+stays high. This is NOT Qdrant-point purging by age — that is ``aim-purge``, a
+separate domain (PLAN-028 P0-3).
+
+Design (W-07 skills-with-scripts): this is the deterministic, fragile core invoked
+BY PATH from SKILL.md. The model orchestrates (which files, what order, how to read
+the plan); this script does the exact line-counting, marker-classification, and
+structural compaction. Anything genuinely semantic (rewriting prose to fewer words)
+is surfaced as a FLAG for a human/LLM pass — the script never silently truncates
+recall-value content (the "memory blindness" guard, BP-159 §6).
+
+Safety:
+- ``--dry-run`` is the DEFAULT. Without ``--apply`` nothing is ever written.
+- ``--apply`` writes a timestamped ``.bak`` sidecar before mutating each file.
+- Archived entries move to a local cold-tier file and leave a one-line pointer in
+  the hot file. Nothing with recall value is deleted without being archived first.
+
+Usage:
+    # Dry-run audit of a sanctum dir (DEFAULT — never mutates):
+    python3 lore_hygiene.py <sanctum-path>
+
+    # Apply the plan after reviewing it:
+    python3 lore_hygiene.py <sanctum-path> --apply
+
+    # Audit a single file with an explicit cap:
+    python3 lore_hygiene.py <sanctum-path>/LORE.md --cap 200
+
+    # Also push archived entries to the Qdrant cold tier (best-effort, opt-in):
+    python3 lore_hygiene.py <sanctum-path> --apply --qdrant --group-id <project>
+"""
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+
+# --- Constants (no voodoo: every value carries its BP-159/BP-165 rationale) ---
+
+# BP-159 §2: always-injected instruction/memory files standardize on a ~200-line
+# ceiling — models reliably follow ~150-200 distinct instructions and Claude Code's
+# MEMORY.md silently truncates past line 200 (claude-code #25006).
+CAP_LINES = 200
+
+# BP-165 DELTA-1: compact when a file crosses ~80% of its cap. 2026 sources put
+# Claude Code auto-compaction at 83.5% with proactive /compact recommended 70-90%;
+# 0.80 sits safely inside that band. At CAP_LINES=200 the trigger is 160 lines.
+COMPACT_AT = 0.80
+
+# Sanctum hot files this skill curates by default and their caps. LORE/MEMORY use
+# the 200-line family cap. CLAUDE.md (BP-165 DELTA-2, 300-line companion cap) lives
+# at project root, not the sanctum, so it is not scanned by default — pass it
+# explicitly with --cap 300 if desired.
+HOT_FILE_CAPS = {"LORE.md": CAP_LINES, "MEMORY.md": CAP_LINES}
+
+# BP-159 §6 prune-vs-archive decision rule, expressed as explicit inline markers.
+# Marker-driven classification is the deterministic, safe subset: utility/LRU
+# scoring needs retrieval telemetry the script cannot see, so we never GUESS that
+# an entry is low-utility — the operator (or an upstream LLM pass) tags it.
+# PRUNE = delete: superseded / contradicted / proven-wrong / expired TTL.
+PRUNE_MARKERS = ("[superseded]", "[contradicted]", "[wrong]", "[obsolete]", "[prune]")
+# ARCHIVE = move to cold tier + leave a pointer: stale-but-historically-meaningful.
+ARCHIVE_MARKERS = ("[stale]", "[archive]")
+# [expired:YYYY-MM-DD] is a TTL entry — delete once the date has passed (BP-159 §6).
+EXPIRY_RE = re.compile(r"\[expired:(\d{4}-\d{2}-\d{2})\]")
+
+# Cold-tier archive location (BP-159 §3: cold tier may be a vector DB OR sharded
+# files). Local archive files are the always-available, testable cold tier; the
+# optional --qdrant push layers the vector tier on top.
+ARCHIVE_SUBDIR = "references/lore-archive"
+
+# Truncation length for the one-line hot-file pointer left behind on archive.
+POINTER_SUMMARY_CHARS = 80
+
+
+@dataclass
+class EntryAction:
+    """One classified entry and what should happen to it."""
+
+    text: str  # full entry text (may be multi-line)
+    section: str  # owning "## section" header, or "" for preamble
+    action: str  # "keep" | "prune" | "archive" | "dedup"
+    reason: str  # human-readable justification for the plan
+
+
+@dataclass
+class FilePlan:
+    """The compaction plan for a single file — pure data, no I/O performed."""
+
+    filename: str
+    cap: int
+    original_lines: int
+    new_text: str
+    archived_blocks: list[str] = field(default_factory=list)
+    actions: list[EntryAction] = field(default_factory=list)
+
+    @property
+    def trigger(self) -> int:
+        return int(self.cap * COMPACT_AT)
+
+    @property
+    def projected_lines(self) -> int:
+        return len(self.new_text.splitlines())
+
+    @property
+    def over_cap(self) -> bool:
+        return self.original_lines > self.cap
+
+    @property
+    def over_trigger(self) -> bool:
+        return self.original_lines >= self.trigger
+
+    @property
+    def counts(self) -> dict[str, int]:
+        out = {"prune": 0, "archive": 0, "dedup": 0}
+        for a in self.actions:
+            if a.action in out:
+                out[a.action] += 1
+        return out
+
+    @property
+    def has_changes(self) -> bool:
+        return any(a.action != "keep" for a in self.actions)
+
+    @property
+    def residual_over_cap(self) -> int:
+        """Lines still over cap after mechanical compaction (needs a semantic pass)."""
+        return max(0, self.projected_lines - self.cap)
+
+
+def split_frontmatter(text: str) -> tuple[list[str], list[str]]:
+    """Return (frontmatter_lines, body_lines). Frontmatter is preserved verbatim."""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return [], lines
+    for idx in range(1, len(lines)):
+        if lines[idx].strip() == "---":
+            return lines[: idx + 1], lines[idx + 1 :]
+    # Unterminated fence — treat the whole file as body rather than guessing.
+    return [], lines
+
+
+def is_bullet(line: str) -> bool:
+    return bool(re.match(r"\s*([-*]|\d+\.)\s+", line))
+
+
+def is_table_row(line: str) -> bool:
+    return line.lstrip().startswith("|")
+
+
+def is_pointer(line: str) -> bool:
+    """A pointer we previously left behind — never re-process it (idempotency)."""
+    return "_[archived " in line and "→" in line
+
+
+def parse_entries(body_lines: list[str]) -> list[tuple[str, str]]:
+    """Group body lines into (section, entry_text) units.
+
+    An entry is: a bullet (plus indented continuation lines), a table row, or a
+    contiguous paragraph. Headers and blank lines are structural separators, not
+    entries, and are emitted as their own ("__section__"/"__blank__"/"__header__")
+    units so reassembly can preserve document shape.
+    """
+    entries: list[tuple[str, str]] = []
+    section = ""
+    i = 0
+    n = len(body_lines)
+    while i < n:
+        line = body_lines[i]
+        stripped = line.strip()
+        if not stripped:
+            entries.append(("__blank__", ""))
+            i += 1
+            continue
+        if stripped.startswith("#"):
+            if stripped.startswith("## "):
+                section = stripped
+            entries.append(("__header__", line))
+            i += 1
+            continue
+        if is_bullet(line):
+            block = [line]
+            i += 1
+            # Absorb indented continuation lines belonging to this bullet.
+            while (
+                i < n
+                and body_lines[i].strip()
+                and body_lines[i].startswith((" ", "\t"))
+            ):
+                block.append(body_lines[i])
+                i += 1
+            entries.append((section, "\n".join(block)))
+            continue
+        if is_table_row(line):
+            entries.append((section, line))
+            i += 1
+            continue
+        # Paragraph: contiguous non-blank, non-bullet, non-header, non-table lines.
+        block = [line]
+        i += 1
+        while i < n:
+            nxt = body_lines[i]
+            if (
+                not nxt.strip()
+                or nxt.strip().startswith("#")
+                or is_bullet(nxt)
+                or is_table_row(nxt)
+            ):
+                break
+            block.append(nxt)
+            i += 1
+        entries.append((section, "\n".join(block)))
+    return entries
+
+
+def is_table_separator(text: str) -> bool:
+    """A markdown table header separator row like ``|---|---|`` — never an entry."""
+    return bool(re.fullmatch(r"\s*\|[\s:|-]+\|?\s*", text))
+
+
+def classify(text: str, today: date) -> tuple[str, str]:
+    """Apply the BP-159 §6 decision rule to one entry. Returns (action, reason)."""
+    lowered = text.lower()
+
+    for marker in PRUNE_MARKERS:
+        if marker in lowered:
+            return "prune", f"contains {marker} — superseded/contradicted/low-utility"
+
+    # GFM strikethrough across the whole entry content = struck-out / superseded.
+    stripped = re.sub(r"^\s*([-*]|\d+\.)\s+", "", text.strip())
+    if stripped.startswith("~~") and stripped.rstrip().endswith("~~"):
+        return "prune", "struck-out (~~...~~) — superseded"
+
+    m = EXPIRY_RE.search(lowered)
+    if m:
+        try:
+            when = date.fromisoformat(m.group(1))
+        except ValueError:
+            when = None
+        if when and when < today:
+            return "prune", f"TTL expired on {m.group(1)}"
+
+    for marker in ARCHIVE_MARKERS:
+        if marker in lowered:
+            return (
+                "archive",
+                f"contains {marker} — stale-but-meaningful, archived to cold tier",
+            )
+
+    return "keep", ""
+
+
+def normalize(text: str) -> str:
+    """Whitespace-insensitive key for duplicate detection."""
+    return re.sub(r"\s+", " ", text.strip()).lower()
+
+
+def pointer_for(text: str, today: date, archive_relpath: str) -> str:
+    """One-line hot-file pointer left where an archived entry used to be."""
+    body = re.sub(r"^\s*([-*]|\d+\.)\s+", "", text.strip().splitlines()[0]).strip()
+    if len(body) > POINTER_SUMMARY_CHARS:
+        body = body[:POINTER_SUMMARY_CHARS].rstrip() + "…"
+    return f"- _[archived {today.isoformat()}]_ {body} → {archive_relpath}"
+
+
+def collapse_blanks(lines: list[str]) -> list[str]:
+    """Collapse runs of >1 blank line into a single blank line."""
+    out: list[str] = []
+    for line in lines:
+        if not line.strip() and out and not out[-1].strip():
+            continue
+        out.append(line)
+    # Trim trailing blanks.
+    while out and not out[-1].strip():
+        out.pop()
+    return out
+
+
+def plan_file(text: str, filename: str, cap: int, today: date) -> FilePlan:
+    """Compute the compaction plan for one file's text. Pure — performs no I/O."""
+    original_lines = len(text.splitlines())
+    frontmatter, body_lines = split_frontmatter(text)
+    units = parse_entries(body_lines)
+
+    archive_relpath = f"{ARCHIVE_SUBDIR}/{Path(filename).stem}.archive.md"
+    actions: list[EntryAction] = []
+    archived_blocks: list[str] = []
+    seen: set[str] = set()
+    out_body: list[str] = []
+
+    for section, unit in units:
+        if section in ("__blank__", "__header__"):
+            out_body.append(unit)
+            continue
+
+        # Never re-process a pointer we left on a prior run (idempotency) or a
+        # table separator row (structural, not content).
+        if is_pointer(unit) or is_table_separator(unit):
+            out_body.append(unit)
+            continue
+
+        action, reason = classify(unit, today)
+
+        if action == "prune":
+            actions.append(EntryAction(unit, section, "prune", reason))
+            continue
+
+        if action == "archive":
+            actions.append(EntryAction(unit, section, "archive", reason))
+            sec_label = section.lstrip("# ").strip() or "(preamble)"
+            archived_blocks.append(
+                f"## [{today.isoformat()}] archived from {filename} — {sec_label}\n\n{unit}\n"
+            )
+            out_body.append(pointer_for(unit, today, archive_relpath))
+            continue
+
+        # keep — but drop exact duplicates (BP-159 §7 dedup), keeping the first.
+        key = normalize(unit)
+        if key in seen:
+            actions.append(
+                EntryAction(unit, section, "dedup", "duplicate of an earlier entry")
+            )
+            continue
+        seen.add(key)
+        actions.append(EntryAction(unit, section, "keep", ""))
+        out_body.append(unit)
+
+    body = collapse_blanks(out_body)
+    new_text = "\n".join(frontmatter + body)
+    if new_text and not new_text.endswith("\n"):
+        new_text += "\n"
+
+    return FilePlan(
+        filename=filename,
+        cap=cap,
+        original_lines=original_lines,
+        new_text=new_text,
+        archived_blocks=archived_blocks,
+        actions=actions,
+    )
+
+
+def resolve_targets(path: Path) -> list[tuple[Path, int]]:
+    """Resolve the CLI path to a list of (file, cap) targets."""
+    if path.is_file():
+        return [(path, HOT_FILE_CAPS.get(path.name, CAP_LINES))]
+    if path.is_dir():
+        targets = []
+        for name, cap in HOT_FILE_CAPS.items():
+            candidate = path / name
+            if candidate.is_file():
+                targets.append((candidate, cap))
+        return targets
+    return []
+
+
+def print_plan(plan: FilePlan) -> None:
+    pct = round(100 * plan.original_lines / plan.cap)
+    status = (
+        "OVER CAP"
+        if plan.over_cap
+        else ("over trigger" if plan.over_trigger else "under trigger")
+    )
+    print(f"\n{plan.filename}")
+    print(
+        f"  {plan.original_lines}/{plan.cap} lines ({pct}% — {status}; "
+        f"compaction trigger {plan.trigger} = {int(COMPACT_AT * 100)}%)"
+    )
+    if not plan.has_changes:
+        if plan.over_cap:
+            print(
+                f"  actions: none available mechanically — STILL {plan.residual_over_cap} "
+                f"over cap; needs a manual/LLM semantic-summarization pass "
+                f"(no auto-truncation)"
+            )
+        else:
+            print("  actions: none (clean, no-op)")
+        return
+    c = plan.counts
+    print(
+        f"  actions: prune {c['prune']} · archive {c['archive']} · dedup {c['dedup']}"
+    )
+    for a in plan.actions:
+        if a.action == "keep":
+            continue
+        first = a.text.strip().splitlines()[0]
+        if len(first) > 70:
+            first = first[:70].rstrip() + "…"
+        print(f"    [{a.action}] {first}   ({a.reason})")
+    print(f"  projected: {plan.projected_lines} lines", end="")
+    if plan.residual_over_cap:
+        print(
+            f"  — STILL {plan.residual_over_cap} over cap; "
+            f"needs a manual/LLM semantic-summarization pass (no auto-truncation)"
+        )
+    else:
+        print("  (≤ cap ✓)")
+
+
+def write_backup(path: Path, today: date) -> Path:
+    """Timestamped sidecar backup before any mutation."""
+    backup = path.with_suffix(path.suffix + f".{today.isoformat()}.bak")
+    backup.write_text(path.read_text())
+    return backup
+
+
+def push_to_qdrant(blocks: list[str], group_id: str, agent_id: str) -> bool:
+    """Best-effort push of archived blocks to the Qdrant cold tier (BP-165 B.1).
+
+    Reuses the runtime ``memory.storage`` import path used by bootstrap/sanctum-init.
+    Gracefully degrades to a no-op when the runtime or Qdrant is unavailable — the
+    local archive file is always the source of truth; Qdrant is an additive tier.
+    """
+    install_src = Path.home() / ".ai-memory" / "src"
+    if str(install_src) not in sys.path:
+        sys.path.insert(0, str(install_src))
+    try:
+        from memory.storage import MemoryStorage
+    except Exception as exc:  # runtime not installed / import error
+        print(f"  qdrant: skipped — memory.storage unavailable ({exc})")
+        return False
+    try:
+        storage = MemoryStorage()
+        for block in blocks:
+            storage.store_agent_memory(
+                content=block,
+                memory_type="agent_memory",
+                group_id=group_id,
+                agent_id=agent_id,
+            )
+        print(f"  qdrant: pushed {len(blocks)} archived block(s) to cold tier")
+        return True
+    except Exception as exc:  # Qdrant down, etc.
+        print(f"  qdrant: skipped — push failed ({exc})")
+        return False
+
+
+def apply_plan(
+    path: Path, plan: FilePlan, today: date, qdrant: bool, group_id: str, agent_id: str
+) -> None:
+    """Mutate the file per its plan: backup, write hot file, append cold archive."""
+    if not plan.has_changes:
+        if plan.over_cap:
+            print(
+                f"  {plan.filename}: WARNING — {plan.residual_over_cap} over cap with no "
+                f"mechanical actions available; manual/LLM semantic summarization required "
+                f"(not auto-truncated)"
+            )
+        else:
+            print(f"  {plan.filename}: no changes — skipped")
+        return
+    backup = write_backup(path, today)
+    print(f"  {plan.filename}: backed up → {backup.name}")
+
+    if plan.archived_blocks:
+        archive_path = path.parent / ARCHIVE_SUBDIR / f"{path.stem}.archive.md"
+        archive_path.parent.mkdir(parents=True, exist_ok=True)
+        with archive_path.open("a") as fh:
+            for block in plan.archived_blocks:
+                fh.write(block + "\n")
+        print(
+            f"  {plan.filename}: archived {len(plan.archived_blocks)} entr(ies) → {archive_path.name}"
+        )
+        if qdrant:
+            push_to_qdrant(plan.archived_blocks, group_id, agent_id)
+
+    path.write_text(plan.new_text)
+    print(
+        f"  {plan.filename}: rewritten ({plan.original_lines} → {plan.projected_lines} lines)"
+    )
+    if plan.residual_over_cap:
+        print(
+            f"  {plan.filename}: WARNING — still {plan.residual_over_cap} over cap; "
+            f"manual/LLM semantic summarization required (not auto-truncated)"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Sanctum lore-file hygiene: cap enforcement, anchored compaction, prune-vs-archive.",
+    )
+    parser.add_argument(
+        "path", help="Sanctum directory (scans LORE.md/MEMORY.md) or a single file."
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Mutate files. Without this flag the script is read-only (dry-run DEFAULT).",
+    )
+    parser.add_argument(
+        "--cap",
+        type=int,
+        default=None,
+        help=f"Override the line cap (default {CAP_LINES}; per-file caps apply when scanning a dir).",
+    )
+    parser.add_argument(
+        "--qdrant",
+        action="store_true",
+        help="On --apply, also push archived entries to the Qdrant cold tier (best-effort, opt-in).",
+    )
+    parser.add_argument(
+        "--group-id",
+        default=None,
+        help="Project scope (group_id) for the Qdrant push. Required with --qdrant.",
+    )
+    parser.add_argument(
+        "--agent-id", default="parzival", help="Agent id for the Qdrant push."
+    )
+    args = parser.parse_args()
+
+    if args.qdrant and not args.apply:
+        parser.error("--qdrant requires --apply (dry-run never writes anywhere).")
+    if args.qdrant and not args.group_id:
+        parser.error(
+            "--qdrant requires --group-id (project scope is required-explicit, W-09)."
+        )
+
+    root = Path(args.path).resolve()
+    targets = resolve_targets(root)
+    if not targets:
+        print(f"No lore files found at {root} (expected a sanctum dir or a file).")
+        return 1
+
+    today = date.today()
+    mode = "APPLY" if args.apply else "DRY-RUN (read-only — no files will be changed)"
+    print(f"aim-lore-hygiene · {mode}")
+    print(f"target: {root}")
+
+    plans = []
+    for file_path, cap in targets:
+        cap = args.cap if args.cap is not None else cap
+        plan = plan_file(file_path.read_text(), file_path.name, cap, today)
+        plans.append((file_path, plan))
+        print_plan(plan)
+
+    if args.apply:
+        print("\napplying:")
+        for file_path, plan in plans:
+            apply_plan(
+                file_path, plan, today, args.qdrant, args.group_id or "", args.agent_id
+            )
+    else:
+        actionable = sum(1 for _, p in plans if p.has_changes)
+        print(
+            f"\n{actionable} file(s) have proposed changes. Re-run with --apply to write."
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/_ai-memory/pov/skills/aim-lore-hygiene/scripts/lore_hygiene.py
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/scripts/lore_hygiene.py
@@ -347,25 +347,23 @@ def parse_entries(body_lines: list[str]) -> list[tuple[str, str]]:
             continue
 
         # Raw-HTML block (CommonMark HTML block type 6/7): opaque KEEP from the start
-        # line to its BLANK-LINE terminator — inner lines need NOT start with ``<`` (a
-        # ``<div>`` / inner content / ``</div>`` block is ONE opaque unit). Gathering by
-        # a same-kind ``startswith('<')`` predicate would stop at the first inner line,
-        # leaking the remainder into the paragraph branch to be classified/deduped/pruned
-        # — silent corruption of the operator's file. A block running to EOF with no
-        # trailing blank keeps its remainder opaque (keep-when-uncertain). The gather also
-        # stops at an ATX heading (keep-when-uncertain: a visible ``## heading`` is always
-        # structure) so a heading with no blank line before it is emitted as ``__header__``
-        # and advances ``section`` — never absorbed into the opaque block, which would
-        # mis-attribute the next section's entries and let the section-scoped dedup drop
-        # a legitimately distinct cross-section entry.
+        # line to its BLANK-LINE terminator (or EOF) — inner lines need NOT start with
+        # ``<`` (a ``<div>`` / inner content / ``</div>`` block is ONE opaque unit). Every
+        # inner line — INCLUDING any that begins with ``#`` (an HTML-comment ``# TODO``, a
+        # CSS ``#id`` selector, an inner ``##``) — stays inside the opaque unit and is NEVER
+        # re-classified/deduped/pruned/split. The gather has NO inner-content stop rule: a
+        # same-kind ``startswith('<')`` predicate or a ``#``-guard would terminate at the
+        # first such inner line and leak the block's remainder into the paragraph branch to
+        # be classified/deduped/pruned — silent corruption of the operator's file. A block
+        # running to EOF with no trailing blank keeps its remainder opaque
+        # (keep-when-uncertain). Cross-section dedup safety (an HTML block that absorbs a
+        # following ``## heading`` because there is no blank line between them) is handled
+        # in plan_file's dedup layer, which resets the ``seen`` set on every opaque/header
+        # boundary — NOT by stopping the gather here on inner content.
         if is_html_block_start(line):
             block = [line]
             i += 1
-            while (
-                i < n
-                and body_lines[i].strip()
-                and not body_lines[i].lstrip().startswith("#")
-            ):
+            while i < n and body_lines[i].strip():
                 block.append(body_lines[i])
                 i += 1
             entries.append(("__passthrough__", "\n".join(block)))
@@ -546,9 +544,12 @@ def plan_file(text: str, filename: str, cap: int, today: date) -> FilePlan:
     archive_relpath = f"{ARCHIVE_SUBDIR}/{Path(filename).stem}.archive.md"
     actions: list[EntryAction] = []
     archived_blocks: list[str] = []
-    # Dedup is SECTION-SCOPED: the key carries the owning ``## section`` so two
-    # genuinely distinct entries with identical text under DIFFERENT sections are both
-    # kept (across-section identical lines are legitimately distinct records). A
+    # Dedup is bounded by STRUCTURAL BOUNDARIES: the ``seen`` set collapses duplicate
+    # content only within a contiguous run uninterrupted by a heading or opaque block.
+    # The key still carries the owning ``## section`` so identical text under DIFFERENT
+    # sections stays distinct, and ``seen`` is cleared on every ``__header__`` /
+    # ``__passthrough__`` boundary below (the section-independent guard that closes the
+    # cross-section-dedup HIGH even when an HTML block absorbs the next heading). A
     # file-global set would silently drop the second as a "duplicate" (M-XSEC).
     seen: set[tuple[str, str]] = set()
     out_body: list[str] = []
@@ -558,7 +559,22 @@ def plan_file(text: str, filename: str, cap: int, today: date) -> FilePlan:
         # headers, and every __passthrough__ block (code fences, thematic breaks,
         # table header+separator pairs, blockquotes, indented code, raw HTML). They
         # are NEVER classified, deduped, or split — the keep-when-uncertain backstop.
-        if section in ("__blank__", "__header__", "__passthrough__"):
+        #
+        # A __header__ or __passthrough__ is a STRUCTURAL BOUNDARY: it RESETS the dedup
+        # ``seen`` set so two identical content entries on opposite sides of it are BOTH
+        # kept — a heading or opaque block between twins means they are not a safe dedup
+        # pair (keep-when-uncertain). This is the section-independent fix for the
+        # cross-section-dedup HIGH: even when an HTML/comment block absorbs a following
+        # ``## heading`` (so ``section`` does not advance), the passthrough boundary still
+        # clears ``seen``, so the next run's first occurrence is kept rather than dropped
+        # as a phantom same-section duplicate. ``__blank__`` is ordinary spacing between
+        # bullets and does NOT reset — genuine adjacent duplicates separated only by blank
+        # lines must still collapse keep-first.
+        if section in ("__header__", "__passthrough__"):
+            seen.clear()
+            out_body.append(unit)
+            continue
+        if section == "__blank__":
             out_body.append(unit)
             continue
 

--- a/_ai-memory/pov/skills/aim-lore-hygiene/scripts/lore_hygiene.py
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/scripts/lore_hygiene.py
@@ -146,6 +146,31 @@ def split_frontmatter(text: str) -> tuple[list[str], list[str]]:
     return [], lines
 
 
+def detect_newline(text: str) -> str:
+    """Return the file's dominant line ending so untouched content is re-emitted with
+    it; default LF when none is present (L-CRLF).
+
+    Parsing strips endings via ``splitlines()`` and reassembly joins with ``"\\n"``, so
+    without this a CRLF (or lone-CR) file would be silently rewritten with LF endings —
+    not byte-preserving for untouched content. A single dominant ending is chosen so the
+    rewrite is uniform (never a mixed-ending file).
+    """
+    crlf = text.count("\r\n")
+    lone_cr = text.count("\r") - crlf
+    lone_lf = text.count("\n") - crlf
+    if crlf and crlf >= lone_lf and crlf >= lone_cr:
+        return "\r\n"
+    if lone_cr and lone_cr > lone_lf:
+        return "\r"
+    return "\n"
+
+
+def read_preserving_newlines(path: Path) -> str:
+    """Read text WITHOUT universal-newline translation so the original line ending stays
+    visible to ``detect_newline`` (``Path.read_text`` would collapse CRLF/CR to LF)."""
+    return path.read_bytes().decode("utf-8")
+
+
 def is_bullet(line: str) -> bool:
     # L-PLUS-BULLET: ``+`` is a valid GFM unordered-list bullet alongside ``-``/``*``.
     return bool(re.match(r"\s*([-*+]|\d+\.)\s+", line))
@@ -238,7 +263,9 @@ def parse_entries(body_lines: list[str]) -> list[tuple[str, str]]:
       - ``__passthrough__`` — an opaque structural/uncertain block kept byte-for-byte:
         a whole code fence (open→close inclusive), a thematic break, a table
         header+separator pair, a blockquote, an indented-code block, or a raw-HTML
-        block. Unterminated fences keep their remainder opaque (keep-when-uncertain).
+        block gathered to its blank-line terminator (CommonMark HTML block type 6/7 —
+        inner lines need NOT start with ``<``). Unterminated fences and an HTML block
+        running to EOF keep their remainder opaque (keep-when-uncertain).
     """
     entries: list[tuple[str, str]] = []
     section = ""
@@ -306,18 +333,30 @@ def parse_entries(body_lines: list[str]) -> list[tuple[str, str]]:
             i += 1
             continue
 
-        # Keep-when-uncertain: blockquotes, indented code, raw HTML — opaque KEEP,
-        # gathered into one contiguous block so multi-line constructs stay intact.
-        if is_blockquote(line) or is_indented_code(line) or is_html_block_start(line):
-            if is_blockquote(line):
-                same = is_blockquote
-            elif is_indented_code(line):
-                same = is_indented_code
-            else:
-                same = is_html_block_start
+        # Keep-when-uncertain: blockquotes and indented code are opaque KEEP, gathered
+        # by their own same-kind predicate (every line starts with ``>`` / is indented
+        # ≥4) — that predicate IS correct for these two constructs.
+        if is_blockquote(line) or is_indented_code(line):
+            same = is_blockquote if is_blockquote(line) else is_indented_code
             block = [line]
             i += 1
             while i < n and body_lines[i].strip() and same(body_lines[i]):
+                block.append(body_lines[i])
+                i += 1
+            entries.append(("__passthrough__", "\n".join(block)))
+            continue
+
+        # Raw-HTML block (CommonMark HTML block type 6/7): opaque KEEP from the start
+        # line to its BLANK-LINE terminator — inner lines need NOT start with ``<`` (a
+        # ``<div>`` / inner content / ``</div>`` block is ONE opaque unit). Gathering by
+        # a same-kind ``startswith('<')`` predicate would stop at the first inner line,
+        # leaking the remainder into the paragraph branch to be classified/deduped/pruned
+        # — silent corruption of the operator's file. A block running to EOF with no
+        # trailing blank keeps its remainder opaque (keep-when-uncertain).
+        if is_html_block_start(line):
+            block = [line]
+            i += 1
+            while i < n and body_lines[i].strip():
                 block.append(body_lines[i])
                 i += 1
             entries.append(("__passthrough__", "\n".join(block)))
@@ -351,6 +390,7 @@ def parse_entries(body_lines: list[str]) -> list[tuple[str, str]]:
                 or is_thematic_break(nxt)
                 or _fence_marker(nxt) is not None
                 or is_blockquote(nxt)
+                or is_html_block_start(nxt)
             ):
                 break
             block.append(nxt)
@@ -497,7 +537,11 @@ def plan_file(text: str, filename: str, cap: int, today: date) -> FilePlan:
     archive_relpath = f"{ARCHIVE_SUBDIR}/{Path(filename).stem}.archive.md"
     actions: list[EntryAction] = []
     archived_blocks: list[str] = []
-    seen: set[str] = set()
+    # Dedup is SECTION-SCOPED: the key carries the owning ``## section`` so two
+    # genuinely distinct entries with identical text under DIFFERENT sections are both
+    # kept (across-section identical lines are legitimately distinct records). A
+    # file-global set would silently drop the second as a "duplicate" (M-XSEC).
+    seen: set[tuple[str, str]] = set()
     out_body: list[str] = []
 
     for section, unit in units:
@@ -547,11 +591,13 @@ def plan_file(text: str, filename: str, cap: int, today: date) -> FilePlan:
             out_body.append(unit)
             continue
 
-        # keep — but drop exact duplicates (BP-159 §7 dedup), keeping the first.
-        key = normalize(unit)
+        # keep — but drop exact duplicates within the SAME section (BP-159 §7 dedup),
+        # keeping the first. Scoping by section preserves identical-but-distinct entries
+        # that live under different ``## section`` headers.
+        key = (section, normalize(unit))
         if key in seen:
             actions.append(
-                EntryAction(unit, section, "dedup", "duplicate of an earlier entry")
+                EntryAction(unit, section, "dedup", "duplicate within the same section")
             )
             continue
         seen.add(key)
@@ -562,6 +608,12 @@ def plan_file(text: str, filename: str, cap: int, today: date) -> FilePlan:
     new_text = "\n".join(frontmatter + body)
     if new_text and not new_text.endswith("\n"):
         new_text += "\n"
+    # Re-emit untouched content with the file's original line ending (L-CRLF). Internal
+    # text is ending-stripped, so it holds only LF separators — a single replace yields
+    # a uniform, never-mixed file.
+    newline = detect_newline(text)
+    if newline != "\n":
+        new_text = new_text.replace("\n", newline)
 
     return FilePlan(
         filename=filename,
@@ -643,7 +695,9 @@ def write_backup(path: Path, today: date) -> Path:
     while backup.exists():
         backup = path.parent / f"{path.name}.{stamp}.{n}.bak"
         n += 1
-    backup.write_text(path.read_text())
+    # Byte-faithful copy (read_bytes/write_bytes) so the pre-mutation original is
+    # preserved exactly — including its CRLF/CR line endings (L-CRLF).
+    backup.write_bytes(path.read_bytes())
     return backup
 
 
@@ -724,7 +778,9 @@ def apply_plan(
         if qdrant:
             push_to_qdrant(plan.archived_blocks, group_id, agent_id)
 
-    path.write_text(plan.new_text)
+    # write_bytes (not write_text) so the line endings already baked into new_text are
+    # emitted verbatim with no os.linesep retranslation (L-CRLF).
+    path.write_bytes(plan.new_text.encode("utf-8"))
     print(
         f"  {plan.filename}: rewritten ({plan.original_lines} → {plan.projected_lines} lines)"
     )
@@ -791,7 +847,9 @@ def main() -> int:
     plans = []
     for file_path, cap in targets:
         cap = args.cap if args.cap is not None else cap
-        plan = plan_file(file_path.read_text(), file_path.name, cap, today)
+        plan = plan_file(
+            read_preserving_newlines(file_path), file_path.name, cap, today
+        )
         plans.append((file_path, plan))
         print_plan(plan)
 

--- a/_ai-memory/pov/skills/aim-lore-hygiene/scripts/lore_hygiene.py
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/scripts/lore_hygiene.py
@@ -147,7 +147,8 @@ def split_frontmatter(text: str) -> tuple[list[str], list[str]]:
 
 
 def is_bullet(line: str) -> bool:
-    return bool(re.match(r"\s*([-*]|\d+\.)\s+", line))
+    # L-PLUS-BULLET: ``+`` is a valid GFM unordered-list bullet alongside ``-``/``*``.
+    return bool(re.match(r"\s*([-*+]|\d+\.)\s+", line))
 
 
 def is_table_row(line: str) -> bool:
@@ -220,59 +221,76 @@ def parse_entries(body_lines: list[str]) -> list[tuple[str, str]]:
 
 
 def is_table_separator(text: str) -> bool:
-    """A markdown table header separator row like ``|---|---|`` — never an entry."""
-    return bool(re.fullmatch(r"\s*\|[\s:|-]+\|?\s*", text))
+    """A markdown table header *separator* row like ``|---|---|`` — never an entry.
+
+    L-DASH-CELL: tightened so *every* cell is a true GFM separator cell — optional
+    leading/trailing colon around one or more dashes (``---``, ``:---``, ``---:``,
+    ``:---:``). The previous loose ``[\\s:|-]+`` class accepted any mix of dashes,
+    colons, pipes and spaces, so a bare-dash *content* row could slip through
+    unclassified. A single-dash cell (``| - | - |``) is a valid GFM separator and
+    is still treated as one (kept, structural) — that passthrough is benign.
+    """
+    s = text.strip()
+    if not s.startswith("|"):
+        return False
+    cells = s.strip("|").split("|")
+    return bool(cells) and all(re.fullmatch(r"\s*:?-+:?\s*", cell) for cell in cells)
 
 
 # Strip a leading list/table prefix so a marker tag sitting in the ANCHORED leading
-# position can be matched: bullet (``- ``/``* ``), ordered number (``1. ``), or the
-# first table-cell pipe (``| ``).
-_LEADING_PREFIX_RE = re.compile(r"^\s*(?:[-*]|\d+\.)\s+")
+# position can be matched: bullet (``- ``/``* ``/``+ ``), ordered number (``1. ``),
+# or the first table-cell pipe (``| ``).
+_LEADING_PREFIX_RE = re.compile(r"^\s*(?:[-*+]|\d+\.)\s+")
 _LEADING_CELL_RE = re.compile(r"^\s*\|\s*")
-_TRAILING_CELL_RE = re.compile(r"\s*\|\s*$")
 
 
-def _anchor_zones(text: str) -> tuple[str, str]:
-    """Return (leading, trailing) lowercased zones where a marker tag is *anchored*.
+def _anchor_zone(text: str) -> str:
+    """Return the lowercased LEADING zone where a marker tag is *anchored* (H1).
 
-    A marker only classifies an entry when it sits in one of two dedicated positions
-    (H1): the LEADING zone — the first line with its bullet/number/table-cell prefix
-    removed — or the TRAILING zone — the last line with a trailing table-cell pipe
-    removed. A marker merely *mentioned* in prose (e.g. an entry documenting the
-    marker vocabulary) falls in neither zone and is ignored, so it is never pruned.
+    A marker classifies an entry ONLY when it sits in the single dedicated leading
+    position: the first line with its bullet/number prefix removed, or the first
+    cell of a table row. A marker merely *mentioned* in prose — or one that merely
+    *ends* a line of prose — falls outside this zone and is ignored, so recall-worthy
+    content is never self-destructively pruned.
+
+    Trailing-zone anchoring was removed in cycle-2: a trailing tag pruned prose that
+    happened to end in a marker token (M-TRAILING-PROSE), silently missed a trailing
+    tag on a multi-line entry's first line (M-MULTILINE-TRAILING-MISS), and missed
+    trailing punctuation (TGT-4). Leading-only is the single unambiguous convention
+    (see decision-rule.md).
     """
     lines = text.strip().splitlines()
     first = lines[0] if lines else ""
-    last = lines[-1] if lines else ""
     lead = _LEADING_PREFIX_RE.sub("", first)
-    lead = _LEADING_CELL_RE.sub("", lead).strip().lower()
-    trail = _TRAILING_CELL_RE.sub("", last).strip().lower()
-    return lead, trail
+    return _LEADING_CELL_RE.sub("", lead).strip().lower()
 
 
 def classify(text: str, today: date) -> tuple[str, str]:
     """Apply the BP-159 §6 decision rule to one entry. Returns (action, reason).
 
-    Markers are matched only in an anchored position (leading tag after the
-    bullet/number/table-cell prefix, or a trailing tag at the end of the entry),
-    never as a bare substring anywhere in the prose (H1).
+    Markers are matched only in the anchored LEADING position (a leading tag after
+    the bullet/number prefix or in the first table cell), never as a bare substring
+    elsewhere in the prose nor at the trailing end (H1, leading-only).
     """
-    lead, trail = _anchor_zones(text)
+    lead = _anchor_zone(text)
 
     def anchored(marker: str) -> bool:
-        return lead.startswith(marker) or trail.endswith(marker)
+        return lead.startswith(marker)
 
     for marker in PRUNE_MARKERS:
         if anchored(marker):
             return "prune", f"tagged {marker} — superseded/contradicted/low-utility"
 
-    # GFM strikethrough across the whole entry content = struck-out / superseded.
-    stripped = re.sub(r"^\s*([-*]|\d+\.)\s+", "", text.strip())
-    if stripped.startswith("~~") and stripped.rstrip().endswith("~~"):
+    # GFM strikethrough across the WHOLE entry content = struck-out / superseded.
+    # M-STRIKE-PARTIAL: prune only when a single ``~~…~~`` span covers all of the
+    # (prefix-stripped) content — an entry with live, un-struck text between two
+    # spans (``~~old~~ but still relevant ~~Y~~``) is KEPT, not pruned.
+    stripped = re.sub(r"^\s*([-*+]|\d+\.)\s+", "", text.strip()).strip()
+    if re.fullmatch(r"~~(?:(?!~~).)*~~", stripped, re.DOTALL):
         return "prune", "struck-out (~~...~~) — superseded"
 
-    # TTL marker, anchored leading or trailing.
-    m = EXPIRY_RE.match(lead) or re.search(r"\[expired:(\d{4}-\d{2}-\d{2})\]$", trail)
+    # TTL marker, anchored leading only.
+    m = EXPIRY_RE.match(lead)
     if m:
         try:
             when = date.fromisoformat(m.group(1))
@@ -311,7 +329,7 @@ def _strip_leading_markers(body: str) -> str:
 
 def pointer_for(text: str, today: date, archive_relpath: str) -> str:
     """One-line hot-file pointer left where an archived entry used to be."""
-    body = re.sub(r"^\s*([-*]|\d+\.)\s+", "", text.strip().splitlines()[0]).strip()
+    body = re.sub(r"^\s*([-*+]|\d+\.)\s+", "", text.strip().splitlines()[0]).strip()
     body = _strip_leading_markers(body)
     if len(body) > POINTER_SUMMARY_CHARS:
         body = body[:POINTER_SUMMARY_CHARS].rstrip() + "…"
@@ -366,7 +384,15 @@ def plan_file(text: str, filename: str, cap: int, today: date) -> FilePlan:
             archived_blocks.append(
                 f"## [{today.isoformat()}] archived from {filename} — {sec_label}\n\n{unit}\n"
             )
-            out_body.append(pointer_for(unit, today, archive_relpath))
+            # H3: a table content row must NEVER yield an inline bullet pointer.
+            # pointer_for() emits a ``- _[archived …]_ …`` bullet line; injecting
+            # that mid-table would break the table AND leak the row's pipes/marker
+            # into the hot file (the leading-strip in pointer_for can't clean an
+            # interior ``|``). Drop the row in place so the table stays well-formed
+            # — the full row content is preserved in the cold archive block above.
+            # Non-table entries still leave the dated one-line pointer.
+            if not is_table_row(unit):
+                out_body.append(pointer_for(unit, today, archive_relpath))
             continue
 
         # keep — table rows (header/separator/content) are NEVER deduped: a file-
@@ -533,6 +559,15 @@ def apply_plan(
         # write below leaves the hot file un-rewritten, so a rerun re-classifies the
         # same entries to archive. Skipping blocks already present makes that rerun
         # safe — no duplicate cold entries — while never losing archived content.
+        #
+        # TGT-2: this dedup is exact-string, and each archive block is headed with
+        # today's date (``## [YYYY-MM-DD] archived from …``). A SAME-DAY crash-rerun
+        # is therefore fully idempotent (identical block string → skipped). A
+        # CROSS-DAY crash-rerun (hot file still un-rewritten the next day) produces a
+        # second, differently-dated archive block for the same content. This is
+        # accepted behavior: it preserves an honest per-day archival audit trail and
+        # never loses content; the operator may collapse duplicate dated blocks by
+        # hand if desired.
         existing = archive_path.read_text() if archive_path.exists() else ""
         appended = 0
         with archive_path.open("a") as fh:

--- a/_ai-memory/pov/skills/aim-lore-hygiene/scripts/lore_hygiene.py
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/scripts/lore_hygiene.py
@@ -160,13 +160,85 @@ def is_pointer(line: str) -> bool:
     return "_[archived " in line and "→" in line
 
 
-def parse_entries(body_lines: list[str]) -> list[tuple[str, str]]:
-    """Group body lines into (section, entry_text) units.
+# --- Structural-construct recognizers (the keep-when-uncertain backstop) ---------
+#
+# parse_entries is STRUCTURE-AWARE: it only ever lets the classifier/dedup touch
+# units it can confidently identify as genuine CONTENT (bullets, paragraphs, table
+# content rows). Every structural or ambiguous construct — code fences, thematic
+# breaks, table header+separator rows, blockquotes, indented code, raw HTML — is
+# emitted as an opaque ``__passthrough__`` unit: copied through byte-for-byte, never
+# classified, deduped, split, or rewritten. Data-safety beats cleverness: this skill
+# mutates the operator's OWN memory, so anything we cannot confidently classify we
+# KEEP intact (BP-159 §6 governing principle).
 
-    An entry is: a bullet (plus indented continuation lines), a table row, or a
-    contiguous paragraph. Headers and blank lines are structural separators, not
-    entries, and are emitted as their own ("__section__"/"__blank__"/"__header__")
-    units so reassembly can preserve document shape.
+# CommonMark code fence: 3+ backticks or tildes, up to 3 leading spaces of indent.
+_FENCE_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})")
+
+# CommonMark thematic break: 3+ matching ``-``/``*``/``_``, optional inner spaces.
+_THEMATIC_BREAK_RE = re.compile(r"^ {0,3}([-*_])(?:[ \t]*\1){2,}[ \t]*$")
+
+
+def _fence_marker(line: str) -> tuple[str, int] | None:
+    """Return (fence_char, run_length) if ``line`` is a code-fence delimiter, else None."""
+    m = _FENCE_RE.match(line)
+    if not m:
+        return None
+    seq = m.group(1)
+    return seq[0], len(seq)
+
+
+def _is_fence_close(line: str, fence_char: str, fence_len: int) -> bool:
+    """A closing fence: same char, length ≥ opening run, and NO info string (CommonMark)."""
+    m = _FENCE_RE.match(line)
+    if not m:
+        return False
+    seq = m.group(1)
+    if seq[0] != fence_char or len(seq) < fence_len:
+        return False
+    return line[m.end() :].strip() == ""
+
+
+def is_thematic_break(line: str) -> bool:
+    return bool(_THEMATIC_BREAK_RE.match(line))
+
+
+def is_blockquote(line: str) -> bool:
+    return line.lstrip(" ").startswith(">")
+
+
+def is_indented_code(line: str) -> bool:
+    """A line indented ≥4 spaces (or a leading tab) — opaque at a unit boundary.
+
+    Only meaningful at the START of a fresh unit: bullet/paragraph continuation lines
+    are absorbed by their own branches and never reach this check, so a 4-space indent
+    here is a standalone indented-code block (CommonMark), kept opaque.
+    """
+    if not line.strip():
+        return False
+    if line.startswith("\t"):
+        return True
+    return len(line) - len(line.lstrip(" ")) >= 4
+
+
+def is_html_block_start(line: str) -> bool:
+    return line.lstrip(" ").startswith("<")
+
+
+def parse_entries(body_lines: list[str]) -> list[tuple[str, str]]:
+    """Group body lines into (section, unit_text) units — STRUCTURE-AWARE.
+
+    Genuine CONTENT units carry their owning ``## section`` (or "" for preamble) and
+    are the ONLY units the classifier/dedup ever act on: bullets (plus indented
+    continuation lines), table CONTENT rows, and contiguous paragraphs.
+
+    Everything else is emitted with a special tag so reassembly preserves document
+    shape AND so it is never classified/deduped/split:
+      - ``__blank__``       — a blank line
+      - ``__header__``      — an ATX ``#`` heading line
+      - ``__passthrough__`` — an opaque structural/uncertain block kept byte-for-byte:
+        a whole code fence (open→close inclusive), a thematic break, a table
+        header+separator pair, a blockquote, an indented-code block, or a raw-HTML
+        block. Unterminated fences keep their remainder opaque (keep-when-uncertain).
     """
     entries: list[tuple[str, str]] = []
     section = ""
@@ -175,16 +247,82 @@ def parse_entries(body_lines: list[str]) -> list[tuple[str, str]]:
     while i < n:
         line = body_lines[i]
         stripped = line.strip()
+
         if not stripped:
             entries.append(("__blank__", ""))
             i += 1
             continue
+
         if stripped.startswith("#"):
             if stripped.startswith("## "):
                 section = stripped
             entries.append(("__header__", line))
             i += 1
             continue
+
+        # Code fence → the ENTIRE block (delimiters + body) is one opaque unit.
+        fence = _fence_marker(line)
+        if fence is not None:
+            fence_char, fence_len = fence
+            block = [line]
+            i += 1
+            while i < n:
+                block.append(body_lines[i])
+                closed = _is_fence_close(body_lines[i], fence_char, fence_len)
+                i += 1
+                if closed:
+                    break
+            # Unterminated fence falls through here with the remainder kept opaque.
+            entries.append(("__passthrough__", "\n".join(block)))
+            continue
+
+        # Thematic break (``---``/``***``/``___``) — structural, never deduped.
+        if is_thematic_break(line):
+            entries.append(("__passthrough__", line))
+            i += 1
+            continue
+
+        if is_table_row(line):
+            # A header followed by a separator opens a real table: BOTH rows are
+            # structural passthrough (a tagged header is never classified — M-TBL-HDR,
+            # never orphan a separator). The contiguous CONTENT rows that follow are
+            # genuine content (classified/dropped-in-place, but never deduped — H2).
+            if i + 1 < n and is_table_separator(body_lines[i + 1]):
+                entries.append(("__passthrough__", line))
+                entries.append(("__passthrough__", body_lines[i + 1]))
+                i += 2
+                while (
+                    i < n
+                    and is_table_row(body_lines[i])
+                    and not is_table_separator(body_lines[i])
+                ):
+                    entries.append((section, body_lines[i]))
+                    i += 1
+                continue
+            # A pipe row not forming a header+separator table (e.g. a lone separator
+            # or a malformed one-off row) → treat as a content row; plan_file's
+            # is_table_separator guard still passes a bare separator through opaque.
+            entries.append((section, line))
+            i += 1
+            continue
+
+        # Keep-when-uncertain: blockquotes, indented code, raw HTML — opaque KEEP,
+        # gathered into one contiguous block so multi-line constructs stay intact.
+        if is_blockquote(line) or is_indented_code(line) or is_html_block_start(line):
+            if is_blockquote(line):
+                same = is_blockquote
+            elif is_indented_code(line):
+                same = is_indented_code
+            else:
+                same = is_html_block_start
+            block = [line]
+            i += 1
+            while i < n and body_lines[i].strip() and same(body_lines[i]):
+                block.append(body_lines[i])
+                i += 1
+            entries.append(("__passthrough__", "\n".join(block)))
+            continue
+
         if is_bullet(line):
             block = [line]
             i += 1
@@ -198,11 +336,9 @@ def parse_entries(body_lines: list[str]) -> list[tuple[str, str]]:
                 i += 1
             entries.append((section, "\n".join(block)))
             continue
-        if is_table_row(line):
-            entries.append((section, line))
-            i += 1
-            continue
-        # Paragraph: contiguous non-blank, non-bullet, non-header, non-table lines.
+
+        # Paragraph: contiguous content lines, broken by any structural construct so a
+        # following fence/break/table is never swallowed into a classifiable unit.
         block = [line]
         i += 1
         while i < n:
@@ -212,6 +348,9 @@ def parse_entries(body_lines: list[str]) -> list[tuple[str, str]]:
                 or nxt.strip().startswith("#")
                 or is_bullet(nxt)
                 or is_table_row(nxt)
+                or is_thematic_break(nxt)
+                or _fence_marker(nxt) is not None
+                or is_blockquote(nxt)
             ):
                 break
             block.append(nxt)
@@ -362,12 +501,16 @@ def plan_file(text: str, filename: str, cap: int, today: date) -> FilePlan:
     out_body: list[str] = []
 
     for section, unit in units:
-        if section in ("__blank__", "__header__"):
+        # Structural / opaque units are copied through byte-for-byte: blank lines,
+        # headers, and every __passthrough__ block (code fences, thematic breaks,
+        # table header+separator pairs, blockquotes, indented code, raw HTML). They
+        # are NEVER classified, deduped, or split — the keep-when-uncertain backstop.
+        if section in ("__blank__", "__header__", "__passthrough__"):
             out_body.append(unit)
             continue
 
-        # Never re-process a pointer we left on a prior run (idempotency) or a
-        # table separator row (structural, not content).
+        # Never re-process a pointer we left on a prior run (idempotency) or a bare
+        # table separator that reached us as a content row (structural, not content).
         if is_pointer(unit) or is_table_separator(unit):
             out_body.append(unit)
             continue

--- a/_ai-memory/pov/skills/aim-lore-hygiene/scripts/lore_hygiene.py
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/scripts/lore_hygiene.py
@@ -352,11 +352,20 @@ def parse_entries(body_lines: list[str]) -> list[tuple[str, str]]:
         # a same-kind ``startswith('<')`` predicate would stop at the first inner line,
         # leaking the remainder into the paragraph branch to be classified/deduped/pruned
         # — silent corruption of the operator's file. A block running to EOF with no
-        # trailing blank keeps its remainder opaque (keep-when-uncertain).
+        # trailing blank keeps its remainder opaque (keep-when-uncertain). The gather also
+        # stops at an ATX heading (keep-when-uncertain: a visible ``## heading`` is always
+        # structure) so a heading with no blank line before it is emitted as ``__header__``
+        # and advances ``section`` — never absorbed into the opaque block, which would
+        # mis-attribute the next section's entries and let the section-scoped dedup drop
+        # a legitimately distinct cross-section entry.
         if is_html_block_start(line):
             block = [line]
             i += 1
-            while i < n and body_lines[i].strip():
+            while (
+                i < n
+                and body_lines[i].strip()
+                and not body_lines[i].lstrip().startswith("#")
+            ):
                 block.append(body_lines[i])
                 i += 1
             entries.append(("__passthrough__", "\n".join(block)))

--- a/_ai-memory/pov/skills/aim-lore-hygiene/scripts/lore_hygiene.py
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/scripts/lore_hygiene.py
@@ -224,20 +224,55 @@ def is_table_separator(text: str) -> bool:
     return bool(re.fullmatch(r"\s*\|[\s:|-]+\|?\s*", text))
 
 
+# Strip a leading list/table prefix so a marker tag sitting in the ANCHORED leading
+# position can be matched: bullet (``- ``/``* ``), ordered number (``1. ``), or the
+# first table-cell pipe (``| ``).
+_LEADING_PREFIX_RE = re.compile(r"^\s*(?:[-*]|\d+\.)\s+")
+_LEADING_CELL_RE = re.compile(r"^\s*\|\s*")
+_TRAILING_CELL_RE = re.compile(r"\s*\|\s*$")
+
+
+def _anchor_zones(text: str) -> tuple[str, str]:
+    """Return (leading, trailing) lowercased zones where a marker tag is *anchored*.
+
+    A marker only classifies an entry when it sits in one of two dedicated positions
+    (H1): the LEADING zone — the first line with its bullet/number/table-cell prefix
+    removed — or the TRAILING zone — the last line with a trailing table-cell pipe
+    removed. A marker merely *mentioned* in prose (e.g. an entry documenting the
+    marker vocabulary) falls in neither zone and is ignored, so it is never pruned.
+    """
+    lines = text.strip().splitlines()
+    first = lines[0] if lines else ""
+    last = lines[-1] if lines else ""
+    lead = _LEADING_PREFIX_RE.sub("", first)
+    lead = _LEADING_CELL_RE.sub("", lead).strip().lower()
+    trail = _TRAILING_CELL_RE.sub("", last).strip().lower()
+    return lead, trail
+
+
 def classify(text: str, today: date) -> tuple[str, str]:
-    """Apply the BP-159 §6 decision rule to one entry. Returns (action, reason)."""
-    lowered = text.lower()
+    """Apply the BP-159 §6 decision rule to one entry. Returns (action, reason).
+
+    Markers are matched only in an anchored position (leading tag after the
+    bullet/number/table-cell prefix, or a trailing tag at the end of the entry),
+    never as a bare substring anywhere in the prose (H1).
+    """
+    lead, trail = _anchor_zones(text)
+
+    def anchored(marker: str) -> bool:
+        return lead.startswith(marker) or trail.endswith(marker)
 
     for marker in PRUNE_MARKERS:
-        if marker in lowered:
-            return "prune", f"contains {marker} — superseded/contradicted/low-utility"
+        if anchored(marker):
+            return "prune", f"tagged {marker} — superseded/contradicted/low-utility"
 
     # GFM strikethrough across the whole entry content = struck-out / superseded.
     stripped = re.sub(r"^\s*([-*]|\d+\.)\s+", "", text.strip())
     if stripped.startswith("~~") and stripped.rstrip().endswith("~~"):
         return "prune", "struck-out (~~...~~) — superseded"
 
-    m = EXPIRY_RE.search(lowered)
+    # TTL marker, anchored leading or trailing.
+    m = EXPIRY_RE.match(lead) or re.search(r"\[expired:(\d{4}-\d{2}-\d{2})\]$", trail)
     if m:
         try:
             when = date.fromisoformat(m.group(1))
@@ -247,10 +282,10 @@ def classify(text: str, today: date) -> tuple[str, str]:
             return "prune", f"TTL expired on {m.group(1)}"
 
     for marker in ARCHIVE_MARKERS:
-        if marker in lowered:
+        if anchored(marker):
             return (
                 "archive",
-                f"contains {marker} — stale-but-meaningful, archived to cold tier",
+                f"tagged {marker} — stale-but-meaningful, archived to cold tier",
             )
 
     return "keep", ""
@@ -261,9 +296,23 @@ def normalize(text: str) -> str:
     return re.sub(r"\s+", " ", text.strip()).lower()
 
 
+def _strip_leading_markers(body: str) -> str:
+    """Drop any leading classification marker(s) from a pointer body (M3) so the
+    one-line pointer reads clean (the ``_[archived …]_`` prefix already records it)."""
+    changed = True
+    while changed:
+        changed = False
+        for marker in PRUNE_MARKERS + ARCHIVE_MARKERS:
+            if body.lower().startswith(marker):
+                body = body[len(marker) :].lstrip()
+                changed = True
+    return body
+
+
 def pointer_for(text: str, today: date, archive_relpath: str) -> str:
     """One-line hot-file pointer left where an archived entry used to be."""
     body = re.sub(r"^\s*([-*]|\d+\.)\s+", "", text.strip().splitlines()[0]).strip()
+    body = _strip_leading_markers(body)
     if len(body) > POINTER_SUMMARY_CHARS:
         body = body[:POINTER_SUMMARY_CHARS].rstrip() + "…"
     return f"- _[archived {today.isoformat()}]_ {body} → {archive_relpath}"
@@ -318,6 +367,15 @@ def plan_file(text: str, filename: str, cap: int, today: date) -> FilePlan:
                 f"## [{today.isoformat()}] archived from {filename} — {sec_label}\n\n{unit}\n"
             )
             out_body.append(pointer_for(unit, today, archive_relpath))
+            continue
+
+        # keep — table rows (header/separator/content) are NEVER deduped: a file-
+        # global seen set would silently drop the header + separator of a second
+        # same-schema table and corrupt it (H2). Markers still prune/archive a
+        # tagged content row above; structural rows simply pass through.
+        if is_table_row(unit):
+            actions.append(EntryAction(unit, section, "keep", ""))
+            out_body.append(unit)
             continue
 
         # keep — but drop exact duplicates (BP-159 §7 dedup), keeping the first.
@@ -404,8 +462,18 @@ def print_plan(plan: FilePlan) -> None:
 
 
 def write_backup(path: Path, today: date) -> Path:
-    """Timestamped sidecar backup before any mutation."""
-    backup = path.with_suffix(path.suffix + f".{today.isoformat()}.bak")
+    """Timestamped sidecar backup before any mutation.
+
+    Two distinct applies on the same day must not collide (M1): a same-day backup
+    already on disk is never overwritten — a ``.N`` counter is appended so every
+    apply preserves its own pre-mutation original.
+    """
+    stamp = today.isoformat()
+    backup = path.parent / f"{path.name}.{stamp}.bak"
+    n = 1
+    while backup.exists():
+        backup = path.parent / f"{path.name}.{stamp}.{n}.bak"
+        n += 1
     backup.write_text(path.read_text())
     return backup
 
@@ -461,12 +529,20 @@ def apply_plan(
     if plan.archived_blocks:
         archive_path = path.parent / ARCHIVE_SUBDIR / f"{path.stem}.archive.md"
         archive_path.parent.mkdir(parents=True, exist_ok=True)
+        # Cold-append is idempotent (L3): a crash between this append and the hot-file
+        # write below leaves the hot file un-rewritten, so a rerun re-classifies the
+        # same entries to archive. Skipping blocks already present makes that rerun
+        # safe — no duplicate cold entries — while never losing archived content.
+        existing = archive_path.read_text() if archive_path.exists() else ""
+        appended = 0
         with archive_path.open("a") as fh:
             for block in plan.archived_blocks:
+                if block in existing:
+                    continue
                 fh.write(block + "\n")
-        print(
-            f"  {plan.filename}: archived {len(plan.archived_blocks)} entr(ies) → {archive_path.name}"
-        )
+                existing += block + "\n"
+                appended += 1
+        print(f"  {plan.filename}: archived {appended} entr(ies) → {archive_path.name}")
         if qdrant:
             push_to_qdrant(plan.archived_blocks, group_id, agent_id)
 
@@ -514,6 +590,8 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    if args.cap is not None and args.cap <= 0:
+        parser.error(f"--cap must be a positive integer (got {args.cap}).")
     if args.qdrant and not args.apply:
         parser.error("--qdrant requires --apply (dry-run never writes anywhere).")
     if args.qdrant and not args.group_id:

--- a/_ai-memory/pov/skills/aim-lore-hygiene/tests/test_lore_hygiene.py
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/tests/test_lore_hygiene.py
@@ -886,3 +886,201 @@ def test_REALISTIC_memory_file_only_genuine_entry_acted_on(tmp_path):
     assert "prune 1" in r.stdout
     assert "archive 0" in r.stdout
     assert "dedup 0" in r.stdout
+
+
+# --- H-HTML: multi-line raw-HTML blocks stay fully opaque (blank-line terminated) ---
+#
+# On f24547f the keep-when-uncertain HTML arm gathered with ``same=is_html_block_start``,
+# stopping at the first inner line not starting with ``<``; inner lines then leaked to
+# the paragraph/bullet branch and were classified/deduped/pruned. The tests below FAIL
+# on f24547f (inner content pruned/deduped) and pass once HTML is gathered to its
+# blank-line terminator as one opaque unit.
+
+
+def test_HTML_multiline_block_inner_marker_and_dup_preserved(tmp_path):
+    """A multi-line ``<div>`` / inner-marker-line / ``</div>`` block is ONE opaque unit:
+    the whole block is byte-preserved, a leading-marker inner line is NOT pruned, and a
+    repeated inner line is NOT deduped. Fails on f24547f (inner ``[superseded]`` line
+    pruned; repeated inner line deduped to one)."""
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Notes\n\n"
+        '<div class="callout">\n'
+        "- [superseded] inner content that looks taggable but is inside the block\n"
+        "- a repeated inner line\n"
+        "- a repeated inner line\n"
+        "</div>\n"
+        "\n"
+        "- a real fact to keep.\n"
+    )
+    lore = _write_lore(tmp_path, content)
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+
+    assert '<div class="callout">' in hot
+    assert "</div>" in hot
+    assert (
+        "- [superseded] inner content that looks taggable but is inside the block"
+        in hot
+    ), "inner HTML marker line was pruned (block not opaque)"
+    assert hot.count("- a repeated inner line") == 2, "inner HTML dup line was deduped"
+    assert "- a real fact to keep." in hot
+
+    # (f) idempotent: a second apply changes nothing.
+    sha1 = _sha(lore)
+    r2 = _run(str(lore.parent), "--apply")
+    assert r2.returncode == 0, r2.stderr
+    assert _sha(lore) == sha1, "second apply mutated an already-clean HTML block"
+
+
+def test_HTML_block_to_eof_no_trailing_blank_is_opaque(tmp_path):
+    """An HTML block running to EOF with no trailing blank line keeps its remainder
+    opaque. Fails on f24547f, where the inner ``[prune]`` line was pruned and the dup
+    inner line deduped."""
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Notes\n\n"
+        "<div>\n"
+        "- [prune] looks tagged but is inside an HTML block that runs to EOF\n"
+        "- dup inner line\n"
+        "- dup inner line\n"
+        "</div>"  # no trailing newline / blank line — block runs to EOF
+    )
+    lore = _write_lore(tmp_path, content)
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+
+    assert "<div>" in hot and "</div>" in hot
+    assert (
+        "- [prune] looks tagged but is inside an HTML block that runs to EOF" in hot
+    ), "inner marker line pruned in an HTML-to-EOF block"
+    assert hot.count("- dup inner line") == 2, "inner dup line deduped in HTML-to-EOF"
+
+    sha1 = _sha(lore)
+    r2 = _run(str(lore.parent), "--apply")
+    assert r2.returncode == 0, r2.stderr
+    assert _sha(lore) == sha1, "second apply mutated an HTML-to-EOF block"
+
+
+def test_HTML_after_paragraph_not_swallowed(tmp_path):
+    """A paragraph immediately followed by an HTML block start: the paragraph is its own
+    classifiable entry (so a duplicate paragraph dedups) and the HTML is opaque (not
+    swallowed into the paragraph). Fails on f24547f, where the HTML start was glued into
+    the paragraph (no html break in the paragraph break-set), so the standalone duplicate
+    paragraph did NOT dedup and survived twice."""
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Notes\n\n"
+        "Prose that must stay its own entry.\n"
+        '<div class="x">a callout right after the prose</div>\n'
+        "\n"
+        "Prose that must stay its own entry.\n"
+    )
+    lore = _write_lore(tmp_path, content)
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+
+    # Paragraph classified → the standalone duplicate is deduped to one occurrence.
+    assert (
+        hot.count("Prose that must stay its own entry.") == 1
+    ), "HTML was swallowed into the paragraph (duplicate paragraph not deduped)"
+    # HTML kept opaque, byte-preserved.
+    assert '<div class="x">a callout right after the prose</div>' in hot
+
+    sha1 = _sha(lore)
+    r2 = _run(str(lore.parent), "--apply")
+    assert r2.returncode == 0, r2.stderr
+    assert _sha(lore) == sha1, "second apply was not idempotent"
+
+
+# --- M-XSEC-DEDUP: dedup is section-scoped ---------------------------------------
+
+
+def test_dedup_is_section_scoped(tmp_path):
+    """Two identical content lines under DIFFERENT ``## section``s are BOTH kept; two
+    identical lines within ONE section dedup to the first. Fails on f24547f, whose
+    file-global ``seen`` set dropped the cross-section twin (one occurrence survived).
+    """
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n"
+        "## Section A\n\n"
+        "- identical content line\n"
+        "- identical content line\n"  # within-section dup → second deduped
+        "- a unique A line\n\n"
+        "## Section B\n\n"
+        "- identical content line\n"  # cross-section twin → KEPT
+        "- a unique B line\n"
+    )
+    lore = _write_lore(tmp_path, content)
+    assert lore.read_text().count("- identical content line") == 3
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+
+    # One in Section A (within-section dup collapsed) + one in Section B (cross-section
+    # twin kept) = two. f24547f's file-global dedup leaves only one.
+    assert (
+        hot.count("- identical content line") == 2
+    ), "cross-section identical entry was wrongly deduped (or within-section not deduped)"
+    assert "- a unique A line" in hot
+    assert "- a unique B line" in hot
+
+    sha1 = _sha(lore)
+    r2 = _run(str(lore.parent), "--apply")
+    assert r2.returncode == 0, r2.stderr
+    assert _sha(lore) == sha1, "second apply was not idempotent"
+
+
+# --- L-CRLF: the file's original line ending is preserved ------------------------
+
+
+def test_CRLF_input_keeps_crlf_no_mixing(tmp_path):
+    """A CRLF file with one genuine prune keeps CRLF on untouched lines and never emits
+    a mixed-ending file. Fails on f24547f, which read with universal-newline translation
+    and rewrote the file with LF (no CRLF in the output)."""
+    sanctum = tmp_path / "_ai-memory" / "sanctum" / "parzival"
+    sanctum.mkdir(parents=True)
+    lore = sanctum / "LORE.md"
+    content = (
+        "---\r\n"
+        "type: sanctum-lore\r\n"
+        "---\r\n"
+        "\r\n"
+        "# Lore\r\n"
+        "\r\n"
+        "## Things Learned the Hard Way\r\n"
+        "\r\n"
+        "- [superseded] an old belief that is now wrong\r\n"
+        "- a durable fact to keep\r\n"
+        "- another durable fact to keep\r\n"
+    )
+    lore.write_bytes(content.encode("utf-8"))
+
+    r = _run(str(sanctum), "--apply")
+    assert r.returncode == 0, r.stderr
+
+    raw = lore.read_bytes()
+    assert b"\r\n" in raw, "CRLF line endings were not preserved"
+    # No mixing: stripping every CRLF leaves no lone LF.
+    assert b"\n" not in raw.replace(b"\r\n", b""), "output mixed CRLF and LF endings"
+
+    text = raw.decode("utf-8")
+    assert (
+        "an old belief that is now wrong" not in text
+    ), "the tagged entry was not pruned"
+    assert "a durable fact to keep" in text
+    assert "another durable fact to keep" in text
+
+    # A byte-faithful backup preserves the original CRLF too.
+    backup = next(iter(sanctum.glob("LORE.md.*.bak")))
+    assert b"\r\n" in backup.read_bytes(), "backup did not preserve CRLF"
+
+    # (f) idempotent: a second apply changes nothing (still CRLF, no churn).
+    sha1 = _sha(lore)
+    r2 = _run(str(sanctum), "--apply")
+    assert r2.returncode == 0, r2.stderr
+    assert _sha(lore) == sha1, "second apply mutated the CRLF file"

--- a/_ai-memory/pov/skills/aim-lore-hygiene/tests/test_lore_hygiene.py
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/tests/test_lore_hygiene.py
@@ -1035,6 +1035,46 @@ def test_dedup_is_section_scoped(tmp_path):
     assert _sha(lore) == sha1, "second apply was not idempotent"
 
 
+def test_HTML_block_before_heading_no_blank_advances_section(tmp_path):
+    """An HTML/comment block whose last line is immediately followed by a ``## heading``
+    (no blank line between) must NOT absorb that heading: the heading is emitted as a
+    structural ``__header__`` and advances ``section``, so a content line under the new
+    section is NOT wrongly judged a same-section duplicate of an identical line in the
+    prior section. Both cross-section twins are kept (dedup 0). Fails on 647a5e5, whose
+    blank-line-only HTML gather swallows the heading, leaving the second section's twin
+    attributed to the first section and silently deleted by the section-scoped dedup."""
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n"
+        "## Decisions\n\n"
+        "- DEC-1: use approach X for the pipeline.\n"
+        "<!-- reviewed 2026-01 -->\n"  # HTML/comment block, no blank before next heading
+        "## Conventions\n\n"
+        "- DEC-1: use approach X for the pipeline.\n"  # cross-section twin → KEPT
+        "- a unique conventions line\n"
+    )
+    lore = _write_lore(tmp_path, content)
+    assert lore.read_text().count("- DEC-1: use approach X for the pipeline.") == 2
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+
+    # Both twins survive: the heading advanced the section, so neither is a same-section
+    # duplicate. On 647a5e5 the swallowed heading drops the Conventions twin to zero → one.
+    assert (
+        hot.count("- DEC-1: use approach X for the pipeline.") == 2
+    ), "cross-section twin silently deleted (heading absorbed into the HTML block)"
+    # The heading and the opaque comment line are both preserved.
+    assert "## Conventions" in hot
+    assert "<!-- reviewed 2026-01 -->" in hot
+    assert "- a unique conventions line" in hot
+
+    sha1 = _sha(lore)
+    r2 = _run(str(lore.parent), "--apply")
+    assert r2.returncode == 0, r2.stderr
+    assert _sha(lore) == sha1, "second apply was not idempotent"
+
+
 # --- L-CRLF: the file's original line ending is preserved ------------------------
 
 

--- a/_ai-memory/pov/skills/aim-lore-hygiene/tests/test_lore_hygiene.py
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/tests/test_lore_hygiene.py
@@ -648,3 +648,241 @@ def test_L_plus_bullet_is_classified(tmp_path):
 
     assert "An old belief on a plus-bullet, now wrong." not in hot
     assert "A current fact on a plus-bullet that must be kept." in hot
+
+
+# --- Structure-aware parser (cycle-3 root-cause): structural constructs are opaque -
+#
+# The whole data-corruption class (fenced content deduped/pruned, thematic-break
+# dedup, tagged-table-header archive, keep-when-uncertain) closes at once because the
+# parser now classifies/dedups GENUINE CONTENT ENTRIES ONLY; every structural or
+# ambiguous construct is opaque passthrough. Each test below FAILS on f5b26b5.
+
+
+def test_FENCE_markerless_bullet_list_survives_intact(tmp_path):
+    """H-FENCE: a fenced bullet-list with NO markers must survive byte-for-byte — both
+    fence delimiters AND the fenced bullets. Fails on f5b26b5, where the parser saw
+    the fenced bullets as content: identical lines (incl. the closing ```` ``` ````)
+    deduped away, corrupting the fence."""
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Code Examples\n\n"
+        "```\n"
+        "- step one in the example\n"
+        "- step two in the example\n"
+        "- step one in the example\n"  # an exact dup line — must NOT be deduped
+        "```\n"
+        "\n"
+        "- A real bullet after the fence to keep.\n"
+    )
+    lore = _write_lore(tmp_path, content)
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+
+    assert hot.count("```") == 2, "a fence delimiter was lost (fence corrupted)"
+    assert hot.count("- step one in the example") == 2, "fenced dup line was deduped"
+    assert "- step two in the example" in hot
+    assert "- A real bullet after the fence to keep." in hot
+
+
+def test_FENCE_marker_leading_line_inside_fence_is_kept(tmp_path):
+    """A marker-leading line INSIDE a code fence is fenced content, not a tagged entry,
+    and must be KEPT. Fails on f5b26b5, which pruned it as a [prune]-tagged bullet."""
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Code Examples\n\n"
+        "```bash\n"
+        "- [prune] this is example text demonstrating a marker, not a real entry\n"
+        "echo done\n"
+        "```\n"
+        "- [prune] a genuine tagged entry OUTSIDE the fence, which IS pruned.\n"
+    )
+    lore = _write_lore(tmp_path, content)
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+
+    # Inside the fence → kept verbatim (fence delimiters intact).
+    assert hot.count("```") == 2
+    assert "- [prune] this is example text demonstrating a marker" in hot
+    assert "echo done" in hot
+    # The genuine tagged entry outside the fence is still pruned.
+    assert "a genuine tagged entry OUTSIDE the fence" not in hot
+
+
+def test_FENCE_unterminated_keeps_remainder_opaque(tmp_path):
+    """An unterminated fence keeps its remainder opaque (keep-when-uncertain) — nothing
+    inside it is classified/deduped."""
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Code Examples\n\n"
+        "```\n"
+        "- [superseded] looks tagged but is inside an unterminated fence\n"
+        "- a duplicate line\n"
+        "- a duplicate line\n"
+    )
+    lore = _write_lore(tmp_path, content)
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+
+    assert "looks tagged but is inside an unterminated fence" in hot
+    assert hot.count("- a duplicate line") == 2, "deduped inside an unterminated fence"
+
+
+def test_TBL_HDR_tagged_header_keeps_table_valid(tmp_path):
+    """M-TBL-HDR: a tagged table HEADER row is structural — it must NOT be classified/
+    removed, so the separator is never orphaned. Fails on f5b26b5, which archived the
+    tagged header and left a dangling separator (corrupt table)."""
+    content = (
+        "---\ntype: sanctum-memory\n---\n\n# Memory\n\n## Pending Items\n\n"
+        "| [stale] Item | Owner | Unblock |\n"
+        "|------|-------|--------|\n"
+        "| live row one | alice | review |\n"
+        "| live row two | bob | merge |\n"
+    )
+    sanctum = tmp_path / "_ai-memory" / "sanctum" / "parzival"
+    sanctum.mkdir(parents=True)
+    mem = sanctum / "MEMORY.md"
+    mem.write_text(content)
+
+    r = _run(str(mem), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = mem.read_text()
+
+    # The tagged header survives intact, atop its separator — table stays valid.
+    assert "| [stale] Item | Owner | Unblock |" in hot, "tagged header was removed"
+    assert hot.count("|------|-------|--------|") == 1, "separator orphaned/removed"
+    assert "| live row one | alice | review |" in hot
+    assert "| live row two | bob | merge |" in hot
+    # Nothing was archived (the header is structural, not a stale content entry).
+    archive_path = sanctum / "references" / "lore-archive" / "MEMORY.archive.md"
+    assert not archive_path.exists() or "Item" not in archive_path.read_text()
+
+
+def test_THEMATIC_breaks_are_not_deduped(tmp_path):
+    """Repeated thematic breaks (``---`` three times) are structural delimiters, never deduped.
+    Fails on f5b26b5, which deduped the repeats down to one."""
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Sections\n\n"
+        "- first fact\n\n"
+        "---\n\n"
+        "- second fact\n\n"
+        "---\n\n"
+        "- third fact\n\n"
+        "---\n\n"
+        "- fourth fact\n"
+    )
+    lore = _write_lore(tmp_path, content)
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+
+    # Count standalone ``---`` lines in the BODY (excludes the frontmatter fence,
+    # which is split off and reattached verbatim).
+    body = hot.split("\n---\n", 1)[-1]  # drop frontmatter open+close
+    assert body.count("\n---\n") == 3, "a thematic break was deduped away"
+    for fact in ("first", "second", "third", "fourth"):
+        assert f"- {fact} fact" in hot
+
+
+def test_UNCERTAIN_blockquote_and_html_kept_unchanged(tmp_path):
+    """Keep-when-uncertain: blockquotes and raw-HTML blocks are ambiguous constructs →
+    kept opaque, never classified or deduped, even when they contain a marker token or
+    duplicate lines. Fails on f5b26b5, which pruned the [superseded]-leading blockquote
+    line and deduped the repeated HTML line."""
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Notes\n\n"
+        "> [superseded] a quoted line that merely shows a marker, kept opaque\n"
+        "> a second quoted line\n"
+        "\n"
+        '<div class="callout">a raw html block</div>\n'
+        "\n"
+        '<div class="callout">a raw html block</div>\n'  # dup across a blank line
+        "\n"
+        "- a normal fact to keep\n"
+    )
+    lore = _write_lore(tmp_path, content)
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+
+    assert "> [superseded] a quoted line that merely shows a marker" in hot
+    assert "> a second quoted line" in hot
+    assert hot.count('<div class="callout">a raw html block</div>') == 2
+    assert "- a normal fact to keep" in hot
+
+
+def test_REALISTIC_memory_file_only_genuine_entry_acted_on(tmp_path):
+    """A realistic MEMORY.md-shaped file (frontmatter + bullets + two same-schema
+    tables + a fenced code block + prose mentioning markers + ONE real tagged entry):
+    only the genuine tagged entry is acted on; everything structural is byte-preserved.
+    Fails on f5b26b5 across multiple constructs at once."""
+    content = (
+        "---\n"
+        "type: sanctum-memory\n"
+        "agent: parzival\n"
+        "---\n"
+        "\n"
+        "# Memory\n"
+        "\n"
+        "## Conventions\n"
+        "\n"
+        "- Tag an entry [superseded] in prose when it is no longer accurate.\n"
+        "- A durable convention with no marker.\n"
+        "\n"
+        "## Pending Items\n"
+        "\n"
+        "| Item | Owner | Unblock |\n"
+        "|------|-------|--------|\n"
+        "| pending task A | alice | review |\n"
+        "\n"
+        "## Insights to Carry\n"
+        "\n"
+        "| Item | Owner | Unblock |\n"
+        "|------|-------|--------|\n"
+        "| insight B | bob | n/a |\n"
+        "\n"
+        "## Snippets\n"
+        "\n"
+        "```text\n"
+        "- [prune] example showing how to tag a line — NOT a real entry\n"
+        "- a sample documentation line\n"
+        "- a sample documentation line\n"  # exact dup inside the fence
+        "```\n"
+        "\n"
+        "## Decisions\n"
+        "\n"
+        "- [superseded] the one genuine tagged entry that should be pruned.\n"
+        "- a live decision to keep.\n"
+    )
+    sanctum = tmp_path / "_ai-memory" / "sanctum" / "parzival"
+    sanctum.mkdir(parents=True)
+    mem = sanctum / "MEMORY.md"
+    mem.write_text(content)
+
+    r = _run(str(mem), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = mem.read_text()
+
+    # ONLY the genuine tagged entry is gone.
+    assert "the one genuine tagged entry that should be pruned." not in hot
+    assert "- a live decision to keep." in hot
+
+    # Everything structural is byte-preserved.
+    assert "- Tag an entry [superseded] in prose when it is no longer accurate." in hot
+    assert "- A durable convention with no marker." in hot
+    assert hot.count("| Item | Owner | Unblock |") == 2, "a table header was lost"
+    assert hot.count("|------|-------|--------|") == 2, "a table separator was lost"
+    assert "| pending task A | alice | review |" in hot
+    assert "| insight B | bob | n/a |" in hot
+    assert hot.count("```") == 2, "a code fence delimiter was lost"
+    assert "- [prune] example showing how to tag a line — NOT a real entry" in hot
+    assert hot.count("- a sample documentation line") == 2, "fenced dup line deduped"
+
+    # Exactly one prune action, no archive/dedup churn on structure.
+    assert "prune 1" in r.stdout
+    assert "archive 0" in r.stdout
+    assert "dedup 0" in r.stdout

--- a/_ai-memory/pov/skills/aim-lore-hygiene/tests/test_lore_hygiene.py
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/tests/test_lore_hygiene.py
@@ -1,0 +1,262 @@
+"""Tests for lore_hygiene.py (BP-165 B.4 — subprocess + tmp_path seam).
+
+Covers the architecture spec's required scenarios:
+  T1 — --dry-run (DEFAULT) mutates nothing (sha256 unchanged)
+  T2 — over-cap file → plan proposes compaction
+  T3 — --apply brings the file ≤ cap
+  T4 — idempotency: a second --apply is a no-op (sha256 stable)
+  T5 — an archived entry leaves a one-line pointer + a cold-tier archive file
+  T6 — a superseded entry is DELETED, not archived
+  plus a realistic-size (production-scale) LORE fixture.
+
+Every test runs the script via subprocess against a tmp_path fixture, asserting
+observable behaviour at the filesystem level (no mocks).
+"""
+
+import hashlib
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).parent.parent / "scripts" / "lore_hygiene.py"
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _lore(keep: int = 150, prune: int = 40, archive: int = 12, dup: int = 8) -> str:
+    """Build a controllable LORE.md fixture.
+
+    Returns a file that is over the 200-line cap and reducible back under it via
+    prune (drop) + archive (multi-line → 1-line pointer) + dedup (drop repeats).
+    """
+    lines = [
+        "---",
+        "type: sanctum-lore",
+        "agent: parzival",
+        "tier: 3",
+        "load: session-start",
+        "---",
+        "",
+        "# Lore",
+        "",
+        "## System Architecture",
+        "",
+    ]
+    lines += [
+        f"- Keep fact {i}: component {i} connects to service {i}." for i in range(keep)
+    ]
+    lines += ["", "## Things Learned the Hard Way", ""]
+    lines += [
+        f"- [superseded] Old belief {i} that was later proven wrong."
+        for i in range(prune)
+    ]
+    for i in range(archive):
+        lines += [
+            f"- [stale] Historical decision {i} about the old pipeline.",
+            "  Context that mattered at the time but is now background.",
+            "  A second continuation line of detail for this decision.",
+        ]
+    # Exact duplicates of an early keep entry — should dedup to one.
+    lines += ["- Keep fact 0: component 0 connects to service 0." for _ in range(dup)]
+    lines += [""]
+    return "\n".join(lines) + "\n"
+
+
+def _write_lore(tmp_path: Path, content: str | None = None) -> Path:
+    sanctum = tmp_path / "_ai-memory" / "sanctum" / "parzival"
+    sanctum.mkdir(parents=True)
+    lore = sanctum / "LORE.md"
+    lore.write_text(content if content is not None else _lore())
+    return lore
+
+
+def test_T1_dry_run_mutates_nothing(tmp_path):
+    lore = _write_lore(tmp_path)
+    sanctum = lore.parent
+    before = _sha(lore)
+
+    # Default invocation (no --apply) must be read-only.
+    r = _run(str(sanctum))
+    assert r.returncode == 0, r.stderr
+    assert "DRY-RUN" in r.stdout
+
+    assert _sha(lore) == before, "dry-run modified the file"
+    assert not list(sanctum.glob("*.bak")), "dry-run created a backup"
+    assert not (
+        sanctum / "references" / "lore-archive"
+    ).exists(), "dry-run wrote an archive"
+
+
+def test_T2_over_cap_plan_proposes_compaction(tmp_path):
+    lore = _write_lore(tmp_path)
+    original = len(lore.read_text().splitlines())
+    assert original > 200, "fixture should be over cap"
+
+    r = _run(str(lore.parent))
+    assert r.returncode == 0, r.stderr
+    assert "OVER CAP" in r.stdout
+    # The plan must propose concrete actions.
+    assert "[prune]" in r.stdout
+    assert "[archive]" in r.stdout
+    assert "projected:" in r.stdout
+
+
+def test_T3_apply_brings_file_under_cap(tmp_path):
+    lore = _write_lore(tmp_path)
+    assert len(lore.read_text().splitlines()) > 200
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+
+    after = len(lore.read_text().splitlines())
+    assert after <= 200, f"file still over cap after --apply ({after} lines)"
+    # A timestamped backup must have been written before mutation.
+    assert list(lore.parent.glob("LORE.md.*.bak")), "no backup sidecar written"
+
+
+def test_T4_apply_is_idempotent(tmp_path):
+    lore = _write_lore(tmp_path)
+
+    r1 = _run(str(lore.parent), "--apply")
+    assert r1.returncode == 0, r1.stderr
+    sha_after_first = _sha(lore)
+
+    r2 = _run(str(lore.parent), "--apply")
+    assert r2.returncode == 0, r2.stderr
+    assert _sha(lore) == sha_after_first, "second --apply changed an already-clean file"
+    assert "no changes" in r2.stdout.lower()
+
+
+def test_T5_archive_leaves_pointer_and_cold_file(tmp_path):
+    lore = _write_lore(tmp_path)
+    sanctum = lore.parent
+
+    r = _run(str(sanctum), "--apply")
+    assert r.returncode == 0, r.stderr
+
+    archive = sanctum / "references" / "lore-archive" / "LORE.archive.md"
+    assert archive.exists(), "cold-tier archive file not created"
+    archive_text = archive.read_text()
+    assert "Historical decision 0 about the old pipeline." in archive_text
+
+    hot = lore.read_text()
+    assert "_[archived " in hot and "→" in hot, "no one-line pointer left in hot file"
+    # The full multi-line archived detail must NOT remain in the hot file.
+    assert "A second continuation line of detail" not in hot
+
+
+def test_T6_superseded_is_deleted_not_archived(tmp_path):
+    lore = _write_lore(tmp_path)
+    sanctum = lore.parent
+
+    r = _run(str(sanctum), "--apply")
+    assert r.returncode == 0, r.stderr
+
+    hot = lore.read_text()
+    archive_path = sanctum / "references" / "lore-archive" / "LORE.archive.md"
+    archive_text = archive_path.read_text() if archive_path.exists() else ""
+
+    needle = "Old belief 0 that was later proven wrong."
+    assert needle not in hot, "superseded entry survived in the hot file"
+    assert (
+        needle not in archive_text
+    ), "superseded entry was archived (should be deleted)"
+
+
+def test_expired_ttl_and_strikethrough_are_pruned(tmp_path):
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Things Learned the Hard Way\n\n"
+        "- [expired:2000-01-01] A TTL entry whose date has long passed.\n"
+        "- ~~A struck-out belief that was reversed.~~\n"
+        "- A current, valid fact that must be kept.\n"
+    )
+    lore = _write_lore(tmp_path, content)
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+    assert "A TTL entry whose date has long passed" not in hot
+    assert "struck-out belief" not in hot
+    assert "A current, valid fact that must be kept." in hot
+
+
+def test_clean_under_cap_file_is_noop(tmp_path):
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## System Architecture\n\n"
+        "- A small, clean, current fact.\n- Another durable fact.\n"
+    )
+    lore = _write_lore(tmp_path, content)
+    before = _sha(lore)
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    assert _sha(lore) == before, "clean under-cap file was modified"
+    assert not list(lore.parent.glob("*.bak"))
+
+
+def test_realistic_size_production_lore(tmp_path):
+    """feedback_realistic_size_production_artifact_tests — exercise a production-scale
+    LORE file (well over cap, mixed content) end to end."""
+    lore = _write_lore(tmp_path, _lore(keep=130, prune=60, archive=20, dup=10))
+    original = len(lore.read_text().splitlines())
+    assert original > 250, "realistic fixture should be substantially over cap"
+
+    # Dry-run reports the over-cap state without mutating.
+    before = _sha(lore)
+    r_dry = _run(str(lore.parent))
+    assert r_dry.returncode == 0, r_dry.stderr
+    assert "OVER CAP" in r_dry.stdout
+    assert _sha(lore) == before
+
+    # Apply brings it under cap and produces a backup + archive.
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    assert len(lore.read_text().splitlines()) <= 200
+    assert (lore.parent / "references" / "lore-archive" / "LORE.archive.md").exists()
+
+
+def test_residual_over_cap_flags_not_truncates(tmp_path):
+    """memory-blindness guard (BP-159 §6): when a file is over cap with only unique,
+    current keep-entries, the script flags a residual instead of silently truncating."""
+    # 210 unique, unprunable, unarchivable entries — mechanical compaction cannot
+    # get under 200 without semantic summarization, which the script refuses to fake.
+    lore = _write_lore(tmp_path, _lore(keep=210, prune=0, archive=0, dup=0))
+    n_keep_before = lore.read_text().count("- Keep fact ")
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+
+    hot = lore.read_text()
+    assert (
+        len(hot.splitlines()) > 200
+    ), "file was truncated under cap (memory blindness!)"
+    assert hot.count("- Keep fact ") == n_keep_before, "keep entries were lost"
+    assert (
+        "manual/LLM semantic summarization" in r.stdout.lower()
+        or "still" in r.stdout.lower()
+    )
+
+
+def test_scans_both_hot_files_in_a_sanctum_dir(tmp_path):
+    sanctum = tmp_path / "_ai-memory" / "sanctum" / "parzival"
+    sanctum.mkdir(parents=True)
+    (sanctum / "LORE.md").write_text(_lore())
+    (sanctum / "MEMORY.md").write_text(
+        "---\ntype: sanctum-memory\n---\n\n# Memory\n\n## Pending Items\n\n"
+        "| Item | Owner | Unblock |\n|------|-------|--------|\n"
+        "| [superseded] old task | x | y |\n| live task | a | b |\n"
+    )
+
+    r = _run(str(sanctum))
+    assert r.returncode == 0, r.stderr
+    assert "LORE.md" in r.stdout and "MEMORY.md" in r.stdout

--- a/_ai-memory/pov/skills/aim-lore-hygiene/tests/test_lore_hygiene.py
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/tests/test_lore_hygiene.py
@@ -262,18 +262,17 @@ def test_scans_both_hot_files_in_a_sanctum_dir(tmp_path):
     assert "LORE.md" in r.stdout and "MEMORY.md" in r.stdout
 
 
-# --- H1: anchored marker matching (substring-in-prose must NOT prune) -----------
+# --- H1: leading-only marker matching (prose mention / trailing must NOT prune) --
 
 
-def test_H1_prose_mention_kept_anchored_tag_pruned(tmp_path):
+def test_H1_prose_mention_kept_leading_tag_pruned(tmp_path):
     """A marker mentioned in prose is recall-worthy and must be KEPT; only a marker
-    in an anchored (leading or trailing) position classifies the entry. Fails on the
-    old substring-anywhere matcher, which self-destructively prunes the prose entry."""
+    in the anchored LEADING position classifies the entry. Fails on the old
+    substring-anywhere matcher, which self-destructively prunes the prose entry."""
     content = (
         "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Patterns & Conventions\n\n"
         "- Tag an entry [superseded] when it is no longer accurate.\n"
         "- [superseded] Old belief that was later proven wrong.\n"
-        "- A fact retired only at the end of its life [obsolete]\n"
         "- A current, durable fact with no marker at all.\n"
     )
     lore = _write_lore(tmp_path, content)
@@ -286,10 +285,60 @@ def test_H1_prose_mention_kept_anchored_tag_pruned(tmp_path):
     assert "Tag an entry [superseded] when it is no longer accurate." in hot
     # Leading anchored tag — pruned.
     assert "Old belief that was later proven wrong." not in hot
-    # Trailing anchored tag — pruned.
-    assert "A fact retired only at the end of its life" not in hot
     # Untagged fact — kept.
     assert "A current, durable fact with no marker at all." in hot
+
+
+def test_M_trailing_prose_marker_is_kept(tmp_path):
+    """LEADING-ONLY anchoring (M-TRAILING-PROSE): an entry whose prose merely *ends*
+    in a marker token is recall-worthy and must be KEPT. Fails on the cycle-1
+    trailing-zone matcher, which wrongly pruned it."""
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Patterns & Conventions\n\n"
+        "- A fact retired only at the end of its life [obsolete]\n"
+        "- The deploy rule changed after the incident [superseded]\n"
+        "- [superseded] An entry actually tagged for prune at the front.\n"
+    )
+    lore = _write_lore(tmp_path, content)
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+
+    # Prose ending in a marker token — KEPT (trailing anchoring removed in cycle-2).
+    assert "A fact retired only at the end of its life [obsolete]" in hot
+    assert "The deploy rule changed after the incident [superseded]" in hot
+    # A genuine leading tag still prunes.
+    assert "An entry actually tagged for prune at the front." not in hot
+
+
+def test_M_multiline_entry_leading_tag_handled(tmp_path):
+    """LEADING-ONLY anchoring: a multi-line entry with a LEADING tag is classified by
+    its first line; a multi-line entry whose marker only *ends* the first line is
+    KEPT (no trailing-zone miss/over-reach)."""
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Things Learned the Hard Way\n\n"
+        "- [stale] A historical decision about the old pipeline.\n"
+        "  A continuation line with the detail that mattered then.\n"
+        "- A live decision whose first line ends in a token [obsolete]\n"
+        "  and continues with detail that must be kept.\n"
+    )
+    lore = _write_lore(tmp_path, content)
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+    archive = (
+        lore.parent / "references" / "lore-archive" / "LORE.archive.md"
+    ).read_text()
+
+    # Leading [stale] on a multi-line entry → archived (pointer in hot, detail cold).
+    assert "A historical decision about the old pipeline." in archive
+    assert "A continuation line with the detail that mattered then." not in hot
+    assert "_[archived " in hot
+    # Marker only ending the first line → KEPT in full (both lines).
+    assert "A live decision whose first line ends in a token [obsolete]" in hot
+    assert "and continues with detail that must be kept." in hot
 
 
 # --- H2: table header/separator rows are never deduped --------------------------
@@ -463,3 +512,139 @@ def test_L3_rerun_does_not_duplicate_cold_entries(tmp_path):
     assert (
         archive.count("Historical decision 0 about the old pipeline.") == 1
     ), "cold tier accumulated a duplicate on rerun"
+
+
+# --- H3: archiving a tagged table content row must not corrupt the table ---------
+
+
+def test_H3_archive_tagged_table_row_no_corruption_no_leak(tmp_path):
+    """An [archive]-tagged table CONTENT row must NOT inject an inline bullet pointer
+    into the table body (mid-table line break + leaked pipes/marker). The table must
+    stay well-formed, the archived content must reach the cold tier, and no marker or
+    table pipe may leak into the hot file. Fails on 94de5fa, where the archive branch
+    emitted pointer_for(unit) for the table row before the is_table_row guard."""
+    content = (
+        "---\ntype: sanctum-memory\n---\n\n# Memory\n\n## Pending Items\n\n"
+        "| Item | Owner | Unblock |\n|------|-------|--------|\n"
+        "| live task one | alice | review |\n"
+        "| [archive] old pipeline migration row | bob | done |\n"
+        "| live task two | carol | merge |\n"
+    )
+    sanctum = tmp_path / "_ai-memory" / "sanctum" / "parzival"
+    sanctum.mkdir(parents=True)
+    mem = sanctum / "MEMORY.md"
+    mem.write_text(content)
+
+    r = _run(str(mem), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = mem.read_text()
+
+    # Table stays well-formed: header + separator + the two live rows survive intact.
+    assert hot.count("| Item | Owner | Unblock |") == 1
+    assert hot.count("|------|-------|--------|") == 1
+    assert "| live task one | alice | review |" in hot
+    assert "| live task two | carol | merge |" in hot
+
+    # No inline bullet pointer injected into the table body, and NO marker/pipe leak:
+    # the archived row's content (and its marker) must be gone from the hot file.
+    assert "_[archived " not in hot, "an inline pointer bullet was injected into table"
+    assert "[archive] old pipeline migration row" not in hot
+    assert "old pipeline migration row" not in hot, "archived table content leaked hot"
+
+    # No malformed bullet-with-pipes line survived anywhere in the hot file.
+    for line in hot.splitlines():
+        if line.lstrip().startswith("-"):
+            assert "|" not in line, f"a bullet line leaked table pipes: {line!r}"
+
+    # The archived row content is preserved in the cold tier (data safety).
+    archive = (
+        sanctum / "references" / "lore-archive" / "MEMORY.archive.md"
+    ).read_text()
+    assert "old pipeline migration row" in archive
+
+
+# --- TGT-1: a prune-tagged table content row is dropped in place, table valid -----
+
+
+def test_TGT1_prune_tagged_table_row_dropped_table_valid(tmp_path):
+    """A [prune]-tagged table CONTENT row is dropped in place; the table stays valid
+    and nothing is written to the cold tier (prune deletes; archive preserves)."""
+    content = (
+        "---\ntype: sanctum-memory\n---\n\n# Memory\n\n## Pending Items\n\n"
+        "| Item | Owner | Unblock |\n|------|-------|--------|\n"
+        "| live task one | alice | review |\n"
+        "| [superseded] a row that is now wrong | bob | n/a |\n"
+        "| live task two | carol | merge |\n"
+    )
+    sanctum = tmp_path / "_ai-memory" / "sanctum" / "parzival"
+    sanctum.mkdir(parents=True)
+    mem = sanctum / "MEMORY.md"
+    mem.write_text(content)
+
+    r = _run(str(mem), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = mem.read_text()
+
+    assert hot.count("| Item | Owner | Unblock |") == 1
+    assert hot.count("|------|-------|--------|") == 1
+    assert "| live task one | alice | review |" in hot
+    assert "| live task two | carol | merge |" in hot
+    # The pruned row is gone, with no marker/pipe residue and no pointer bullet.
+    assert "a row that is now wrong" not in hot
+    assert "_[archived " not in hot
+    # Pruned (not archived): no cold-tier file is created for it.
+    archive_path = sanctum / "references" / "lore-archive" / "MEMORY.archive.md"
+    if archive_path.exists():
+        assert "a row that is now wrong" not in archive_path.read_text()
+
+
+# --- M-STRIKE-PARTIAL: only a FULLY-struck entry is pruned -----------------------
+
+
+def test_M_strike_partial_kept_full_struck_pruned(tmp_path):
+    """Partial strikethrough (live un-struck text between spans) is KEPT; only a
+    single ~~...~~ span covering the whole entry is pruned. Fails on 94de5fa, whose
+    starts-with-~~ and ends-with-~~ test wrongly pruned the partial entry."""
+    # The first entry both STARTS and ENDS with a ~~ span but has live, un-struck
+    # text between them — this is the exact shape the cycle-1 starts-/ends-with-~~
+    # check wrongly pruned.
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Things Learned the Hard Way\n\n"
+        "- ~~old approach~~ but still relevant, see ~~ticket Y~~\n"
+        "- ~~A belief fully struck out because it was reversed.~~\n"
+        "- A current, valid fact with no strikethrough.\n"
+    )
+    lore = _write_lore(tmp_path, content)
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+
+    # Partial strikethrough with interior live text — KEPT.
+    assert "but still relevant, see" in hot
+    # Fully-struck entry — pruned.
+    assert "A belief fully struck out because it was reversed." not in hot
+    # Untagged fact — kept.
+    assert "A current, valid fact with no strikethrough." in hot
+
+
+# --- L-PLUS-BULLET: '+' bullets are recognized ----------------------------------
+
+
+def test_L_plus_bullet_is_classified(tmp_path):
+    """A '+' unordered-list bullet must be recognized so a leading tag on it acts.
+    Fails on 94de5fa, where is_bullet/_LEADING_PREFIX_RE ignored '+', leaving the
+    leading marker unanchored and the entry wrongly kept."""
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Things Learned the Hard Way\n\n"
+        "+ [superseded] An old belief on a plus-bullet, now wrong.\n"
+        "+ A current fact on a plus-bullet that must be kept.\n"
+    )
+    lore = _write_lore(tmp_path, content)
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+
+    assert "An old belief on a plus-bullet, now wrong." not in hot
+    assert "A current fact on a plus-bullet that must be kept." in hot

--- a/_ai-memory/pov/skills/aim-lore-hygiene/tests/test_lore_hygiene.py
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/tests/test_lore_hygiene.py
@@ -260,3 +260,206 @@ def test_scans_both_hot_files_in_a_sanctum_dir(tmp_path):
     r = _run(str(sanctum))
     assert r.returncode == 0, r.stderr
     assert "LORE.md" in r.stdout and "MEMORY.md" in r.stdout
+
+
+# --- H1: anchored marker matching (substring-in-prose must NOT prune) -----------
+
+
+def test_H1_prose_mention_kept_anchored_tag_pruned(tmp_path):
+    """A marker mentioned in prose is recall-worthy and must be KEPT; only a marker
+    in an anchored (leading or trailing) position classifies the entry. Fails on the
+    old substring-anywhere matcher, which self-destructively prunes the prose entry."""
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Patterns & Conventions\n\n"
+        "- Tag an entry [superseded] when it is no longer accurate.\n"
+        "- [superseded] Old belief that was later proven wrong.\n"
+        "- A fact retired only at the end of its life [obsolete]\n"
+        "- A current, durable fact with no marker at all.\n"
+    )
+    lore = _write_lore(tmp_path, content)
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+
+    # Prose mention — KEPT (the H1 regression: old code wrongly pruned this).
+    assert "Tag an entry [superseded] when it is no longer accurate." in hot
+    # Leading anchored tag — pruned.
+    assert "Old belief that was later proven wrong." not in hot
+    # Trailing anchored tag — pruned.
+    assert "A fact retired only at the end of its life" not in hot
+    # Untagged fact — kept.
+    assert "A current, durable fact with no marker at all." in hot
+
+
+# --- H2: table header/separator rows are never deduped --------------------------
+
+
+def test_H2_two_same_schema_tables_keep_headers_and_separators(tmp_path):
+    """Two tables sharing a column schema must each retain their header + separator
+    after --apply. Fails on the old file-global dedup, which drops the 2nd header."""
+    content = (
+        "---\ntype: sanctum-memory\n---\n\n# Memory\n\n"
+        "## Pending Items\n\n"
+        "| Item | Owner | Unblock |\n|------|-------|--------|\n"
+        "| task one | alice | review |\n\n"
+        "## Insights to Carry\n\n"
+        "| Item | Owner | Unblock |\n|------|-------|--------|\n"
+        "| task two | bob | merge |\n"
+    )
+    sanctum = tmp_path / "_ai-memory" / "sanctum" / "parzival"
+    sanctum.mkdir(parents=True)
+    mem = sanctum / "MEMORY.md"
+    mem.write_text(content)
+
+    r = _run(str(mem), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = mem.read_text()
+
+    assert (
+        hot.count("| Item | Owner | Unblock |") == 2
+    ), "a table header was deduped away"
+    assert hot.count("|------|-------|--------|") == 2, "a separator was deduped away"
+    assert "| task one | alice | review |" in hot
+    assert "| task two | bob | merge |" in hot
+
+
+# --- M1: same-day applies must not overwrite the prior backup -------------------
+
+
+def test_M1_two_same_day_applies_produce_distinct_backups(tmp_path):
+    lore = _write_lore(tmp_path)
+    r1 = _run(str(lore.parent), "--apply")
+    assert r1.returncode == 0, r1.stderr
+    assert len(list(lore.parent.glob("LORE.md.*.bak"))) == 1
+
+    # Re-introduce same-day drift and apply again — must not clobber the 1st backup.
+    lore.write_text(_lore())
+    r2 = _run(str(lore.parent), "--apply")
+    assert r2.returncode == 0, r2.stderr
+
+    backups = sorted(lore.parent.glob("LORE.md.*.bak"))
+    assert len(backups) == 2, "second same-day apply overwrote the first backup"
+    assert backups[0].name != backups[1].name
+
+
+# --- M2: --qdrant degrades gracefully when the runtime/Qdrant is absent ---------
+
+
+def test_M2_qdrant_runtime_absent_is_graceful_noop(tmp_path):
+    lore = _write_lore(tmp_path)
+    sanctum = lore.parent
+
+    r = _run(str(sanctum), "--apply", "--qdrant", "--group-id", "testproj")
+    assert r.returncode == 0, r.stderr  # no hard dependency, no crash
+
+    # The local archive (source of truth) is written regardless of the Qdrant tier.
+    assert (sanctum / "references" / "lore-archive" / "LORE.archive.md").exists()
+    # The Qdrant path executed and reported its status (push or graceful skip).
+    assert "qdrant:" in r.stdout
+
+
+# --- M3: classification marker must not leak into the pointer body --------------
+
+
+def test_M3_marker_stripped_from_pointer(tmp_path):
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Things Learned the Hard Way\n\n"
+        "- [stale] Historical decision about the old pipeline.\n"
+        "  Detail that now lives behind the index line.\n"
+    )
+    lore = _write_lore(tmp_path, content)
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+
+    assert "_[archived " in hot, "no pointer was left"
+    assert "[stale]" not in hot, "classification marker leaked into the pointer"
+    assert "Historical decision about the old pipeline." in hot
+
+
+# --- M4: --cap override, multi-file apply, single-file invocation ----------------
+
+
+def test_M4_cap_override_changes_over_cap_status(tmp_path):
+    # ~225 unique keep-lines: over the 200 default, comfortably under a 300 override.
+    lore = _write_lore(tmp_path, _lore(keep=210, prune=0, archive=0, dup=0))
+    n = len(lore.read_text().splitlines())
+    assert 200 < n < 300, n
+
+    r_default = _run(str(lore))
+    assert "OVER CAP" in r_default.stdout
+
+    r_override = _run(str(lore), "--cap", "300")
+    assert r_override.returncode == 0, r_override.stderr
+    assert "OVER CAP" not in r_override.stdout
+    assert "/300 lines" in r_override.stdout
+
+
+def test_M4_multi_file_apply_mutates_both(tmp_path):
+    sanctum = tmp_path / "_ai-memory" / "sanctum" / "parzival"
+    sanctum.mkdir(parents=True)
+    (sanctum / "LORE.md").write_text(_lore())
+    (sanctum / "MEMORY.md").write_text(
+        "---\ntype: sanctum-memory\n---\n\n# Memory\n\n## Pending Items\n\n"
+        "- [superseded] an old pending item that is now done.\n"
+        "- a live pending item to keep.\n"
+    )
+
+    r = _run(str(sanctum), "--apply")
+    assert r.returncode == 0, r.stderr
+    assert list(sanctum.glob("LORE.md.*.bak"))
+    assert list(sanctum.glob("MEMORY.md.*.bak"))
+
+    mem = (sanctum / "MEMORY.md").read_text()
+    assert "an old pending item that is now done." not in mem
+    assert "a live pending item to keep." in mem
+
+
+def test_M4_single_file_invocation(tmp_path):
+    lore = _write_lore(tmp_path)
+    # Pass the FILE itself (not the sanctum dir).
+    r = _run(str(lore), "--apply")
+    assert r.returncode == 0, r.stderr
+    assert len(lore.read_text().splitlines()) <= 200
+    assert list(lore.parent.glob("LORE.md.*.bak"))
+
+
+# --- L1: --cap <= 0 is guarded (no ZeroDivisionError) ---------------------------
+
+
+def test_L1_cap_zero_is_guarded(tmp_path):
+    lore = _write_lore(tmp_path)
+    r = _run(str(lore), "--cap", "0")
+    assert r.returncode != 0
+    assert "--cap must be a positive integer" in r.stderr
+
+
+# --- L3: a crash-rerun must not duplicate cold-tier entries ----------------------
+
+
+def test_L3_rerun_does_not_duplicate_cold_entries(tmp_path):
+    """Simulates a crash between cold-append and hot-write: the hot file keeps its
+    [stale] entry, so a rerun re-archives it. The cold tier must stay deduplicated."""
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Things Learned the Hard Way\n\n"
+        "- [stale] Historical decision 0 about the old pipeline.\n"
+        "  Context that mattered at the time.\n"
+    )
+    lore = _write_lore(tmp_path, content)
+
+    r1 = _run(str(lore.parent), "--apply")
+    assert r1.returncode == 0, r1.stderr
+
+    # Re-introduce the same [stale] entry (the crash-rerun scenario) and re-apply.
+    lore.write_text(content)
+    r2 = _run(str(lore.parent), "--apply")
+    assert r2.returncode == 0, r2.stderr
+
+    archive = (
+        lore.parent / "references" / "lore-archive" / "LORE.archive.md"
+    ).read_text()
+    assert (
+        archive.count("Historical decision 0 about the old pipeline.") == 1
+    ), "cold tier accumulated a duplicate on rerun"

--- a/_ai-memory/pov/skills/aim-lore-hygiene/tests/test_lore_hygiene.py
+++ b/_ai-memory/pov/skills/aim-lore-hygiene/tests/test_lore_hygiene.py
@@ -964,18 +964,29 @@ def test_HTML_block_to_eof_no_trailing_blank_is_opaque(tmp_path):
     assert _sha(lore) == sha1, "second apply mutated an HTML-to-EOF block"
 
 
-def test_HTML_after_paragraph_not_swallowed(tmp_path):
-    """A paragraph immediately followed by an HTML block start: the paragraph is its own
-    classifiable entry (so a duplicate paragraph dedups) and the HTML is opaque (not
-    swallowed into the paragraph). Fails on f24547f, where the HTML start was glued into
-    the paragraph (no html break in the paragraph break-set), so the standalone duplicate
-    paragraph did NOT dedup and survived twice."""
+# --- DEFECT #7: an inner ``#``-line must NOT re-expose the rest of the HTML block -----
+#
+# Cycle-6 added a ``and not body_lines[i].lstrip().startswith("#")`` guard to the HTML
+# gather so a heading could advance ``section``. But that guard ALSO terminates the gather
+# at ANY inner line starting with ``#`` (an HTML-comment ``# TODO``, a CSS ``#id``, an
+# inner ``##``), re-exposing every line AFTER it to the classifier — silent prune/dedup of
+# the operator's own data. R1 removes the guard: the block is opaque to its blank-line/EOF
+# terminator with NO inner stop rule. These FAIL on e108bfc (inner line re-exposed).
+
+
+def test_defect7_div_inner_hash_line_does_not_re_expose_block(tmp_path):
+    """A ``<div>`` block with an inner ``#``-leading line followed by a ``[superseded]``
+    inner line is ONE opaque unit: the ``[superseded]`` line is NOT pruned. On e108bfc the
+    ``#``-guard stops the gather at the ``#``-line, re-exposing the ``[superseded]`` line
+    to the classifier, which prunes it (silent loss)."""
     content = (
         "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Notes\n\n"
-        "Prose that must stay its own entry.\n"
-        '<div class="x">a callout right after the prose</div>\n'
+        '<div class="callout">\n'
+        "# an inner hash-leading line (looks like a heading but is inside the block)\n"
+        "- [superseded] inner line AFTER the hash that must stay opaque\n"
+        "</div>\n"
         "\n"
-        "Prose that must stay its own entry.\n"
+        "- a real fact to keep.\n"
     )
     lore = _write_lore(tmp_path, content)
 
@@ -983,12 +994,289 @@ def test_HTML_after_paragraph_not_swallowed(tmp_path):
     assert r.returncode == 0, r.stderr
     hot = lore.read_text()
 
-    # Paragraph classified → the standalone duplicate is deduped to one occurrence.
+    assert '<div class="callout">' in hot and "</div>" in hot
     assert (
-        hot.count("Prose that must stay its own entry.") == 1
-    ), "HTML was swallowed into the paragraph (duplicate paragraph not deduped)"
-    # HTML kept opaque, byte-preserved.
+        "# an inner hash-leading line (looks like a heading but is inside the block)"
+        in hot
+    )
+    assert (
+        "- [superseded] inner line AFTER the hash that must stay opaque" in hot
+    ), "inner line after an inner #-line was re-exposed and pruned (defect #7)"
+    assert "- a real fact to keep." in hot
+
+    sha1 = _sha(lore)
+    r2 = _run(str(lore.parent), "--apply")
+    assert r2.returncode == 0, r2.stderr
+    assert _sha(lore) == sha1, "second apply mutated an opaque HTML block (defect #7)"
+
+
+def test_defect7_comment_inner_hash_line_does_not_re_expose_block(tmp_path):
+    """The ``<!--`` comment variant of defect #7: an inner ``#``-line inside a comment
+    block must not re-expose the following ``[superseded]`` inner line to pruning. FAILS on
+    e108bfc."""
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Notes\n\n"
+        "<!-- review notes:\n"
+        "## an inner ATX-looking line inside the comment\n"
+        "- [superseded] inner line AFTER the hash that must stay opaque\n"
+        "end of notes -->\n"
+        "\n"
+        "- a real fact to keep.\n"
+    )
+    lore = _write_lore(tmp_path, content)
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+
+    assert "<!-- review notes:" in hot and "end of notes -->" in hot
+    assert "## an inner ATX-looking line inside the comment" in hot
+    assert (
+        "- [superseded] inner line AFTER the hash that must stay opaque" in hot
+    ), "inner comment line after an inner #-line was re-exposed and pruned (defect #7)"
+
+    sha1 = _sha(lore)
+    r2 = _run(str(lore.parent), "--apply")
+    assert r2.returncode == 0, r2.stderr
+    assert (
+        _sha(lore) == sha1
+    ), "second apply mutated an opaque comment block (defect #7)"
+
+
+def test_defect7_inner_hash_line_does_not_re_expose_inner_duplicate(tmp_path):
+    """Opus-D untagged variant of defect #7: an inner duplicate line AFTER an inner
+    ``#``-line inside a ``<div>`` block must NOT be deduped — the whole block is opaque. On
+    e108bfc the ``#``-guard re-exposes both duplicates as same-section content and the
+    second is deduped away (count drops 2→1)."""
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Notes\n\n"
+        "<div>\n"
+        "# inner hash line\n"
+        "- a duplicated inner line\n"
+        "- a duplicated inner line\n"
+        "</div>\n"
+        "\n"
+        "- a real fact to keep.\n"
+    )
+    lore = _write_lore(tmp_path, content)
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+
+    assert (
+        hot.count("- a duplicated inner line") == 2
+    ), "inner HTML duplicate after a #-line was deduped (defect #7)"
+
+    sha1 = _sha(lore)
+    r2 = _run(str(lore.parent), "--apply")
+    assert r2.returncode == 0, r2.stderr
+    assert _sha(lore) == sha1, "second apply mutated an opaque HTML block (defect #7)"
+
+
+# --- CYCLE-5 HIGH (div/details variants): an opaque block before a heading resets dedup --
+#
+# When an HTML block absorbs a following ``## heading`` (no blank between), ``section`` does
+# not advance. R2 resets the dedup ``seen`` set on every ``__passthrough__`` / ``__header__``
+# boundary, so a cross-section twin after the block is kept. These FAIL on a build with R1
+# reverted (HTML opaque again) but no R2 — the absorbed heading attributes the twin to the
+# prior section and the section-scoped dedup drops it.
+
+
+def test_cycle5_div_block_before_heading_cross_section_twins_both_kept(tmp_path):
+    """``<div>`` variant: a one-line ``<div>`` block immediately before a ``## heading``
+    (no blank between) absorbs the heading; the opaque boundary resets dedup so both
+    cross-section twins are kept (dedup 0). FAILS on a no-R2 build."""
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n"
+        "## Decisions\n\n"
+        "- DEC-1: use approach X for the pipeline.\n"
+        '<div class="note">a side note with no blank before the next heading</div>\n'
+        "## Conventions\n\n"
+        "- DEC-1: use approach X for the pipeline.\n"  # cross-section twin → KEPT
+        "- a unique conventions line\n"
+    )
+    lore = _write_lore(tmp_path, content)
+    assert lore.read_text().count("- DEC-1: use approach X for the pipeline.") == 2
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+
+    assert (
+        hot.count("- DEC-1: use approach X for the pipeline.") == 2
+    ), "cross-section twin deleted (no dedup-boundary reset on the opaque <div>)"
+    assert (
+        '<div class="note">a side note with no blank before the next heading</div>'
+        in hot
+    )
+    assert "## Conventions" in hot
+    assert "- a unique conventions line" in hot
+
+    sha1 = _sha(lore)
+    r2 = _run(str(lore.parent), "--apply")
+    assert r2.returncode == 0, r2.stderr
+    assert _sha(lore) == sha1, "second apply was not idempotent"
+
+
+def test_cycle5_details_block_before_heading_cross_section_twins_both_kept(tmp_path):
+    """``<details>`` variant: a multi-line ``<details>`` block immediately before a
+    ``## heading`` (no blank between) absorbs the heading; the opaque boundary resets dedup
+    so both cross-section twins are kept. FAILS on a no-R2 build."""
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n"
+        "## Decisions\n\n"
+        "- DEC-1: use approach X for the pipeline.\n"
+        "<details>\n"
+        "<summary>background</summary>\n"
+        "some collapsed detail here\n"
+        "</details>\n"
+        "## Conventions\n\n"
+        "- DEC-1: use approach X for the pipeline.\n"  # cross-section twin → KEPT
+        "- a unique conventions line\n"
+    )
+    lore = _write_lore(tmp_path, content)
+    assert lore.read_text().count("- DEC-1: use approach X for the pipeline.") == 2
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+
+    assert (
+        hot.count("- DEC-1: use approach X for the pipeline.") == 2
+    ), "cross-section twin deleted (no dedup-boundary reset on the opaque <details>)"
+    assert "<details>" in hot and "</details>" in hot
+    assert "some collapsed detail here" in hot
+    assert "## Conventions" in hot
+
+    sha1 = _sha(lore)
+    r2 = _run(str(lore.parent), "--apply")
+    assert r2.returncode == 0, r2.stderr
+    assert _sha(lore) == sha1, "second apply was not idempotent"
+
+
+# --- DEDUP BOUNDARY: within a contiguous run dedups; an opaque/heading boundary does not --
+
+
+def test_within_section_adjacent_duplicate_collapses(tmp_path):
+    """Two identical content bullets in one section with NO structural boundary between
+    them collapse keep-first (R2 does not regress ordinary within-run dedup). Passes on all
+    bases."""
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Notes\n\n"
+        "- a repeated fact about the system.\n"
+        "- a repeated fact about the system.\n"  # adjacent dup → second collapsed
+        "- a unique fact.\n"
+    )
+    lore = _write_lore(tmp_path, content)
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+
+    assert (
+        hot.count("- a repeated fact about the system.") == 1
+    ), "adjacent within-section duplicate was not collapsed keep-first"
+    assert "- a unique fact." in hot
+    assert "dedup 1" in r.stdout
+
+    sha1 = _sha(lore)
+    r2 = _run(str(lore.parent), "--apply")
+    assert r2.returncode == 0, r2.stderr
+    assert _sha(lore) == sha1, "second apply was not idempotent"
+
+
+def test_dup_across_code_fence_both_kept(tmp_path):
+    """Two identical content bullets separated by a code fence (a ``__passthrough__``) are
+    BOTH kept — the fence is a structural boundary that resets dedup (R2, the new safe
+    behavior, asserted explicitly so it is intentional). FAILS on a no-R2 build (the fence
+    did not reset ``seen`` → second deduped)."""
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Notes\n\n"
+        "- identical content line.\n"
+        "```text\n"
+        "some fenced sample\n"
+        "```\n"
+        "- identical content line.\n"
+    )
+    lore = _write_lore(tmp_path, content)
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+
+    assert (
+        hot.count("- identical content line.") == 2
+    ), "duplicate separated by a code fence was wrongly deduped (boundary did not reset)"
+    assert hot.count("```") == 2, "a fence delimiter was lost"
+    assert "clean, no-op" in r.stdout, "an unexpected dedup/prune action fired"
+
+    sha1 = _sha(lore)
+    r2 = _run(str(lore.parent), "--apply")
+    assert r2.returncode == 0, r2.stderr
+    assert _sha(lore) == sha1, "second apply was not idempotent"
+
+
+def test_dup_across_opaque_block_is_kept(tmp_path):
+    """Two identical content bullets separated by an opaque ``<div>`` block (blank-bounded,
+    so it does NOT absorb a heading) are BOTH kept — the opaque block resets dedup (R2).
+    FAILS on a no-R2 build."""
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Notes\n\n"
+        "- identical content line.\n"
+        '<div class="callout">an opaque callout between the twins</div>\n'
+        "\n"
+        "- identical content line.\n"
+    )
+    lore = _write_lore(tmp_path, content)
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+
+    assert (
+        hot.count("- identical content line.") == 2
+    ), "duplicate separated by an opaque <div> was wrongly deduped (boundary did not reset)"
+    assert '<div class="callout">an opaque callout between the twins</div>' in hot
+    assert "clean, no-op" in r.stdout, "an unexpected dedup/prune action fired"
+
+    sha1 = _sha(lore)
+    r2 = _run(str(lore.parent), "--apply")
+    assert r2.returncode == 0, r2.stderr
+    assert _sha(lore) == sha1, "second apply was not idempotent"
+
+
+def test_HTML_after_paragraph_not_swallowed(tmp_path):
+    """A paragraph immediately followed by an HTML block start: the paragraph is its own
+    classifiable entry and the HTML block is opaque (not swallowed into the paragraph).
+    Proven by a leading-tagged prose entry that is PRUNED as its own unit while the
+    immediately-following ``<div>`` callout survives byte-for-byte — if the div were glued
+    into the paragraph, the whole unit (div included) would be pruned. Fails on f24547f,
+    where the HTML start was glued into the paragraph (no html break in the paragraph
+    break-set), so the div would be pruned along with the tagged prose.
+
+    The original variant proved non-swallowing via cross-block dedup; R2 now intentionally
+    resets dedup on an opaque boundary (so twins across an opaque block are BOTH kept),
+    making cross-block dedup an invalid discriminator here. The boundary-reset behavior is
+    covered by test_dup_across_opaque_block_is_kept and the cross-section tests."""
+    content = (
+        "---\ntype: sanctum-lore\n---\n\n# Lore\n\n## Notes\n\n"
+        "[superseded] prose that is its own tagged entry.\n"
+        '<div class="x">a callout right after the prose</div>\n'
+        "\n"
+        "A trailing prose line that stays.\n"
+    )
+    lore = _write_lore(tmp_path, content)
+
+    r = _run(str(lore.parent), "--apply")
+    assert r.returncode == 0, r.stderr
+    hot = lore.read_text()
+
+    # Tagged prose pruned as its own unit; the adjacent HTML block is NOT swallowed into
+    # it (else the div would be pruned too) and survives opaque, byte-preserved.
+    assert "[superseded] prose that is its own tagged entry." not in hot
     assert '<div class="x">a callout right after the prose</div>' in hot
+    assert "A trailing prose line that stays." in hot
 
     sha1 = _sha(lore)
     r2 = _run(str(lore.parent), "--apply")
@@ -1035,14 +1323,16 @@ def test_dedup_is_section_scoped(tmp_path):
     assert _sha(lore) == sha1, "second apply was not idempotent"
 
 
-def test_HTML_block_before_heading_no_blank_advances_section(tmp_path):
-    """An HTML/comment block whose last line is immediately followed by a ``## heading``
-    (no blank line between) must NOT absorb that heading: the heading is emitted as a
-    structural ``__header__`` and advances ``section``, so a content line under the new
-    section is NOT wrongly judged a same-section duplicate of an identical line in the
-    prior section. Both cross-section twins are kept (dedup 0). Fails on 647a5e5, whose
-    blank-line-only HTML gather swallows the heading, leaving the second section's twin
-    attributed to the first section and silently deleted by the section-scoped dedup."""
+def test_HTML_comment_block_before_heading_cross_section_twins_both_kept(tmp_path):
+    """Cycle-5 HIGH (comment variant): an HTML/comment block whose last line is
+    immediately followed by a ``## heading`` (no blank line between) ABSORBS that heading
+    into one opaque ``__passthrough__`` unit (R1 — HTML is opaque to its blank-line/EOF
+    terminator, no inner stop rule). Section tracking does NOT advance, but the opaque
+    block is a STRUCTURAL BOUNDARY that resets the dedup ``seen`` set (R2), so the
+    identical content line after it is NOT judged a same-section duplicate. Both twins are
+    kept (dedup 0). Fails on a build with R1 reverted but no R2 — the absorbed heading
+    leaves the second twin in the prior section and the section-scoped dedup drops it.
+    """
     content = (
         "---\ntype: sanctum-lore\n---\n\n# Lore\n\n"
         "## Decisions\n\n"
@@ -1059,12 +1349,12 @@ def test_HTML_block_before_heading_no_blank_advances_section(tmp_path):
     assert r.returncode == 0, r.stderr
     hot = lore.read_text()
 
-    # Both twins survive: the heading advanced the section, so neither is a same-section
-    # duplicate. On 647a5e5 the swallowed heading drops the Conventions twin to zero → one.
+    # Both twins survive: the opaque block between them reset dedup, so the second is not a
+    # same-section duplicate. Without R2 the absorbed heading drops the twin to zero → one.
     assert (
         hot.count("- DEC-1: use approach X for the pipeline.") == 2
-    ), "cross-section twin silently deleted (heading absorbed into the HTML block)"
-    # The heading and the opaque comment line are both preserved.
+    ), "cross-section twin silently deleted (no dedup-boundary reset on the opaque block)"
+    # The heading (now inside the opaque block) and the comment line are both preserved.
     assert "## Conventions" in hot
     assert "<!-- reviewed 2026-01 -->" in hot
     assert "- a unique conventions line" in hot


### PR DESCRIPTION
## What

Adds **`aim-lore-hygiene`**, a net-new skill that keeps always-injected sanctum
files (`LORE.md`, `MEMORY.md`) healthy: it enforces a ~200-line cap, flags files
crossing the ~80%-of-cap compaction trigger, and applies the prune-vs-archive
decision rule.

Entry classification is **marker-driven** (the script never guesses an entry is
low-utility):

- **Delete** — `[superseded]`, `[contradicted]`, `[wrong]`, `[obsolete]`,
  `[prune]`, an `[expired:YYYY-MM-DD]` TTL that has passed, or `~~strikethrough~~`.
- **Archive** — `[stale]`/`[archive]` entries move to a local cold-tier file
  (`references/lore-archive/<FILE>.archive.md`) with a one-line pointer left in
  the hot file.
- **Dedup** — exact-duplicate entries collapse to the first occurrence.
- **Keep** — everything else.

The script is **read-only dry-run by default**; `--apply` writes a timestamped
`.bak` sidecar before mutating. It never fakes semantic shrinkage: an over-cap
file with no mechanical actions available is flagged for a manual/LLM
summarization pass rather than truncated, so recall-value content is never lost.
An opt-in `--qdrant --group-id <project>` additionally pushes archived blocks to
the Qdrant cold tier (best-effort, degrades gracefully when the runtime/Qdrant is
unavailable).

## Why

Per-operator lore files are injected every session and grow without bound; past
~200 lines, rules get lost in the noise and `MEMORY.md` is silently truncated.
This skill is the write-side hygiene lifecycle those files were missing —
FILE-content compaction, distinct from `aim-purge` (which purges Qdrant points by
age).

## Structure

Thin `SKILL.md` (frontmatter + when-to-use + numbered steps) over an external,
unit-tested `scripts/lore_hygiene.py` invoked **by path**; on-demand `references/`
for caps and the decision rule.

```
aim-lore-hygiene/
├── SKILL.md
├── scripts/lore_hygiene.py
├── references/{caps.md, decision-rule.md}
└── tests/test_lore_hygiene.py
```

## Tests

11 tests run the script via subprocess against `tmp_path` fixtures (no mocks),
covering dry-run safety, cap enforcement, compaction-under-cap, idempotency,
archive-leaves-pointer + cold file, superseded-is-deleted-not-archived,
expiry/strikethrough pruning, the no-truncation guard, and a production-scale
fixture.

- New skill tests: **11 passed**.
- Lint gate: **black, ruff, isort** all clean.
- Full local suite: **4215 passed, 683 skipped, 6 failed** — the 6 are
  pre-existing environment-only failures (project-discovery config dirs, GitHub
  config defaults, Streamlit CI import); no new failures.