### PR TITLE
Ship an AI-Memory agent-guidance file to projects via the installer (TD-600)

### DIFF
--- a/.claude/rules/ai-memory.md
+++ b/.claude/rules/ai-memory.md
@@ -1,0 +1,81 @@
+# AI Memory — Agent Guidance
+
+This file ships with the **AI-Memory** module and is loaded into every Claude Code session in this project. It explains how to work with the memory system, plus the general engineering conduct AI-Memory expects. (Your own project's `CLAUDE.md` is separate and untouched.)
+
+## Using AI Memory
+
+AI Memory is a persistent context layer: it captures decisions, code patterns, and conventions as you work, and surfaces the relevant past context automatically — at session start and per turn — so you don't re-explain prior work.
+
+- **Recall is automatic.** Relevant memory is injected on session resume and as you work; you rarely need to ask for it.
+- **Search on demand** with the `aim-search` skill. Check system health with `aim-status`; deliberately store something with `aim-save`; view configuration with `aim-settings`.
+- **Memory is project-scoped** — each project's memory is isolated. The project id is auto-detected; override it with the `AI_MEMORY_PROJECT_ID` environment variable (or in `.claude/settings.json`). If you work across multiple repos, confirm the active project with `aim-status`.
+- **Capture runs in the background** via hooks — no action needed. For throwaway or experimental work where you don't want it recorded, toggle capture with `aim-pause-updates`.
+- **Trust but verify recalled facts.** Injected memories describe what was true when written. If a recalled fact names a file, flag, or function, confirm it still exists before relying on it.
+
+## If something's off
+
+AI-Memory is actively developed. If an `aim-*` skill, hook, or piece of guidance is confusing, behaves unexpectedly, or looks stale, **surface it** — tell the person you're working with, or open an issue on the AI-Memory repository (https://github.com/Hidden-History/ai-memory/issues). That feedback shapes the product. Don't silently work around a broken skill.
+
+---
+
+# General engineering conduct
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Agent-guidance rule file** — the installer now ships an AI-Memory-owned
+  `.claude/rules/ai-memory.md` into each project, auto-loaded by Claude Code at
+  session start. It explains how to work with the memory system (`aim-*` skills,
+  automatic recall, project scoping, capture toggling) and the general engineering
+  conduct AI-Memory expects. The installer owns this exact filename, so it is
+  overwritten idempotently on every install and never touches user-authored files —
+  not `CLAUDE.md`, `.claude/CLAUDE.md`, `CLAUDE.local.md`, or any other
+  `.claude/rules/*.md`. Deployed on both fresh installs and in-place updates.
+
 - **`aim-lore-hygiene` skill** — per-operator hygiene for always-injected sanctum
   files (`LORE.md`, `MEMORY.md`). Enforces the ~200-line cap, flags files crossing
   the ~80%-of-cap compaction trigger, and applies the prune-vs-archive decision

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Agent-guidance files now refresh on every install** — existing installations
+  pick up updated guidance automatically by re-running
+  `./scripts/install.sh <project-dir>`. No special flag is needed; the guidance
+  file for each configured CLI is deployed on every install, not only on the
+  initial setup.
+
 ### Added
 
 - **Agent-guidance file across all supported CLIs** — the installer now ships an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Agent-guidance rule file** — the installer now ships an AI-Memory-owned
-  `.claude/rules/ai-memory.md` into each project, auto-loaded by Claude Code at
-  session start. It explains how to work with the memory system (`aim-*` skills,
-  automatic recall, project scoping, capture toggling) and the general engineering
-  conduct AI-Memory expects. The installer owns this exact filename, so it is
-  overwritten idempotently on every install and never touches user-authored files —
-  not `CLAUDE.md`, `.claude/CLAUDE.md`, `CLAUDE.local.md`, or any other
-  `.claude/rules/*.md`. Deployed on both fresh installs and in-place updates.
+- **Agent-guidance file across all supported CLIs** — the installer now ships an
+  AI-Memory guidance file into each project for every supported CLI, auto-loaded at
+  session start, in that CLI's own always-on convention. It explains how to work with
+  the memory system (the per-CLI memory commands, automatic recall, project scoping)
+  and the general engineering conduct AI-Memory expects. Each CLI's command names are
+  used (`search-memory` / `memory-status` / `save-memory`):
+  - **Claude Code** — AI-Memory-owned `.claude/rules/ai-memory.md`.
+  - **Gemini CLI** — AI-Memory-owned `AI-MEMORY.md` at the project root, registered in
+    `context.fileName` in `.gemini/settings.json` by appending (never dropping
+    `GEMINI.md` or any user-set entries; the user's `GEMINI.md` is never written).
+  - **Cursor** — AI-Memory-owned `.cursor/rules/ai-memory.mdc` with
+    `alwaysApply: true`; never touches other `.mdc`, `.cursorrules`, or `AGENTS.md`.
+  - **Codex** — a managed marker-block (`<!-- BEGIN AI-MEMORY -->` …
+    `<!-- END AI-MEMORY -->`) in the project-root `AGENTS.md`, inserted if absent and
+    replaced in place on update. A backup is made and the write is atomic; everything
+    outside the markers is preserved byte-for-byte.
+
+  Every CLI's delivery is own-file or managed-block, idempotent on re-install, and
+  zero-clobber of user-authored files. Deployed on both fresh installs and in-place
+  updates.
 
 - **`aim-lore-hygiene` skill** — per-operator hygiene for always-injected sanctum
   files (`LORE.md`, `MEMORY.md`). Enforces the ~200-line cap, flags files crossing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   AI-Memory guidance file into each project for every supported CLI, auto-loaded at
   session start, in that CLI's own always-on convention. It explains how to work with
   the memory system (the per-CLI memory commands, automatic recall, project scoping)
-  and the general engineering conduct AI-Memory expects. Each CLI's command names are
-  used (`search-memory` / `memory-status` / `save-memory`):
+  and the general engineering conduct AI-Memory expects. Each CLI's own command names
+  are used (Gemini and Cursor: `search-memory` / `memory-status` / `save-memory`;
+  Codex: `search-memory` / `memory-status`):
   - **Claude Code** — AI-Memory-owned `.claude/rules/ai-memory.md`.
   - **Gemini CLI** — AI-Memory-owned `AI-MEMORY.md` at the project root, registered in
     `context.fileName` in `.gemini/settings.json` by appending (never dropping

--- a/docs/MULTI-IDE-SUPPORT.md
+++ b/docs/MULTI-IDE-SUPPORT.md
@@ -59,17 +59,17 @@ During installation, you'll see:
 
 ### Manual IDE Selection
 
-Override auto-detection with the `--ide` flag:
+Override auto-detection with the `IDE_FLAG` environment variable:
 
 ```bash
 # Configure specific IDEs only
-./scripts/install.sh --ide gemini,cursor <your-project-dir>
+IDE_FLAG=gemini,cursor ./scripts/install.sh <your-project-dir>
 
 # Skip all non-Claude IDE config
-./scripts/install.sh --ide none <your-project-dir>
+IDE_FLAG=none ./scripts/install.sh <your-project-dir>
 
-# Force overwrite existing IDE configs
-./scripts/install.sh --force <your-project-dir>
+# Force overwrite existing IDE hook configs
+FORCE_IDE=true ./scripts/install.sh <your-project-dir>
 ```
 
 ### Adding IDEs to an Existing Installation
@@ -185,7 +185,7 @@ MCP tools are normalized across all IDEs:
 
 ### IDE not detected during installation
 - Ensure the IDE CLI is in your PATH (`gemini`, `codex`, `agent`/`cursor-agent`)
-- Use `--ide gemini,cursor` to skip detection and force configuration
+- Use `IDE_FLAG=gemini,cursor` to skip detection and force configuration
 
 ### Hooks not firing
 - Check that the config file exists (`.gemini/settings.json`, `.cursor/hooks.json`, etc.)

--- a/docs/MULTI-IDE-SUPPORT.md
+++ b/docs/MULTI-IDE-SUPPORT.md
@@ -76,6 +76,21 @@ Override auto-detection with the `--ide` flag:
 
 Re-run the installer with Option 1 (Add project to existing installation). IDE detection runs automatically and will configure any newly detected IDEs.
 
+## Agent-Guidance File
+
+On install, AI-Memory also deploys an **agent-guidance file** into the project for each configured CLI. This is a short, always-loaded file that tells the agent how to work with the memory system — automatic capture/recall, the per-CLI memory commands, and `AI_MEMORY_PROJECT_ID` project-scoping — plus concise general engineering conduct. It is separate from the hook/adapter configuration above. Each file is AI-Memory-**owned** (or a managed block for Codex), so re-installing is idempotent and **user-authored files are never clobbered**.
+
+| CLI | Guidance file | Mechanism |
+|-----|---------------|-----------|
+| Claude Code | `.claude/rules/ai-memory.md` | owned file; auto-loaded at session start |
+| Gemini CLI | `AI-MEMORY.md` (project root) | owned file; appended to `context.fileName` in `.gemini/settings.json` (preserves `GEMINI.md` + user entries; the user's `GEMINI.md` is never written) |
+| Cursor | `.cursor/rules/ai-memory.mdc` | owned file with `alwaysApply: true`; other `.mdc` / `.cursorrules` / `AGENTS.md` untouched |
+| Codex | managed block in project-root `AGENTS.md` | Codex has no owned-file path, so an AI-Memory block delimited by `<!-- BEGIN AI-MEMORY -->` … `<!-- END AI-MEMORY -->` is inserted-if-absent / replaced-in-place; backup-first + atomic write; everything outside the markers is byte-preserved |
+
+**Codex safety behavior**: if the project's `AGENTS.md` already contains malformed or ambiguous AI-Memory markers (an unbalanced `BEGIN`/`END`, out-of-order, or duplicate markers), the deploy refuses and warns, leaving `AGENTS.md` unchanged and letting the install continue — it never deletes or duplicates user content. Resolve the markers manually and re-run to get the block.
+
+**Command names**: the guidance text uses each CLI's own memory commands — Gemini/Cursor use `search-memory` / `memory-status` / `save-memory`; Codex uses `search-memory` / `memory-status` (no `save-memory`); Claude uses the `aim-*` skills.
+
 ## IDE-Specific Details
 
 ### Gemini CLI

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3909,14 +3909,21 @@ with open(sys.argv[4], 'w') as f:
     # a managed marker-block inside the project-root AGENTS.md (insert-if-absent /
     # replace-in-place). merge_agents_md.py backs up + writes atomically and keeps
     # everything outside the markers byte-for-byte. On malformed markers it exits 2
-    # (warns to stderr, leaves file unchanged); || true ensures the install continues.
+    # (warns to stderr, leaves file unchanged); the install always continues.
     local guidance_src="$install_dir/src/memory/adapters/templates/codex/ai-memory.md"
     local merge_script="$install_dir/scripts/merge_agents_md.py"
     if [[ -f "$guidance_src" ]]; then
         if [[ -f "$merge_script" ]]; then
-            python3 "$merge_script" "$project_path/AGENTS.md" "$guidance_src" \
-                && log_success "Deployed agent-guidance block to $project_path/AGENTS.md" \
-                || true
+            if python3 "$merge_script" "$project_path/AGENTS.md" "$guidance_src"; then
+                log_success "Deployed agent-guidance block to $project_path/AGENTS.md"
+            else
+                rc=$?
+                if [[ "$rc" -eq 2 ]]; then
+                    : # malformed-marker refuse — merge_agents_md.py already warned to stderr; continue
+                else
+                    log_warning "Codex guidance deploy failed (exit ${rc}); AGENTS.md left unchanged — continuing install"
+                fi
+            fi
         else
             log_warning "merge_agents_md.py not found in $install_dir/scripts — skipping Codex guidance block"
         fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3714,10 +3714,50 @@ write_gemini_config() {
     local project_id="$3"
     local force="${4:-false}"
     local config_file="$project_path/.gemini/settings.json"
+    local guidance_src="$install_dir/src/memory/adapters/templates/gemini/ai-memory.md"
+
+    # TD-600: deploy the guidance file and ensure context.fileName registration on
+    # every install — regardless of whether the hook config write is skipped below.
+    # Gemini discovers context files by basename, so AI-MEMORY.md lives at project
+    # root (the user's GEMINI.md is never touched).
+    if [[ -f "$guidance_src" ]]; then
+        cp "$guidance_src" "$project_path/AI-MEMORY.md"
+        log_success "Deployed agent-guidance file to $project_path/AI-MEMORY.md"
+    fi
+    # Ensure AI-MEMORY.md is registered in context.fileName when an existing
+    # settings.json would otherwise be skipped (append-preserve: never drops GEMINI.md
+    # or user entries; non-str/non-list type guard retained).
+    if [[ -f "$config_file" ]]; then
+        python3 -c "
+import json, sys
+config_path = sys.argv[1]
+try:
+    with open(config_path) as f:
+        cfg = json.load(f)
+except (ValueError, OSError):
+    cfg = {}
+ctx = cfg.setdefault('context', {})
+existing = ctx.get('fileName')
+if existing is None:
+    names = ['GEMINI.md']
+elif isinstance(existing, str):
+    names = [existing]
+elif isinstance(existing, list):
+    names = list(existing)
+else:
+    names = ['GEMINI.md']
+if 'AI-MEMORY.md' not in names:
+    names.append('AI-MEMORY.md')
+    ctx['fileName'] = names
+    with open(config_path, 'w') as f:
+        json.dump(cfg, f, indent=2)
+        f.write('\n')
+" "$config_file"
+    fi
 
     if [[ -f "$config_file" ]] && grep -q "AI_MEMORY_INSTALL_DIR" "$config_file" 2>/dev/null; then
         if [[ "$force" != "true" ]]; then
-            log_warning "Gemini config already contains ai-memory hooks — skipping (use --force to overwrite)"
+            log_warning "Gemini config already contains ai-memory hooks — skipping (use FORCE_IDE=true to overwrite)"
             return 0
         fi
     fi
@@ -3786,15 +3826,6 @@ with open(config_path, 'w') as f:
     mkdir -p "$project_path/.gemini/commands"
     cp "$install_dir/src/memory/adapters/templates/gemini/"*.toml "$project_path/.gemini/commands/" 2>/dev/null || true
 
-    # TD-600: deploy the AI-Memory-owned guidance file to project root. Gemini
-    # discovers context files by basename in the project tree, so it lives at the
-    # root (never the user's GEMINI.md, which is left untouched).
-    local guidance_src="$install_dir/src/memory/adapters/templates/gemini/ai-memory.md"
-    if [[ -f "$guidance_src" ]]; then
-        cp "$guidance_src" "$project_path/AI-MEMORY.md"
-        log_success "Deployed agent-guidance file to $project_path/AI-MEMORY.md"
-    fi
-
     log_success "Gemini CLI config written to $config_file"
 }
 
@@ -3804,10 +3835,20 @@ write_cursor_config() {
     local project_id="$3"
     local force="${4:-false}"
     local config_file="$project_path/.cursor/hooks.json"
+    local guidance_src="$install_dir/src/memory/adapters/templates/cursor/ai-memory.mdc"
+
+    # TD-600: deploy the AI-Memory-owned guidance rule on every install — regardless
+    # of whether the hook config write is skipped below. The .mdc carries
+    # `alwaysApply: true`; never touches other .mdc, .cursorrules, or AGENTS.md.
+    if [[ -f "$guidance_src" ]]; then
+        mkdir -p "$project_path/.cursor/rules"
+        cp "$guidance_src" "$project_path/.cursor/rules/ai-memory.mdc"
+        log_success "Deployed agent-guidance rule to $project_path/.cursor/rules/ai-memory.mdc"
+    fi
 
     if [[ -f "$config_file" ]] && grep -q "AI_MEMORY_INSTALL_DIR" "$config_file" 2>/dev/null; then
         if [[ "$force" != "true" ]]; then
-            log_warning "Cursor config already contains ai-memory hooks — skipping (use --force to overwrite)"
+            log_warning "Cursor config already contains ai-memory hooks — skipping (use FORCE_IDE=true to overwrite)"
             return 0
         fi
     fi
@@ -3845,16 +3886,6 @@ with open(sys.argv[4], 'w') as f:
         fi
     done
 
-    # TD-600: deploy the AI-Memory-owned guidance rule. The .mdc carries
-    # `alwaysApply: true` frontmatter so Cursor includes it in every conversation.
-    # Own-file overwrite — never touches other .mdc, .cursorrules, or AGENTS.md.
-    local guidance_src="$install_dir/src/memory/adapters/templates/cursor/ai-memory.mdc"
-    if [[ -f "$guidance_src" ]]; then
-        mkdir -p "$project_path/.cursor/rules"
-        cp "$guidance_src" "$project_path/.cursor/rules/ai-memory.mdc"
-        log_success "Deployed agent-guidance rule to $project_path/.cursor/rules/ai-memory.mdc"
-    fi
-
     log_success "Cursor IDE config written to $config_file"
 }
 
@@ -3864,10 +3895,34 @@ write_codex_config() {
     local project_id="$3"
     local force="${4:-false}"
     local config_file="$project_path/.codex/hooks.json"
+    local guidance_src="$install_dir/src/memory/adapters/templates/codex/ai-memory.md"
+    local merge_script="$install_dir/scripts/merge_agents_md.py"
+
+    # TD-600: deploy the guidance block on every install — regardless of whether the
+    # hook config write is skipped below. Managed marker-block in AGENTS.md
+    # (insert-if-absent / replace-in-place); merge_agents_md.py backs up + writes
+    # atomically; everything outside markers preserved byte-for-byte. On malformed
+    # markers (exit 2) it warns and leaves AGENTS.md unchanged; install continues.
+    if [[ -f "$guidance_src" ]]; then
+        if [[ -f "$merge_script" ]]; then
+            if python3 "$merge_script" "$project_path/AGENTS.md" "$guidance_src"; then
+                log_success "Deployed agent-guidance block to $project_path/AGENTS.md"
+            else
+                local rc=$?
+                if [[ "$rc" -eq 2 ]]; then
+                    : # malformed-marker refuse — merge_agents_md.py already warned to stderr; continue
+                else
+                    log_warning "Codex guidance deploy failed (exit ${rc}); AGENTS.md left unchanged — continuing install"
+                fi
+            fi
+        else
+            log_warning "merge_agents_md.py not found in $install_dir/scripts — skipping Codex guidance block"
+        fi
+    fi
 
     if [[ -f "$config_file" ]] && grep -q "AI_MEMORY_INSTALL_DIR" "$config_file" 2>/dev/null; then
         if [[ "$force" != "true" ]]; then
-            log_warning "Codex config already contains ai-memory hooks — skipping (use --force to overwrite)"
+            log_warning "Codex config already contains ai-memory hooks — skipping (use FORCE_IDE=true to overwrite)"
             return 0
         fi
     fi
@@ -3904,30 +3959,6 @@ with open(sys.argv[4], 'w') as f:
             cp "$install_dir/src/memory/adapters/templates/codex/$skill/SKILL.md" "$project_path/.codex/skills/$skill/" 2>/dev/null || true
         fi
     done
-
-    # TD-600: Codex has no always-on owned guidance file, so deliver guidance as
-    # a managed marker-block inside the project-root AGENTS.md (insert-if-absent /
-    # replace-in-place). merge_agents_md.py backs up + writes atomically and keeps
-    # everything outside the markers byte-for-byte. On malformed markers it exits 2
-    # (warns to stderr, leaves file unchanged); the install always continues.
-    local guidance_src="$install_dir/src/memory/adapters/templates/codex/ai-memory.md"
-    local merge_script="$install_dir/scripts/merge_agents_md.py"
-    if [[ -f "$guidance_src" ]]; then
-        if [[ -f "$merge_script" ]]; then
-            if python3 "$merge_script" "$project_path/AGENTS.md" "$guidance_src"; then
-                log_success "Deployed agent-guidance block to $project_path/AGENTS.md"
-            else
-                local rc=$?
-                if [[ "$rc" -eq 2 ]]; then
-                    : # malformed-marker refuse — merge_agents_md.py already warned to stderr; continue
-                else
-                    log_warning "Codex guidance deploy failed (exit ${rc}); AGENTS.md left unchanged — continuing install"
-                fi
-            fi
-        else
-            log_warning "merge_agents_md.py not found in $install_dir/scripts — skipping Codex guidance block"
-        fi
-    fi
 
     log_success "Codex CLI config written to $config_file"
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3770,8 +3770,11 @@ if existing_names is None:
     names = ['GEMINI.md']
 elif isinstance(existing_names, str):
     names = [existing_names]
-else:
+elif isinstance(existing_names, list):
     names = list(existing_names)
+else:
+    # Non-string, non-list value (e.g. integer, boolean) — treat as absent.
+    names = ['GEMINI.md']
 if 'AI-MEMORY.md' not in names:
     names.append('AI-MEMORY.md')
 config['context'] = {'fileName': names}
@@ -3905,11 +3908,18 @@ with open(sys.argv[4], 'w') as f:
     # TD-600: Codex has no always-on owned guidance file, so deliver guidance as
     # a managed marker-block inside the project-root AGENTS.md (insert-if-absent /
     # replace-in-place). merge_agents_md.py backs up + writes atomically and keeps
-    # everything outside the markers byte-for-byte.
+    # everything outside the markers byte-for-byte. On malformed markers it exits 2
+    # (warns to stderr, leaves file unchanged); || true ensures the install continues.
     local guidance_src="$install_dir/src/memory/adapters/templates/codex/ai-memory.md"
+    local merge_script="$install_dir/scripts/merge_agents_md.py"
     if [[ -f "$guidance_src" ]]; then
-        python3 "$install_dir/scripts/merge_agents_md.py" "$project_path/AGENTS.md" "$guidance_src" \
-            && log_success "Deployed agent-guidance block to $project_path/AGENTS.md"
+        if [[ -f "$merge_script" ]]; then
+            python3 "$merge_script" "$project_path/AGENTS.md" "$guidance_src" \
+                && log_success "Deployed agent-guidance block to $project_path/AGENTS.md" \
+                || true
+        else
+            log_warning "merge_agents_md.py not found in $install_dir/scripts — skipping Codex guidance block"
+        fi
     fi
 
     log_success "Codex CLI config written to $config_file"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3727,8 +3727,9 @@ write_gemini_config() {
     local ad="$install_dir/src/memory/adapters"
 
     python3 -c "
-import json, sys
+import json, os, sys
 install_dir, project_id, py, ad = sys.argv[1:5]
+config_path = sys.argv[5]
 config = {
     'env': {
         'AI_MEMORY_INSTALL_DIR': install_dir,
@@ -3754,13 +3755,42 @@ config = {
         'PreCompress': [{'matcher': '.*', 'hooks': [{'type': 'command', 'command': f'\"{py}\" \"{ad}/gemini/pre_compress.py\"', 'timeout': 60000}]}]
     }
 }
-with open(sys.argv[5], 'w') as f:
+# TD-600: register the AI-Memory-owned guidance file in context.fileName so it
+# auto-loads with every prompt, WITHOUT dropping GEMINI.md or any user entries.
+# Setting context.fileName disables Gemini's implicit GEMINI.md default, so when
+# the user has no prior setting we must list GEMINI.md explicitly alongside ours.
+existing_names = None
+if os.path.exists(config_path):
+    try:
+        with open(config_path) as f:
+            existing_names = json.load(f).get('context', {}).get('fileName')
+    except (ValueError, OSError):
+        existing_names = None
+if existing_names is None:
+    names = ['GEMINI.md']
+elif isinstance(existing_names, str):
+    names = [existing_names]
+else:
+    names = list(existing_names)
+if 'AI-MEMORY.md' not in names:
+    names.append('AI-MEMORY.md')
+config['context'] = {'fileName': names}
+with open(config_path, 'w') as f:
     json.dump(config, f, indent=2)
     f.write('\n')
 " "$install_dir" "$project_id" "$py" "$ad" "$config_file"
 
     mkdir -p "$project_path/.gemini/commands"
     cp "$install_dir/src/memory/adapters/templates/gemini/"*.toml "$project_path/.gemini/commands/" 2>/dev/null || true
+
+    # TD-600: deploy the AI-Memory-owned guidance file to project root. Gemini
+    # discovers context files by basename in the project tree, so it lives at the
+    # root (never the user's GEMINI.md, which is left untouched).
+    local guidance_src="$install_dir/src/memory/adapters/templates/gemini/ai-memory.md"
+    if [[ -f "$guidance_src" ]]; then
+        cp "$guidance_src" "$project_path/AI-MEMORY.md"
+        log_success "Deployed agent-guidance file to $project_path/AI-MEMORY.md"
+    fi
 
     log_success "Gemini CLI config written to $config_file"
 }
@@ -3812,6 +3842,16 @@ with open(sys.argv[4], 'w') as f:
         fi
     done
 
+    # TD-600: deploy the AI-Memory-owned guidance rule. The .mdc carries
+    # `alwaysApply: true` frontmatter so Cursor includes it in every conversation.
+    # Own-file overwrite — never touches other .mdc, .cursorrules, or AGENTS.md.
+    local guidance_src="$install_dir/src/memory/adapters/templates/cursor/ai-memory.mdc"
+    if [[ -f "$guidance_src" ]]; then
+        mkdir -p "$project_path/.cursor/rules"
+        cp "$guidance_src" "$project_path/.cursor/rules/ai-memory.mdc"
+        log_success "Deployed agent-guidance rule to $project_path/.cursor/rules/ai-memory.mdc"
+    fi
+
     log_success "Cursor IDE config written to $config_file"
 }
 
@@ -3861,6 +3901,16 @@ with open(sys.argv[4], 'w') as f:
             cp "$install_dir/src/memory/adapters/templates/codex/$skill/SKILL.md" "$project_path/.codex/skills/$skill/" 2>/dev/null || true
         fi
     done
+
+    # TD-600: Codex has no always-on owned guidance file, so deliver guidance as
+    # a managed marker-block inside the project-root AGENTS.md (insert-if-absent /
+    # replace-in-place). merge_agents_md.py backs up + writes atomically and keeps
+    # everything outside the markers byte-for-byte.
+    local guidance_src="$install_dir/src/memory/adapters/templates/codex/ai-memory.md"
+    if [[ -f "$guidance_src" ]]; then
+        python3 "$install_dir/scripts/merge_agents_md.py" "$project_path/AGENTS.md" "$guidance_src" \
+            && log_success "Deployed agent-guidance block to $project_path/AGENTS.md"
+    fi
 
     log_success "Codex CLI config written to $config_file"
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1380,6 +1380,7 @@ main() {
     create_project_symlinks
     configure_project_hooks
     verify_project_hooks
+    deploy_ai_memory_rules
     setup_audit_directory
 
     # Parzival session agent (optional, SPEC-015)
@@ -1596,6 +1597,13 @@ sync_installed_files() {
         log_debug "Copying Claude Code commands..."
         mkdir -p "$dst_dir/.claude/commands"
         cp -r "$src_dir/.claude/commands/"* "$dst_dir/.claude/commands/" 2>/dev/null || true
+    fi
+
+    # .claude/rules/ — AI-Memory-owned agent-guidance rule file (TD-600)
+    if [[ -d "$src_dir/.claude/rules" ]]; then
+        log_debug "Copying Claude Code rules..."
+        mkdir -p "$dst_dir/.claude/rules"
+        cp -r "$src_dir/.claude/rules/"* "$dst_dir/.claude/rules/" 2>/dev/null || true
     fi
 
     # _ai-memory/ — deployable package (full replace: removes stale files not in source)
@@ -4922,6 +4930,23 @@ deploy_ai_memory_agents() {
     if [[ $agents_count -gt 0 ]]; then
         log_success "Deployed $agents_count agent(s) to $PROJECT_PATH/.claude/agents/"
     fi
+}
+
+# TD-600: Deploy the AI-Memory agent-guidance rule file to the project.
+# Claude Code auto-loads $PROJECT_PATH/.claude/rules/*.md at session start.
+# We own this exact filename (ai-memory.md), so overwriting it on each install
+# is idempotent-by-construction and never touches user-authored files —
+# not CLAUDE.md, not .claude/CLAUDE.md, not any other .claude/rules/*.md.
+deploy_ai_memory_rules() {
+    local src="$INSTALL_DIR/.claude/rules/ai-memory.md"
+    if [[ ! -f "$src" ]]; then
+        log_debug "No agent-guidance rule file found in INSTALL_DIR — skipping"
+        return 0
+    fi
+
+    mkdir -p "$PROJECT_PATH/.claude/rules"
+    cp "$src" "$PROJECT_PATH/.claude/rules/ai-memory.md"
+    log_success "Deployed agent-guidance rule to $PROJECT_PATH/.claude/rules/ai-memory.md"
 }
 
 # Write Parzival env vars into _ai-memory/pov/config.yaml

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3917,7 +3917,7 @@ with open(sys.argv[4], 'w') as f:
             if python3 "$merge_script" "$project_path/AGENTS.md" "$guidance_src"; then
                 log_success "Deployed agent-guidance block to $project_path/AGENTS.md"
             else
-                rc=$?
+                local rc=$?
                 if [[ "$rc" -eq 2 ]]; then
                     : # malformed-marker refuse — merge_agents_md.py already warned to stderr; continue
                 else

--- a/scripts/merge_agents_md.py
+++ b/scripts/merge_agents_md.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Splice the AI-Memory agent-guidance managed block into a project's AGENTS.md.
+
+Codex (unlike Claude/Gemini/Cursor) has no always-on AI-Memory-owned guidance
+file: ``AGENTS.override.md`` shadows the user's ``AGENTS.md`` and fallback
+filenames apply only when ``AGENTS.md`` is absent. So Codex guidance is delivered
+as a managed marker-block inside the project-root ``AGENTS.md`` (BP-172 / BP-171
+OQ-3), the one unavoidable managed-block across the 4 supported CLIs.
+
+Behaviour:
+  - Insert-if-absent: append the block to an existing or new AGENTS.md.
+  - Replace-in-place: if the markers already exist, replace only the region
+    between them (the block is owned; everything outside stays byte-for-byte).
+  - Backup-copy-first: a timestamped copy of any existing AGENTS.md is made
+    before writing (mirrors merge_settings.py — copy, not rename).
+  - Atomic write: tempfile + os.replace, so a crash mid-write can't corrupt
+    the user's AGENTS.md.
+
+Exit codes:
+  0 = Success
+  1 = Error (missing arguments, content file not found)
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+BEGIN_MARKER = "<!-- BEGIN AI-MEMORY -->"
+END_MARKER = "<!-- END AI-MEMORY -->"
+
+
+def build_block(content: str) -> str:
+    """Wrap guidance content in the stable managed-block markers."""
+    return f"{BEGIN_MARKER}\n{content.strip()}\n{END_MARKER}"
+
+
+def splice_block(existing: str, content: str) -> str:
+    """Return AGENTS.md text with the AI-Memory block inserted or replaced.
+
+    Everything outside the markers is preserved byte-for-byte. The result is
+    idempotent: splicing an already-spliced document reproduces it exactly.
+    """
+    block = build_block(content)
+
+    begin_idx = existing.find(BEGIN_MARKER)
+    end_idx = existing.find(END_MARKER)
+    if begin_idx != -1 and end_idx != -1 and end_idx > begin_idx:
+        # Replace-in-place: keep bytes before BEGIN and after END untouched.
+        pre = existing[:begin_idx]
+        post = existing[end_idx + len(END_MARKER) :]
+        return pre + block + post
+
+    # Insert-if-absent: append the block, preserving existing content verbatim.
+    if not existing:
+        return block + "\n"
+    separator = "" if existing.endswith("\n") else "\n"
+    return existing + separator + "\n" + block + "\n"
+
+
+def backup_file(path: Path) -> Path:
+    """Create a timestamped copy of an existing file (copy, not rename)."""
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    backup_path = path.with_name(f"{path.name}.backup.{timestamp}")
+    shutil.copy2(path, backup_path)
+    return backup_path
+
+
+def merge_agents_md(agents_path: str, content_path: str) -> None:
+    """Splice the guidance block from ``content_path`` into ``agents_path``.
+
+    Side effects:
+      - Backs up an existing AGENTS.md (timestamped copy) before writing.
+      - Writes the spliced AGENTS.md atomically.
+    """
+    path = Path(agents_path)
+    content = Path(content_path).read_text(encoding="utf-8")
+
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    merged = splice_block(existing, content)
+
+    if merged == existing:
+        print(f"AGENTS.md already up to date: {agents_path}")
+        return
+
+    if path.exists():
+        backup_path = backup_file(path)
+        print(f"Backed up existing AGENTS.md to {backup_path}")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_path = tempfile.mkstemp(dir=path.parent, prefix=".AGENTS_", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(merged)
+        os.replace(temp_path, path)
+    except Exception:
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)
+        raise
+
+    print(f"Updated {agents_path}")
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print("Usage: merge_agents_md.py <agents_md_path> <content_path>")
+        sys.exit(1)
+    agents_path = sys.argv[1]
+    content_path = sys.argv[2]
+    if not Path(content_path).is_file():
+        print(f"ERROR: content file not found: {content_path}")
+        sys.exit(1)
+    merge_agents_md(agents_path, content_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/merge_agents_md.py
+++ b/scripts/merge_agents_md.py
@@ -11,14 +11,18 @@ Behaviour:
   - Insert-if-absent: append the block to an existing or new AGENTS.md.
   - Replace-in-place: if the markers already exist, replace only the region
     between them (the block is owned; everything outside stays byte-for-byte).
+  - Refuse-and-warn: if the markers are in any other state (stray BEGIN or END,
+    END before BEGIN, duplicate blocks), the file is left byte-for-byte unchanged
+    and a WARNING is printed to stderr. The install is not aborted.
   - Backup-copy-first: a timestamped copy of any existing AGENTS.md is made
     before writing (mirrors merge_settings.py — copy, not rename).
   - Atomic write: tempfile + os.replace, so a crash mid-write can't corrupt
     the user's AGENTS.md.
 
 Exit codes:
-  0 = Success
+  0 = Success (wrote or already up-to-date)
   1 = Error (missing arguments, content file not found)
+  2 = Malformed markers (refused — WARNING printed to stderr; install continues)
 """
 
 import os
@@ -32,6 +36,15 @@ BEGIN_MARKER = "<!-- BEGIN AI-MEMORY -->"
 END_MARKER = "<!-- END AI-MEMORY -->"
 
 
+class MalformedMarkersError(Exception):
+    """Raised by splice_block when markers are in an unrecognised state.
+
+    Safe states: (0 BEGIN + 0 END) or (exactly 1 BEGIN strictly before 1 END).
+    Any other combination is malformed; the caller must warn and leave the file
+    unchanged.
+    """
+
+
 def build_block(content: str) -> str:
     """Wrap guidance content in the stable managed-block markers."""
     return f"{BEGIN_MARKER}\n{content.strip()}\n{END_MARKER}"
@@ -40,24 +53,45 @@ def build_block(content: str) -> str:
 def splice_block(existing: str, content: str) -> str:
     """Return AGENTS.md text with the AI-Memory block inserted or replaced.
 
+    Routing (count-based, no naive find assumptions):
+    - 0 BEGIN + 0 END  →  insert-if-absent (append).
+    - 1 BEGIN + 1 END, BEGIN strictly before END  →  replace-in-place.
+    - Any other marker state  →  raise MalformedMarkersError (pure; no IO).
+
     Everything outside the markers is preserved byte-for-byte. The result is
     idempotent: splicing an already-spliced document reproduces it exactly.
+
+    Raises:
+        MalformedMarkersError: markers are present but not in a safe state
+            (stray BEGIN or END, END before BEGIN, duplicate blocks, etc.).
+            The caller is responsible for warning and leaving the file unchanged.
     """
     block = build_block(content)
 
-    begin_idx = existing.find(BEGIN_MARKER)
-    end_idx = existing.find(END_MARKER)
-    if begin_idx != -1 and end_idx != -1 and end_idx > begin_idx:
-        # Replace-in-place: keep bytes before BEGIN and after END untouched.
-        pre = existing[:begin_idx]
-        post = existing[end_idx + len(END_MARKER) :]
-        return pre + block + post
+    n_begin = existing.count(BEGIN_MARKER)
+    n_end = existing.count(END_MARKER)
 
-    # Insert-if-absent: append the block, preserving existing content verbatim.
-    if not existing:
-        return block + "\n"
-    separator = "" if existing.endswith("\n") else "\n"
-    return existing + separator + "\n" + block + "\n"
+    if n_begin == 0 and n_end == 0:
+        # Insert-if-absent: append the block, preserving existing content verbatim.
+        if not existing:
+            return block + "\n"
+        separator = "" if existing.endswith("\n") else "\n"
+        return existing + separator + "\n" + block + "\n"
+
+    if n_begin == 1 and n_end == 1:
+        begin_idx = existing.find(BEGIN_MARKER)
+        end_idx = existing.find(END_MARKER)
+        if end_idx > begin_idx:
+            # Replace-in-place: keep bytes before BEGIN and after END untouched.
+            pre = existing[:begin_idx]
+            post = existing[end_idx + len(END_MARKER) :]
+            return pre + block + post
+
+    # Any other marker state: stray BEGIN or END, END before BEGIN, duplicates.
+    raise MalformedMarkersError(
+        f"{n_begin} BEGIN marker(s) and {n_end} END marker(s) found "
+        f"(expected 0+0 or 1 BEGIN before 1 END)"
+    )
 
 
 def backup_file(path: Path) -> Path:
@@ -74,12 +108,26 @@ def merge_agents_md(agents_path: str, content_path: str) -> None:
     Side effects:
       - Backs up an existing AGENTS.md (timestamped copy) before writing.
       - Writes the spliced AGENTS.md atomically.
+
+    Raises:
+        MalformedMarkersError: if markers are in an unrecognised state.
+            A WARNING is printed to stderr; the file is left unchanged; the
+            caller (main) exits 2 so the install continues without aborting.
     """
     path = Path(agents_path)
     content = Path(content_path).read_text(encoding="utf-8")
 
     existing = path.read_text(encoding="utf-8") if path.exists() else ""
-    merged = splice_block(existing, content)
+    try:
+        merged = splice_block(existing, content)
+    except MalformedMarkersError as exc:
+        print(
+            f"WARNING: {agents_path}: {exc}. "
+            f"Resolve the AI-Memory markers manually, then re-run the installer. "
+            f"File left unchanged.",
+            file=sys.stderr,
+        )
+        raise
 
     if merged == existing:
         print(f"AGENTS.md already up to date: {agents_path}")
@@ -112,7 +160,10 @@ def main() -> None:
     if not Path(content_path).is_file():
         print(f"ERROR: content file not found: {content_path}")
         sys.exit(1)
-    merge_agents_md(agents_path, content_path)
+    try:
+        merge_agents_md(agents_path, content_path)
+    except MalformedMarkersError:
+        sys.exit(2)
 
 
 if __name__ == "__main__":

--- a/scripts/merge_agents_md.py
+++ b/scripts/merge_agents_md.py
@@ -83,6 +83,12 @@ def splice_block(existing: str, content: str) -> str:
         end_idx = existing.find(END_MARKER)
         if end_idx > begin_idx:
             # Replace-in-place: keep bytes before BEGIN and after END untouched.
+            # Accepted residual: a file whose ONLY markers are a single balanced
+            # BEGIN…END pair (even wrapping purely user-authored text) is
+            # indistinguishable from a stale managed block, so replace-in-place
+            # applies. Refusing would break idempotent re-install. The original
+            # content is backup-recoverable if a real unintended replacement occurs.
+            # Do not change this branch to refuse — that would be a regression.
             pre = existing[:begin_idx]
             post = existing[end_idx + len(END_MARKER) :]
             return pre + block + post

--- a/src/memory/adapters/templates/codex/ai-memory.md
+++ b/src/memory/adapters/templates/codex/ai-memory.md
@@ -1,0 +1,81 @@
+# AI Memory — Agent Guidance
+
+This guidance ships with the **AI-Memory** module and is loaded into every Codex session in this project. It explains how to work with the memory system, plus the general engineering conduct AI-Memory expects. (This guidance is a marked block; the rest of your `AGENTS.md` is untouched.)
+
+## Using AI Memory
+
+AI Memory is a persistent context layer: it captures decisions, code patterns, and conventions as you work, and surfaces the relevant past context automatically — at session start and per turn — so you don't re-explain prior work.
+
+- **Recall is automatic.** Relevant memory is injected on session resume and as you work; you rarely need to ask for it.
+- **Search on demand** with the `search-memory` skill. Check system health with `memory-status`.
+- **Memory is project-scoped** — each project's memory is isolated. The project id is auto-detected; override it with the `AI_MEMORY_PROJECT_ID` environment variable. If you work across multiple repos, confirm the active project with `memory-status`.
+- **Capture runs in the background** via hooks — no action needed.
+- **Trust but verify recalled facts.** Injected memories describe what was true when written. If a recalled fact names a file, flag, or function, confirm it still exists before relying on it.
+
+## If something's off
+
+AI-Memory is actively developed. If an AI-Memory skill, hook, or piece of guidance is confusing, behaves unexpectedly, or looks stale, **surface it** — tell the person you're working with, or open an issue on the AI-Memory repository (https://github.com/Hidden-History/ai-memory/issues). That feedback shapes the product. Don't silently work around a broken skill.
+
+---
+
+# General engineering conduct
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/src/memory/adapters/templates/cursor/ai-memory.mdc
+++ b/src/memory/adapters/templates/cursor/ai-memory.mdc
@@ -1,0 +1,86 @@
+---
+description: AI Memory module guidance
+alwaysApply: true
+---
+
+# AI Memory — Agent Guidance
+
+This file ships with the **AI-Memory** module and is loaded into every Cursor session in this project. It explains how to work with the memory system, plus the general engineering conduct AI-Memory expects. (Your own `.cursor` rules are separate and untouched.)
+
+## Using AI Memory
+
+AI Memory is a persistent context layer: it captures decisions, code patterns, and conventions as you work, and surfaces the relevant past context automatically — at session start and per turn — so you don't re-explain prior work.
+
+- **Recall is automatic.** Relevant memory is injected on session resume and as you work; you rarely need to ask for it.
+- **Search on demand** with the `search-memory` skill. Check system health with `memory-status`; deliberately store something with `save-memory`.
+- **Memory is project-scoped** — each project's memory is isolated. The project id is auto-detected; override it with the `AI_MEMORY_PROJECT_ID` environment variable. If you work across multiple repos, confirm the active project with `memory-status`.
+- **Capture runs in the background** via hooks — no action needed.
+- **Trust but verify recalled facts.** Injected memories describe what was true when written. If a recalled fact names a file, flag, or function, confirm it still exists before relying on it.
+
+## If something's off
+
+AI-Memory is actively developed. If an AI-Memory skill, hook, or piece of guidance is confusing, behaves unexpectedly, or looks stale, **surface it** — tell the person you're working with, or open an issue on the AI-Memory repository (https://github.com/Hidden-History/ai-memory/issues). That feedback shapes the product. Don't silently work around a broken skill.
+
+---
+
+# General engineering conduct
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/src/memory/adapters/templates/gemini/ai-memory.md
+++ b/src/memory/adapters/templates/gemini/ai-memory.md
@@ -1,0 +1,81 @@
+# AI Memory — Agent Guidance
+
+This file ships with the **AI-Memory** module and is loaded into every Gemini CLI session in this project. It explains how to work with the memory system, plus the general engineering conduct AI-Memory expects. (Your own project's `GEMINI.md` is separate and untouched.)
+
+## Using AI Memory
+
+AI Memory is a persistent context layer: it captures decisions, code patterns, and conventions as you work, and surfaces the relevant past context automatically — at session start and per turn — so you don't re-explain prior work.
+
+- **Recall is automatic.** Relevant memory is injected on session resume and as you work; you rarely need to ask for it.
+- **Search on demand** with the `search-memory` command. Check system health with `memory-status`; deliberately store something with `save-memory`.
+- **Memory is project-scoped** — each project's memory is isolated. The project id is auto-detected; override it with the `AI_MEMORY_PROJECT_ID` environment variable (or in `.gemini/settings.json`). If you work across multiple repos, confirm the active project with `memory-status`.
+- **Capture runs in the background** via hooks — no action needed.
+- **Trust but verify recalled facts.** Injected memories describe what was true when written. If a recalled fact names a file, flag, or function, confirm it still exists before relying on it.
+
+## If something's off
+
+AI-Memory is actively developed. If an AI-Memory command, hook, or piece of guidance is confusing, behaves unexpectedly, or looks stale, **surface it** — tell the person you're working with, or open an issue on the AI-Memory repository (https://github.com/Hidden-History/ai-memory/issues). That feedback shapes the product. Don't silently work around a broken command.
+
+---
+
+# General engineering conduct
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/tests/test_install_agent_guidance_rule.py
+++ b/tests/test_install_agent_guidance_rule.py
@@ -1,0 +1,191 @@
+"""
+Install tests for the AI-Memory agent-guidance rule file (TD-600).
+
+The installer ships an AI-Memory-owned rule at $PROJECT_PATH/.claude/rules/ai-memory.md
+(Claude Code auto-loads .claude/rules/*.md at session start). Two surfaces are covered:
+
+  1. sync_installed_files() — repo .claude/rules/ flows to INSTALL_DIR/.claude/rules/
+     (Layer 1: source-of-truth threading, runs on both fresh + Option-1 update).
+  2. deploy_ai_memory_rules() — INSTALL_DIR copy flows to PROJECT_PATH/.claude/rules/ai-memory.md
+     (Layer 2: own-file overwrite, zero clobber of user-authored files).
+
+Core safety property: the install creates/overwrites ONLY ai-memory.md. It must NEVER
+touch the user's CLAUDE.md, .claude/CLAUDE.md, CLAUDE.local.md, or any other
+.claude/rules/*.md.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+_INSTALL_SH = _SCRIPTS_DIR / "install.sh"
+_REPO_RULE = Path(__file__).parent.parent / ".claude" / "rules" / "ai-memory.md"
+
+
+@pytest.fixture
+def install_sh_no_main(tmp_path) -> Path:
+    """Copy install.sh minus final 'main "$@"' line into tmp_path for safe sourcing."""
+    content = _INSTALL_SH.read_text(encoding="utf-8")
+    lines = content.splitlines(keepends=True)
+    assert lines[-1].strip() == 'main "$@"', (
+        f"Expected last line 'main \"$@\"', got: {lines[-1]!r}. "
+        "If install.sh structure changed, update this fixture."
+    )
+    copy = tmp_path / "install.sh"
+    copy.write_text("".join(lines[:-1]), encoding="utf-8")
+    copy.chmod(0o755)
+    shutil.copy(
+        _SCRIPTS_DIR / "_env_split_helpers.sh", tmp_path / "_env_split_helpers.sh"
+    )
+    return copy
+
+
+def _run_deploy_rules(
+    install_sh_copy: Path,
+    install_dir: Path,
+    project_dir: Path,
+) -> subprocess.CompletedProcess:
+    """Source install.sh (no-main copy) and call deploy_ai_memory_rules with mocked dirs."""
+    bash_cmd = f"""
+set -euo pipefail
+export INSTALL_DIR="{install_dir}"
+export PROJECT_PATH="{project_dir}"
+source "{install_sh_copy}"
+INSTALL_DIR="{install_dir}"
+PROJECT_PATH="{project_dir}"
+deploy_ai_memory_rules
+"""
+    return subprocess.run(["bash", "-c", bash_cmd], capture_output=True, text=True)
+
+
+@pytest.fixture
+def install_and_project_dirs(tmp_path):
+    """Mock INSTALL_DIR (carrying the shipped rule) + an empty PROJECT_PATH.
+
+    The rule placed in INSTALL_DIR is the real repo file, so assertions about the
+    shipped content (e.g. the wired repo URL) exercise the actual product artifact.
+    """
+    install_dir = tmp_path / "install_dir"
+    project_dir = tmp_path / "project_dir"
+    rules_src = install_dir / ".claude" / "rules"
+    rules_src.mkdir(parents=True)
+    shutil.copy(_REPO_RULE, rules_src / "ai-memory.md")
+    project_dir.mkdir()
+    return install_dir, project_dir
+
+
+class TestDeployAgentGuidanceRule:
+    def test_rule_deployed_with_shipped_content(
+        self, install_sh_no_main, install_and_project_dirs
+    ):
+        install_dir, project_dir = install_and_project_dirs
+        result = _run_deploy_rules(install_sh_no_main, install_dir, project_dir)
+        assert (
+            result.returncode == 0
+        ), f"deploy_ai_memory_rules failed:\n{result.stderr}"
+        deployed = project_dir / ".claude" / "rules" / "ai-memory.md"
+        assert deployed.exists()
+        # Byte-identical to the shipped repo source.
+        assert deployed.read_bytes() == _REPO_RULE.read_bytes()
+
+    def test_repo_url_wired(self, install_sh_no_main, install_and_project_dirs):
+        install_dir, project_dir = install_and_project_dirs
+        _run_deploy_rules(install_sh_no_main, install_dir, project_dir)
+        content = (project_dir / ".claude" / "rules" / "ai-memory.md").read_text()
+        assert "https://github.com/Hidden-History/ai-memory/issues" in content
+
+    def test_rules_dir_created_when_absent(
+        self, install_sh_no_main, install_and_project_dirs
+    ):
+        install_dir, project_dir = install_and_project_dirs
+        # project_dir has no .claude/ at all
+        assert not (project_dir / ".claude" / "rules").exists()
+        result = _run_deploy_rules(install_sh_no_main, install_dir, project_dir)
+        assert result.returncode == 0, result.stderr
+        assert (project_dir / ".claude" / "rules" / "ai-memory.md").exists()
+
+    def test_idempotent_single_file_identical_content(
+        self, install_sh_no_main, install_and_project_dirs
+    ):
+        install_dir, project_dir = install_and_project_dirs
+        _run_deploy_rules(install_sh_no_main, install_dir, project_dir)
+        first = (project_dir / ".claude" / "rules" / "ai-memory.md").read_bytes()
+        # Second run — own-file overwrite, no duplication/append.
+        result = _run_deploy_rules(install_sh_no_main, install_dir, project_dir)
+        assert result.returncode == 0, result.stderr
+        rules_dir = project_dir / ".claude" / "rules"
+        assert [p.name for p in rules_dir.iterdir()] == ["ai-memory.md"]
+        assert (rules_dir / "ai-memory.md").read_bytes() == first
+
+    def test_zero_clobber_user_files_untouched(
+        self, install_sh_no_main, install_and_project_dirs
+    ):
+        install_dir, project_dir = install_and_project_dirs
+
+        # Pre-existing user-authored files that must NEVER be touched.
+        user_claude_md = project_dir / "CLAUDE.md"
+        user_claude_md.write_text(
+            "# My project rules\nDo not touch.\n", encoding="utf-8"
+        )
+        dot_claude_md = project_dir / ".claude" / "CLAUDE.md"
+        dot_claude_md.parent.mkdir(parents=True, exist_ok=True)
+        dot_claude_md.write_text("# dot-claude CLAUDE\n", encoding="utf-8")
+        claude_local = project_dir / "CLAUDE.local.md"
+        claude_local.write_text("# local overrides\n", encoding="utf-8")
+        user_rule = project_dir / ".claude" / "rules" / "my-rule.md"
+        user_rule.parent.mkdir(parents=True, exist_ok=True)
+        user_rule.write_text("# My own rule\nKeep me verbatim.\n", encoding="utf-8")
+
+        before = {
+            p: p.read_bytes()
+            for p in (user_claude_md, dot_claude_md, claude_local, user_rule)
+        }
+
+        result = _run_deploy_rules(install_sh_no_main, install_dir, project_dir)
+        assert result.returncode == 0, result.stderr
+
+        # Every user file is byte-unchanged.
+        for p, original in before.items():
+            assert p.read_bytes() == original, f"{p} was modified by install"
+
+        # Only ai-memory.md was added alongside the user's rule.
+        assert (project_dir / ".claude" / "rules" / "ai-memory.md").exists()
+        assert sorted(
+            p.name for p in (project_dir / ".claude" / "rules").iterdir()
+        ) == ["ai-memory.md", "my-rule.md"]
+
+
+class TestSyncInstalledFilesThreadsRules:
+    """Layer 1: repo .claude/rules/ is synced into INSTALL_DIR/.claude/rules/ on both
+    fresh install (copy_files) and Option-1 update (update_shared_scripts), via the
+    shared sync_installed_files() function."""
+
+    def test_rules_synced_to_install_dir(self, install_sh_no_main, tmp_path):
+        src_dir = tmp_path / "src"
+        dst_dir = tmp_path / "dst"
+        # Minimal source tree required by sync_installed_files().
+        (src_dir / "src" / "memory").mkdir(parents=True)
+        (src_dir / "src" / "memory" / "__init__.py").write_text("", encoding="utf-8")
+        (src_dir / "scripts").mkdir(parents=True)
+        (src_dir / "scripts" / "noop.py").write_text("", encoding="utf-8")
+        (src_dir / ".claude" / "hooks").mkdir(parents=True)
+        (src_dir / ".claude" / "hooks" / "placeholder").write_text("", encoding="utf-8")
+        rules_src = src_dir / ".claude" / "rules"
+        rules_src.mkdir(parents=True)
+        shutil.copy(_REPO_RULE, rules_src / "ai-memory.md")
+
+        bash_cmd = f"""
+set -euo pipefail
+source "{install_sh_no_main}"
+sync_installed_files "{src_dir}" "{dst_dir}"
+"""
+        result = subprocess.run(
+            ["bash", "-c", bash_cmd], capture_output=True, text=True
+        )
+        assert result.returncode == 0, f"sync_installed_files failed:\n{result.stderr}"
+        synced = dst_dir / ".claude" / "rules" / "ai-memory.md"
+        assert synced.exists()
+        assert synced.read_bytes() == _REPO_RULE.read_bytes()

--- a/tests/test_install_multicli_agent_guidance.py
+++ b/tests/test_install_multicli_agent_guidance.py
@@ -139,6 +139,42 @@ class TestGeminiGuidance:
         ]["fileName"]
         assert names.count("AI-MEMORY.md") == 1
 
+    def test_update_path_deploys_guidance_without_force(
+        self, install_sh_no_main, install_dir, tmp_path
+    ):
+        """No-force re-install over an existing ai-memory hook config still deploys
+        the guidance file and registers context.fileName (regression for the
+        hook-config early-return that previously gated guidance deploy)."""
+        project = tmp_path / "proj"
+        (project / ".gemini").mkdir(parents=True)
+        # Simulate an existing ai-memory settings.json (hook config already present).
+        existing_settings = {
+            "env": {"AI_MEMORY_INSTALL_DIR": "/old/path"},
+            "hooks": {},
+            "context": {"fileName": ["GEMINI.md"]},
+        }
+        (project / ".gemini" / "settings.json").write_text(
+            json.dumps(existing_settings), encoding="utf-8"
+        )
+
+        result = _call(install_sh_no_main, "write_gemini_config", project, install_dir)
+        assert result.returncode == 0, result.stderr
+
+        # Guidance file deployed even though the hook config was skipped.
+        guidance = project / "AI-MEMORY.md"
+        assert guidance.exists()
+        assert (
+            guidance.read_bytes()
+            == (_TEMPLATES / "gemini" / "ai-memory.md").read_bytes()
+        )
+        # context.fileName registration happened.
+        names = json.loads((project / ".gemini" / "settings.json").read_text())[
+            "context"
+        ]["fileName"]
+        assert "AI-MEMORY.md" in names
+        # Existing entry preserved.
+        assert "GEMINI.md" in names
+
 
 # --------------------------------------------------------------------------- #
 # Cursor
@@ -198,6 +234,26 @@ class TestCursorGuidance:
         assert [p.name for p in rules.iterdir()] == ["ai-memory.mdc"]
         assert (rules / "ai-memory.mdc").read_bytes() == first
 
+    def test_update_path_deploys_guidance_without_force(
+        self, install_sh_no_main, install_dir, tmp_path
+    ):
+        """No-force re-install over an existing ai-memory hook config still deploys
+        the .mdc guidance rule (regression for the early-return gate)."""
+        project = tmp_path / "proj"
+        hooks_dir = project / ".cursor"
+        hooks_dir.mkdir(parents=True)
+        # Simulate an existing ai-memory hooks.json.
+        (hooks_dir / "hooks.json").write_text(
+            json.dumps({"AI_MEMORY_INSTALL_DIR": "/old"}), encoding="utf-8"
+        )
+
+        result = _call(install_sh_no_main, "write_cursor_config", project, install_dir)
+        assert result.returncode == 0, result.stderr
+
+        mdc = project / ".cursor" / "rules" / "ai-memory.mdc"
+        assert mdc.exists()
+        assert "alwaysApply: true" in mdc.read_text(encoding="utf-8")
+
 
 # --------------------------------------------------------------------------- #
 # Codex
@@ -255,3 +311,25 @@ class TestCodexGuidance:
         second = agents.read_text(encoding="utf-8")
         assert first == second
         assert second.count("<!-- BEGIN AI-MEMORY -->") == 1
+
+    def test_update_path_deploys_guidance_without_force(
+        self, install_sh_no_main, install_dir, tmp_path
+    ):
+        """No-force re-install over an existing ai-memory hook config still deploys
+        the AGENTS.md guidance block (regression for the early-return gate)."""
+        project = tmp_path / "proj"
+        hooks_dir = project / ".codex"
+        hooks_dir.mkdir(parents=True)
+        # Simulate an existing ai-memory hooks.json.
+        (hooks_dir / "hooks.json").write_text(
+            json.dumps({"AI_MEMORY_INSTALL_DIR": "/old"}), encoding="utf-8"
+        )
+
+        result = _call(install_sh_no_main, "write_codex_config", project, install_dir)
+        assert result.returncode == 0, result.stderr
+
+        agents = project / "AGENTS.md"
+        assert agents.exists()
+        text = agents.read_text(encoding="utf-8")
+        assert "<!-- BEGIN AI-MEMORY -->" in text
+        assert "search-memory" in text

--- a/tests/test_install_multicli_agent_guidance.py
+++ b/tests/test_install_multicli_agent_guidance.py
@@ -1,0 +1,257 @@
+"""Install tests for multi-CLI agent-guidance delivery (TD-600 / BP-172).
+
+The installer already ships AI-Memory guidance to Claude (.claude/rules/ai-memory.md).
+This covers the other three CLIs, each in that CLI's own always-on convention:
+
+  - Gemini  → AI-Memory-owned AI-MEMORY.md at project root + appended to
+              context.fileName in .gemini/settings.json (never drops GEMINI.md
+              or user entries; never writes the user's GEMINI.md).
+  - Cursor  → owned .cursor/rules/ai-memory.mdc with `alwaysApply: true`
+              (never touches other .mdc / .cursorrules / AGENTS.md).
+  - Codex   → managed marker-block inside root AGENTS.md (insert/replace;
+              byte-preserved outside markers; backup + atomic write).
+
+Each function is exercised by sourcing install.sh (minus `main "$@"`) and calling
+the real write_<cli>_config with a mocked INSTALL_DIR carrying the shipped
+template files.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).parent.parent
+_SCRIPTS_DIR = _REPO / "scripts"
+_INSTALL_SH = _SCRIPTS_DIR / "install.sh"
+_TEMPLATES = _REPO / "src" / "memory" / "adapters" / "templates"
+
+
+@pytest.fixture
+def install_sh_no_main(tmp_path) -> Path:
+    """Copy install.sh minus final 'main "$@"' line into tmp_path for safe sourcing."""
+    content = _INSTALL_SH.read_text(encoding="utf-8")
+    lines = content.splitlines(keepends=True)
+    assert lines[-1].strip() == 'main "$@"', (
+        f"Expected last line 'main \"$@\"', got: {lines[-1]!r}. "
+        "If install.sh structure changed, update this fixture."
+    )
+    copy = tmp_path / "install.sh"
+    copy.write_text("".join(lines[:-1]), encoding="utf-8")
+    copy.chmod(0o755)
+    shutil.copy(
+        _SCRIPTS_DIR / "_env_split_helpers.sh", tmp_path / "_env_split_helpers.sh"
+    )
+    return copy
+
+
+@pytest.fixture
+def install_dir(tmp_path) -> Path:
+    """Mock INSTALL_DIR carrying the real shipped templates + merge_agents_md.py."""
+    d = tmp_path / "install_dir"
+    # Templates (real shipped guidance source files).
+    shutil.copytree(_TEMPLATES, d / "src" / "memory" / "adapters" / "templates")
+    # Codex managed-block splice script.
+    (d / "scripts").mkdir(parents=True, exist_ok=True)
+    shutil.copy(
+        _SCRIPTS_DIR / "merge_agents_md.py", d / "scripts" / "merge_agents_md.py"
+    )
+    return d
+
+
+def _call(install_sh: Path, func: str, project: Path, install: Path, force="false"):
+    bash_cmd = f"""
+set -euo pipefail
+source "{install_sh}"
+{func} "{project}" "{install}" "test-project" "{force}"
+"""
+    return subprocess.run(["bash", "-c", bash_cmd], capture_output=True, text=True)
+
+
+# --------------------------------------------------------------------------- #
+# Gemini
+# --------------------------------------------------------------------------- #
+class TestGeminiGuidance:
+    def test_owned_file_and_context_registered(
+        self, install_sh_no_main, install_dir, tmp_path
+    ):
+        project = tmp_path / "proj"
+        project.mkdir()
+        result = _call(install_sh_no_main, "write_gemini_config", project, install_dir)
+        assert result.returncode == 0, result.stderr
+
+        guidance = project / "AI-MEMORY.md"
+        assert guidance.exists()
+        assert (
+            guidance.read_bytes()
+            == (_TEMPLATES / "gemini" / "ai-memory.md").read_bytes()
+        )
+
+        settings = json.loads((project / ".gemini" / "settings.json").read_text())
+        names = settings["context"]["fileName"]
+        # Default GEMINI.md preserved (so implicit loading isn't lost) + ours added.
+        assert names == ["GEMINI.md", "AI-MEMORY.md"]
+
+    def test_zero_clobber_user_gemini_md_and_custom_context(
+        self, install_sh_no_main, install_dir, tmp_path
+    ):
+        project = tmp_path / "proj"
+        (project / ".gemini").mkdir(parents=True)
+        user_gemini = project / "GEMINI.md"
+        user_gemini.write_text("# My Gemini rules\nKeep me.\n", encoding="utf-8")
+        # Pre-existing user settings with a custom context.fileName (no AI-Memory marker).
+        (project / ".gemini" / "settings.json").write_text(
+            json.dumps({"context": {"fileName": ["GEMINI.md", "custom.md"]}}),
+            encoding="utf-8",
+        )
+        before = user_gemini.read_bytes()
+
+        result = _call(install_sh_no_main, "write_gemini_config", project, install_dir)
+        assert result.returncode == 0, result.stderr
+
+        # User's GEMINI.md never written.
+        assert user_gemini.read_bytes() == before
+        # Custom entry preserved; AI-MEMORY.md appended; no duplication.
+        names = json.loads((project / ".gemini" / "settings.json").read_text())[
+            "context"
+        ]["fileName"]
+        assert names == ["GEMINI.md", "custom.md", "AI-MEMORY.md"]
+
+    def test_idempotent_no_duplicate_context_entry(
+        self, install_sh_no_main, install_dir, tmp_path
+    ):
+        project = tmp_path / "proj"
+        project.mkdir()
+        _call(install_sh_no_main, "write_gemini_config", project, install_dir)
+        # Force a re-write (marker now present) — must not duplicate AI-MEMORY.md.
+        result = _call(
+            install_sh_no_main,
+            "write_gemini_config",
+            project,
+            install_dir,
+            force="true",
+        )
+        assert result.returncode == 0, result.stderr
+        names = json.loads((project / ".gemini" / "settings.json").read_text())[
+            "context"
+        ]["fileName"]
+        assert names.count("AI-MEMORY.md") == 1
+
+
+# --------------------------------------------------------------------------- #
+# Cursor
+# --------------------------------------------------------------------------- #
+class TestCursorGuidance:
+    def test_owned_mdc_with_always_apply(
+        self, install_sh_no_main, install_dir, tmp_path
+    ):
+        project = tmp_path / "proj"
+        project.mkdir()
+        result = _call(install_sh_no_main, "write_cursor_config", project, install_dir)
+        assert result.returncode == 0, result.stderr
+
+        mdc = project / ".cursor" / "rules" / "ai-memory.mdc"
+        assert mdc.exists()
+        text = mdc.read_text(encoding="utf-8")
+        assert text.startswith("---")
+        assert "alwaysApply: true" in text
+        assert "search-memory" in text
+
+    def test_zero_clobber_other_cursor_files(
+        self, install_sh_no_main, install_dir, tmp_path
+    ):
+        project = tmp_path / "proj"
+        rules = project / ".cursor" / "rules"
+        rules.mkdir(parents=True)
+        user_rule = rules / "my.mdc"
+        user_rule.write_text("---\nalwaysApply: false\n---\nMine.\n", encoding="utf-8")
+        cursorrules = project / ".cursorrules"
+        cursorrules.write_text("legacy user rules\n", encoding="utf-8")
+        agents = project / "AGENTS.md"
+        agents.write_text("# user agents\n", encoding="utf-8")
+        before = {p: p.read_bytes() for p in (user_rule, cursorrules, agents)}
+
+        result = _call(install_sh_no_main, "write_cursor_config", project, install_dir)
+        assert result.returncode == 0, result.stderr
+
+        for p, original in before.items():
+            assert p.read_bytes() == original, f"{p} was modified"
+        assert (rules / "ai-memory.mdc").exists()
+        assert sorted(p.name for p in rules.iterdir()) == ["ai-memory.mdc", "my.mdc"]
+
+    def test_idempotent_single_file(self, install_sh_no_main, install_dir, tmp_path):
+        project = tmp_path / "proj"
+        project.mkdir()
+        _call(install_sh_no_main, "write_cursor_config", project, install_dir)
+        first = (project / ".cursor" / "rules" / "ai-memory.mdc").read_bytes()
+        result = _call(
+            install_sh_no_main,
+            "write_cursor_config",
+            project,
+            install_dir,
+            force="true",
+        )
+        assert result.returncode == 0, result.stderr
+        rules = project / ".cursor" / "rules"
+        assert [p.name for p in rules.iterdir()] == ["ai-memory.mdc"]
+        assert (rules / "ai-memory.mdc").read_bytes() == first
+
+
+# --------------------------------------------------------------------------- #
+# Codex
+# --------------------------------------------------------------------------- #
+class TestCodexGuidance:
+    def test_managed_block_in_agents_md(
+        self, install_sh_no_main, install_dir, tmp_path
+    ):
+        project = tmp_path / "proj"
+        project.mkdir()
+        result = _call(install_sh_no_main, "write_codex_config", project, install_dir)
+        assert result.returncode == 0, result.stderr
+
+        agents = project / "AGENTS.md"
+        assert agents.exists()
+        text = agents.read_text(encoding="utf-8")
+        assert "<!-- BEGIN AI-MEMORY -->" in text
+        assert "<!-- END AI-MEMORY -->" in text
+        assert "search-memory" in text
+
+    def test_zero_clobber_existing_agents_md(
+        self, install_sh_no_main, install_dir, tmp_path
+    ):
+        project = tmp_path / "proj"
+        project.mkdir()
+        agents = project / "AGENTS.md"
+        user_text = "# My AGENTS\n\nUser-authored guidance. Do not clobber.\n"
+        agents.write_text(user_text, encoding="utf-8")
+
+        result = _call(install_sh_no_main, "write_codex_config", project, install_dir)
+        assert result.returncode == 0, result.stderr
+
+        out = agents.read_text(encoding="utf-8")
+        # User content preserved byte-for-byte as a prefix; block appended after.
+        assert out.startswith(user_text)
+        assert "<!-- BEGIN AI-MEMORY -->" in out
+        # Backup of the original was created.
+        backups = list(project.glob("AGENTS.md.backup.*"))
+        assert len(backups) == 1
+        assert backups[0].read_text(encoding="utf-8") == user_text
+
+    def test_idempotent_block_replaced_not_stacked(
+        self, install_sh_no_main, install_dir, tmp_path
+    ):
+        project = tmp_path / "proj"
+        project.mkdir()
+        agents = project / "AGENTS.md"
+        agents.write_text("# My AGENTS\n\nKeep me.\n", encoding="utf-8")
+        _call(install_sh_no_main, "write_codex_config", project, install_dir)
+        first = agents.read_text(encoding="utf-8")
+        result = _call(
+            install_sh_no_main, "write_codex_config", project, install_dir, force="true"
+        )
+        assert result.returncode == 0, result.stderr
+        second = agents.read_text(encoding="utf-8")
+        assert first == second
+        assert second.count("<!-- BEGIN AI-MEMORY -->") == 1

--- a/tests/test_merge_agents_md.py
+++ b/tests/test_merge_agents_md.py
@@ -69,6 +69,24 @@ class TestSpliceBlock:
         assert out.count(mam.BEGIN_MARKER) == 1
         assert out.count(mam.END_MARKER) == 1
 
+    def test_single_balanced_pair_is_treated_as_managed_block_accepted(self):
+        # Accepted residual: a file whose ONLY markers are a single balanced
+        # BEGIN…END pair is indistinguishable from a stale managed block, so
+        # replace-in-place applies. Refusing would break idempotent re-install.
+        # This test pins that accepted behavior; any future routing change that
+        # turns this into a refusal would be a regression.
+        user_owned_text = "user-authored text that happens to sit inside markers\n"
+        original = mam.BEGIN_MARKER + "\n" + user_owned_text + mam.END_MARKER
+        # First run: replace-in-place produces the managed block.
+        out = mam.splice_block(original, _CONTENT)
+        assert out.count(mam.BEGIN_MARKER) == 1
+        assert out.count(mam.END_MARKER) == 1
+        assert "search-memory" in out
+        assert user_owned_text not in out  # replaced, not preserved
+        # Second run is idempotent.
+        out2 = mam.splice_block(out, _CONTENT)
+        assert out == out2
+
 
 class TestMergeAgentsMd:
     def test_creates_new_agents_md(self, tmp_path, content_file):

--- a/tests/test_merge_agents_md.py
+++ b/tests/test_merge_agents_md.py
@@ -1,0 +1,112 @@
+"""Unit tests for the Codex AGENTS.md managed-block splice (TD-600).
+
+merge_agents_md.py delivers AI-Memory's Codex guidance as a managed marker-block
+inside the project-root AGENTS.md. Core safety properties:
+
+  - insert-if-absent / replace-in-place (never stacks a second block);
+  - everything OUTSIDE the markers stays byte-for-byte;
+  - an existing AGENTS.md is backed up (copy) before writing;
+  - the write is atomic (no partial/corrupt AGENTS.md on failure).
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).parent.parent / "scripts" / "merge_agents_md.py"
+
+_spec = importlib.util.spec_from_file_location("merge_agents_md", _SCRIPT)
+mam = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mam)
+
+_CONTENT = "# AI Memory — Agent Guidance\n\nUse `search-memory` and `memory-status`.\n"
+
+
+@pytest.fixture
+def content_file(tmp_path) -> Path:
+    p = tmp_path / "content.md"
+    p.write_text(_CONTENT, encoding="utf-8")
+    return p
+
+
+class TestSpliceBlock:
+    def test_insert_into_empty(self):
+        out = mam.splice_block("", _CONTENT)
+        assert out.startswith(mam.BEGIN_MARKER)
+        assert mam.END_MARKER in out
+        assert "search-memory" in out
+
+    def test_insert_preserves_user_content_verbatim(self):
+        user = "# My project\n\nCustom instructions for my agent.\n"
+        out = mam.splice_block(user, _CONTENT)
+        # User content is preserved exactly as a prefix.
+        assert out.startswith(user)
+        assert mam.BEGIN_MARKER in out and mam.END_MARKER in out
+
+    def test_replace_in_place_is_idempotent(self):
+        user = "# My project\n\nKeep me.\n"
+        once = mam.splice_block(user, _CONTENT)
+        twice = mam.splice_block(once, _CONTENT)
+        assert once == twice
+        assert once.count(mam.BEGIN_MARKER) == 1
+        assert once.count(mam.END_MARKER) == 1
+
+    def test_replace_preserves_bytes_outside_markers(self):
+        pre = "# Header\n\nuser pre text\n\n"
+        post = "\n\n## Trailer\n\nuser post text\n"
+        original = pre + mam.build_block("OLD AI-MEMORY CONTENT") + post
+        out = mam.splice_block(original, _CONTENT)
+        # Bytes before BEGIN and after END are byte-identical; only the block changed.
+        assert out.startswith(pre)
+        assert out.endswith(post)
+        assert "OLD AI-MEMORY CONTENT" not in out
+        assert "search-memory" in out
+
+    def test_block_content_has_no_marker_leak(self):
+        out = mam.splice_block("", _CONTENT)
+        # Exactly one marker pair.
+        assert out.count(mam.BEGIN_MARKER) == 1
+        assert out.count(mam.END_MARKER) == 1
+
+
+class TestMergeAgentsMd:
+    def test_creates_new_agents_md(self, tmp_path, content_file):
+        agents = tmp_path / "AGENTS.md"
+        mam.merge_agents_md(str(agents), str(content_file))
+        assert agents.exists()
+        text = agents.read_text(encoding="utf-8")
+        assert mam.BEGIN_MARKER in text and mam.END_MARKER in text
+        assert "search-memory" in text
+
+    def test_backup_created_for_existing_file(self, tmp_path, content_file):
+        agents = tmp_path / "AGENTS.md"
+        agents.write_text("# Existing user AGENTS\n", encoding="utf-8")
+        mam.merge_agents_md(str(agents), str(content_file))
+        backups = list(tmp_path.glob("AGENTS.md.backup.*"))
+        assert len(backups) == 1
+        assert backups[0].read_text(encoding="utf-8") == "# Existing user AGENTS\n"
+
+    def test_user_content_preserved_byte_for_byte(self, tmp_path, content_file):
+        agents = tmp_path / "AGENTS.md"
+        user_text = "# My AGENTS\n\nDo not clobber this.\n"
+        agents.write_text(user_text, encoding="utf-8")
+        mam.merge_agents_md(str(agents), str(content_file))
+        out = agents.read_text(encoding="utf-8")
+        assert out.startswith(user_text)
+
+    def test_rerun_replaces_not_duplicates(self, tmp_path, content_file):
+        agents = tmp_path / "AGENTS.md"
+        agents.write_text("# My AGENTS\n\nKeep me.\n", encoding="utf-8")
+        mam.merge_agents_md(str(agents), str(content_file))
+        first = agents.read_text(encoding="utf-8")
+        mam.merge_agents_md(str(agents), str(content_file))
+        second = agents.read_text(encoding="utf-8")
+        assert first == second
+        assert second.count(mam.BEGIN_MARKER) == 1
+
+    def test_no_temp_files_left_behind(self, tmp_path, content_file):
+        agents = tmp_path / "AGENTS.md"
+        mam.merge_agents_md(str(agents), str(content_file))
+        leftovers = list(tmp_path.glob(".AGENTS_*"))
+        assert leftovers == []

--- a/tests/test_merge_agents_md.py
+++ b/tests/test_merge_agents_md.py
@@ -110,3 +110,71 @@ class TestMergeAgentsMd:
         mam.merge_agents_md(str(agents), str(content_file))
         leftovers = list(tmp_path.glob(".AGENTS_*"))
         assert leftovers == []
+
+
+class TestSpliceBlockMalformedMarkers:
+    """splice_block raises MalformedMarkersError on every malformed marker state."""
+
+    def test_stray_begin_only_raises(self):
+        stray = "user content\n" + mam.BEGIN_MARKER + "\nmore user content\n"
+        with pytest.raises(mam.MalformedMarkersError):
+            mam.splice_block(stray, _CONTENT)
+
+    def test_stray_end_only_raises(self):
+        stray = "user content\n" + mam.END_MARKER + "\nmore user content\n"
+        with pytest.raises(mam.MalformedMarkersError):
+            mam.splice_block(stray, _CONTENT)
+
+    def test_end_before_begin_raises(self):
+        swapped = "pre\n" + mam.END_MARKER + "\nmid\n" + mam.BEGIN_MARKER + "\npost\n"
+        with pytest.raises(mam.MalformedMarkersError):
+            mam.splice_block(swapped, _CONTENT)
+
+    def test_duplicate_blocks_raises(self):
+        block = mam.build_block(_CONTENT)
+        two_blocks = "user\n" + block + "\n\n" + block + "\n"
+        with pytest.raises(mam.MalformedMarkersError):
+            mam.splice_block(two_blocks, _CONTENT)
+
+
+class TestMergeAgentsMdMalformed:
+    """merge_agents_md leaves the file byte-unchanged and warns on malformed markers."""
+
+    def _assert_refused_twice(
+        self, tmp_path, content_file, original_text: str, capsys
+    ) -> None:
+        """Two calls both refuse: file byte-identical to original, no backup, WARNING in stderr."""
+        agents = tmp_path / "AGENTS.md"
+        agents.write_text(original_text, encoding="utf-8")
+
+        # Run 1: must refuse without writing.
+        with pytest.raises(mam.MalformedMarkersError):
+            mam.merge_agents_md(str(agents), str(content_file))
+        assert agents.read_text(encoding="utf-8") == original_text
+        assert list(tmp_path.glob("AGENTS.md.backup.*")) == []
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+
+        # Run 2: same input (unchanged file) → same refusal; no stacking or deletion.
+        with pytest.raises(mam.MalformedMarkersError):
+            mam.merge_agents_md(str(agents), str(content_file))
+        assert agents.read_text(encoding="utf-8") == original_text
+
+    def test_stray_begin_user_content_not_deleted(self, tmp_path, content_file, capsys):
+        original = (
+            "important user content\n" + mam.BEGIN_MARKER + "\nmore user content\n"
+        )
+        self._assert_refused_twice(tmp_path, content_file, original, capsys)
+
+    def test_stray_end_does_not_stack(self, tmp_path, content_file, capsys):
+        original = "user content\n" + mam.END_MARKER + "\nmore user\n"
+        self._assert_refused_twice(tmp_path, content_file, original, capsys)
+
+    def test_end_before_begin_does_not_stack(self, tmp_path, content_file, capsys):
+        original = "pre\n" + mam.END_MARKER + "\nmid\n" + mam.BEGIN_MARKER + "\npost\n"
+        self._assert_refused_twice(tmp_path, content_file, original, capsys)
+
+    def test_duplicate_blocks_refused(self, tmp_path, content_file, capsys):
+        block = mam.build_block(_CONTENT)
+        original = "user\n" + block + "\n\n" + block + "\n"
+        self._assert_refused_twice(tmp_path, content_file, original, capsys)


### PR DESCRIPTION
## Summary

Ships an AI-Memory-owned **agent-guidance file** into each project the module installs into, for **all four supported CLIs** — Claude Code, Gemini CLI, Cursor, and Codex. Each file auto-loads at session start in that CLI's own always-on convention and explains how to work with the memory system (automatic capture/recall, the per-CLI memory commands, `AI_MEMORY_PROJECT_ID` project-scoping) plus concise general engineering conduct, with a product-framed rule to surface confusing AI-Memory behavior rather than work around it.

Resolves TD-600 (the product previously shipped no agent-guidance file).

## Delivery per CLI

Each CLI gets an AI-Memory-**owned** file (or, for Codex, a managed marker-block), so deployment is idempotent on re-install and **zero-clobber of user-authored files**:

- **Claude Code** — `.claude/rules/ai-memory.md` (Claude Code auto-loads `.claude/rules/*.md`; it reads `CLAUDE.md`/`.claude/rules/`, not `AGENTS.md`).
- **Gemini CLI** — `AI-MEMORY.md` at the project root, registered in `context.fileName` in `.gemini/settings.json` by **appending** — never dropping `GEMINI.md` or user-set entries, and the user's `GEMINI.md` is never written.
- **Cursor** — `.cursor/rules/ai-memory.mdc` with `alwaysApply: true`; never touches other `.mdc`, `.cursorrules`, or `AGENTS.md`.
- **Codex** — a managed marker-block (`<!-- BEGIN AI-MEMORY -->` … `<!-- END AI-MEMORY -->`) in the project-root `AGENTS.md`, since Codex has no owned-file path. Insert-if-absent / replace-in-place; a timestamped backup is made and the write is atomic; everything outside the markers is byte-preserved. If the existing `AGENTS.md` has malformed or ambiguous AI-Memory markers (unbalanced, out-of-order, or duplicate), the deploy **refuses and warns, leaving the file unchanged** while the install continues — it never deletes or duplicates user content.

The guidance content is identical across CLIs except per-CLI command names (Gemini/Cursor: `search-memory` / `memory-status` / `save-memory`; Codex: `search-memory` / `memory-status`) and each CLI's intro/format. Deployed on both fresh installs and in-place updates.

## What changed

- `.claude/rules/ai-memory.md` and `src/memory/adapters/templates/{gemini,cursor,codex}/ai-memory.{md,mdc}` — the shipped guidance files (each under 200 lines).
- `scripts/install.sh` — threads the files repo→install-dir via `sync_installed_files()` (reached on both fresh install and in-place update) and deploys each in the existing per-CLI config path. The Codex deploy degrades gracefully: a refused or failed splice logs and continues, never aborting the install.
- `scripts/merge_agents_md.py` — splices the Codex managed-block with marker well-formedness validation (refuse-and-warn on any unbalanced/ambiguous marker state), backup-first, atomic write.
- Tests — per-CLI deploy, idempotency, zero-clobber against pre-existing user files (`GEMINI.md` + custom `context.fileName`, user `.cursor` rules, pre-existing `AGENTS.md`), and the malformed-marker refuse paths.
- `CHANGELOG.md`, `docs/MULTI-IDE-SUPPORT.md` — documentation.

## Testing

Automated coverage exercises each CLI's deploy, idempotent re-install, zero-clobber of pre-existing user files, and the Codex malformed-marker refuse paths. A multi-CLI no-clobber live-test (install into a project carrying a user `GEMINI.md`, user `.cursor` rules, and a pre-existing user `AGENTS.md`, including a malformed-marker `AGENTS.md`) is run before merge.
