### PR TITLE
Refresh POV docs: correct knowledge/ path, update structure tree, document add-project install (TD-544)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   skills-with-scripts standard). This is FILE-content hygiene, distinct from
   `aim-purge` (Qdrant-point purging).
 
+- **`docs/parzival/` POV docs refreshed (TD-544)** — three pre-existing doc-drift
+  items corrected:
+  - `data/` path under `_ai-memory/pov/` fixed to `knowledge/` in both
+    `README-POV.md` and `INSTALL-GUIDE-POV.md` (factual error in user-facing docs).
+  - `README-POV.md` project-structure tree refreshed to current layout: stale
+    `(v2.1)` label dropped; `scripts/`, `module-help.csv`, and
+    `STEP-FILE-TEMPLATE.md` added; skills list updated to reflect current skill set
+    (`aim-agent-sanctum-init`, `aim-lore-hygiene`, `aim-tracking-freshness` added;
+    `aim-bmad-dispatch` removed); templates list and `workflows/` directory updated
+    to match current on-disk contents.
+  - `INSTALL-GUIDE-POV.md` gains an `add-project` / shared-stack section documenting
+    the `INSTALL_MODE=add-project` flow: when it triggers, what the installer skips
+    vs. runs, prerequisites, per-project configuration, and verification steps.
+
 ### Changed
 
 - **Sanctum templates** — aligned the eight scaffolded sanctum files (`CREED`,

--- a/docs/parzival/INSTALL-GUIDE-POV.md
+++ b/docs/parzival/INSTALL-GUIDE-POV.md
@@ -31,6 +31,7 @@
 - [🚀 Installation](#-installation)
   - [New Projects](#new-projects)
   - [Existing Projects](#existing-projects)
+  - [Adding a Project to a Shared Stack](#adding-a-project-to-a-shared-stack)
 - [🔄 Updating Parzival](#-updating-parzival)
 - [💡 Using Parzival](#-using-parzival)
 - [🛡️ Safety Features](#️-safety-features)
@@ -302,6 +303,81 @@ This safely updates all module code, regenerates skill shims, removes stale file
 
 Re-running `install.sh` is the entire update process. It adds any new module files, removes files that older versions placed elsewhere, and leaves your `oversight/` data untouched. There is no manual file surgery, no data migration, and no breaking changes between versions.
 
+### Adding a Project to a Shared Stack
+
+When AI Memory is already installed on your machine (the shared services at `~/.ai-memory/` are running), you can wire a second — or third, or fourth — project to those same services without touching Docker at all. This is `INSTALL_MODE=add-project`.
+
+#### When it triggers
+
+Run the installer from the new project directory:
+
+```bash
+./scripts/install.sh /path/to/new-project
+```
+
+The installer detects the existing `~/.ai-memory/` installation and prompts:
+
+```
+Found existing AI Memory installation
+
+Options:
+  1. Add project to existing installation (recommended)
+     - Reuses shared Docker services
+     - Creates project-level hooks via symlinks
+  2. Reinstall shared infrastructure (stop services, update files, restart)
+  3. Abort installation
+```
+
+Choose **1** to enter add-project mode. For automation, set `AI_MEMORY_ADD_PROJECT_MODE=true` to skip the prompt.
+
+#### What the installer does (and skips)
+
+| Step | add-project | full install |
+|------|:-----------:|:------------:|
+| Start Docker services (Qdrant, embeddings, Langfuse) | ⏭ skipped | ✅ |
+| Verify existing services are healthy | ✅ | — |
+| Update shared scripts to current version | ✅ | ✅ |
+| Configure per-project GitHub repo and Jira | ✅ | ✅ |
+| Create project hooks via symlinks | ✅ | ✅ |
+| Deploy AI Memory rules file | ✅ | ✅ |
+| Register project for GitHub sync | ✅ | ✅ |
+| Full infrastructure copy and env setup | ⏭ skipped | ✅ |
+
+The installer runs exactly two progress steps in this mode — `Prerequisites & Validation` and `Project Configuration` — instead of the six steps a full install requires.
+
+#### Prerequisites
+
+The shared stack must already be running before you start. Verify with:
+
+```bash
+docker ps | grep ai-memory
+```
+
+If services are stopped, restart them from the shared installation before running the project installer:
+
+```bash
+cd ~/.ai-memory/docker && bash ~/path/to/ai-memory/scripts/stack.sh restart
+```
+
+#### Per-project configuration
+
+`add-project` mode prompts for the new project's GitHub repository and Jira settings (if those integrations are enabled). These are stored alongside the other registered projects in `~/.ai-memory/config/projects.d/`. Each project gets its own isolated Qdrant namespace — the shared Qdrant instance routes memory by `AI_MEMORY_PROJECT_ID`, so projects never see each other's data.
+
+#### Verify the installation
+
+```bash
+cd /path/to/new-project
+claude
+```
+
+Then in Claude Code:
+
+```
+/pov:parzival-start
+```
+
+Parzival should load and confirm the project context. Run `aim-status` to confirm the correct project ID is active.
+
 ---
 
 ## 🔄 Updating Parzival
@@ -468,7 +544,7 @@ my-project/
 │       ├── agents/
 │       │   └── parzival.md         # Main agent definition
 │       ├── constraints/            # Global + phase constraints
-│       ├── data/                   # Reference data (complexity, confidence, escalation, etc.)
+│       ├── knowledge/              # Reference docs (complexity, confidence, escalation, etc.)
 │       ├── references/             # Lazy-loaded reference docs (loaded on-demand)
 │       ├── workflows/              # Phase workflows
 │       ├── skills/                 # 7 Parzival skills (source of truth)

--- a/docs/parzival/README-POV.md
+++ b/docs/parzival/README-POV.md
@@ -602,20 +602,17 @@ Parzival uses a **five-layer constraint enforcement system** to maintain consist
 
 ## 🏛️ Architecture
 
-### Project Structure (v2.1)
+### Project Structure
 
 ```
 _ai-memory/pov/                            # POV module definition
+├── STEP-FILE-TEMPLATE.md                  # Template for authoring new workflow step files
 ├── agents/
 │   └── parzival.md                        # Main agent definition (persona, menu, rules)
-├── config.yaml                            # Module configuration (v2.1.0)
+├── config.yaml                            # Module configuration
 ├── constraints/                           # Layered constraint system
-│   ├── global/                            # GC-01 through GC-15 + GC-19 + GC-20
+│   ├── global/                            # GC-01 through GC-21
 │   │   ├── constraints.md                 # Summary + self-check schedule
-│   │   ├── GC-01-never-implement.md
-│   │   ├── GC-04-user-manages-parzival.md
-│   │   ├── GC-19-spawn-agents-as-teammates.md
-│   │   ├── GC-20-no-instruction-in-activation.md
 │   │   └── ...                            # One file per constraint
 │   ├── discovery/                         # Phase-specific: DC-01 through DC-07
 │   ├── architecture/                      # Phase-specific: AC-01 through AC-08
@@ -625,36 +622,43 @@ _ai-memory/pov/                            # POV module definition
 │   ├── release/                           # Phase-specific: RC-01 through RC-07
 │   ├── maintenance/                       # Phase-specific: MC-01 through MC-08
 │   └── init/                              # Init phase: IN-01 through IN-05
-├── data/                                  # Reference data (escalation, confidence, etc.)
+├── knowledge/                             # Reference docs (escalation, confidence, etc.)
+├── module-help.csv                        # Module command reference
 ├── references/                            # Lazy-loaded reference docs (loaded on-demand only)
 │   ├── workflow-map-details.md            # WORKFLOW-MAP detail (phase summaries, transitions)
 │   ├── auto-memory-best-practices.md      # Claude Code auto-memory directory guidance
 │   └── live-functionality-testing.md      # Live functionality test guidance
+├── scripts/                               # Utility scripts (status prepass, session index, etc.)
 ├── skills/                                # Full skill definitions (loaded on-demand)
 │   ├── aim-parzival-bootstrap/            # Cross-session memory bootstrap
 │   ├── aim-parzival-constraints/          # Constraint loading
 │   ├── aim-parzival-team-builder/         # Team design for parallel execution
-│   ├── aim-agent-dispatch/                # Agent instruction preparation (Layer 3a)
+│   ├── aim-agent-dispatch/                # Agent instruction preparation
 │   ├── aim-agent-lifecycle/               # Agent lifecycle management
-│   ├── aim-bmad-dispatch/                 # BMAD agent activation (Layer 3b)
-│   └── aim-model-dispatch/                # Model selection + multi-provider dispatch
-├── templates/                             # Oversight document templates (7 files)
+│   ├── aim-agent-sanctum-init/            # Sanctum scaffold and init
+│   ├── aim-lore-hygiene/                  # Lore hygiene checks
+│   ├── aim-model-dispatch/                # Model selection + multi-provider dispatch
+│   └── aim-tracking-freshness/            # Tracking freshness verification
+├── templates/                             # Oversight document templates
 │   ├── bug-report.template.md
 │   ├── correction.template.md
 │   ├── decision-log.template.md
 │   ├── session-handoff.template.md
+│   ├── tech-debt-report.template.md
 │   ├── verification-code.template.md
+│   ├── verification-fix.template.md
 │   ├── verification-production.template.md
 │   └── verification-story.template.md
 └── workflows/                             # Workflow engine
     ├── WORKFLOW-MAP.md                    # Master router (routing decision tree)
     ├── STEP-PREAMBLE.md                   # Shared boilerplate referenced by every step file
     ├── cycles/                            # Reusable atomic cycles
-    │   ├── agent-dispatch/                # Agent team management (9 steps)
+    │   ├── agent-dispatch/                # Agent team management
     │   ├── approval-gate/                 # User approval protocol
     │   ├── legitimacy-check/              # Issue triage
     │   ├── research-protocol/             # Verified research
     │   └── review-cycle/                  # Dev-review loop
+    ├── first-breath/                      # First-run onboarding workflow
     ├── init/                              # Init workflows (new + existing)
     ├── phases/                            # Phase workflows (7 phases)
     └── session/                           # Session workflows (start, status, close, etc.)


### PR DESCRIPTION
## What
- Corrects a wrong directory name in the POV structure trees (`data/` → `knowledge/`) in both `README-POV.md` and `INSTALL-GUIDE-POV.md`.
- Refreshes `README-POV.md`'s project-structure tree to the current layout (drops the stale "(v2.1)" label; adds `scripts/`, `module-help.csv`, `STEP-FILE-TEMPLATE.md`, and other current entries).
- Adds an `INSTALL-GUIDE-POV.md` section documenting the add-project / shared-stack install flow (`INSTALL_MODE=add-project`).

## Why
Pre-existing documentation drift (TD-544): a factually-wrong path and a stale tree mislead operators, and the add-project install flow was undocumented.

## Scope
Documentation only — no code changes.
