### PR TITLE
docs: close SOT coverage gaps (content-drift, sanctum, Tier 2 injection, README discoverability)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@
 - **LLM Observability** — Full pipeline tracing via Langfuse (opt-in); every hook span visible with timing and payloads.
 - **Progressive Context Injection** — Token-budget-aware delivery: session bootstrap, per-turn injection, confidence-filtered retrieval.
 
+See [docs/TEMPORAL-FEATURES.md](docs/TEMPORAL-FEATURES.md) for temporal decay configuration and freshness settings.
+
 ---
 
 ## Quick Start
@@ -86,6 +88,7 @@ After pulling a new version and re-running `./scripts/install.sh /path/to/your-p
 | Core + Langfuse (opt-in) | 15 services | 32 GiB | 8 cores |
 
 See [INSTALL.md](INSTALL.md) for step-by-step instructions covering macOS, Linux, and Windows (WSL2), manual installation, configuration options, and uninstallation.
+See [docs/MULTI-IDE-SUPPORT.md](docs/MULTI-IDE-SUPPORT.md) for Gemini CLI, Cursor, and Codex CLI adapter setup.
 
 ---
 
@@ -142,6 +145,7 @@ Memory retrieval fires automatically on:
 - **Session History Keywords** — "What have we done..." → searches session summaries
 
 See [docs/HOOKS.md](docs/HOOKS.md) for complete hook documentation and the full trigger keyword reference.
+See [docs/AI_MEMORY_ARCHITECTURE.md](docs/AI_MEMORY_ARCHITECTURE.md) for the full system architecture reference.
 
 ---
 
@@ -159,7 +163,7 @@ Parzival is an AI project manager for Claude Code. He manages the full project l
 
 Parzival is optional but recommended for complex multi-session projects. AI Memory's core features (semantic search, GitHub sync, skills, freshness detection) work independently.
 
-See [docs/parzival/](docs/parzival/) for the full Parzival documentation suite and [docs/DISPATCH-SKILLS.md](docs/DISPATCH-SKILLS.md) for multi-provider dispatch setup.
+See [Parzival documentation](docs/parzival/README-POV.md) for the full Parzival documentation suite and [docs/DISPATCH-SKILLS.md](docs/DISPATCH-SKILLS.md) for multi-provider dispatch setup.
 
 ---
 
@@ -250,6 +254,7 @@ python scripts/recover_hook_guards.py --apply
 ```
 
 See [docs/RECOVERY.md](docs/RECOVERY.md) for the complete recovery guide.
+See [docs/BACKUP-RESTORE.md](docs/BACKUP-RESTORE.md) for collection backup and restore procedures.
 
 ---
 

--- a/docs/CONTENT-DRIFT.md
+++ b/docs/CONTENT-DRIFT.md
@@ -1,0 +1,210 @@
+# 🔍 Sanctum Content-Drift Detection
+
+Detect when your operator-scaffolded sanctum files have drifted from the evolving reference templates — and surface recommended additions, updates, or removals with rationale. Your content is never automatically changed.
+
+---
+
+## Overview
+
+When you first initialise a sanctum for a Claude Code agent, the `aim-agent-sanctum-init` skill scaffolds eight files from reference templates:
+
+| File | Purpose |
+|------|---------|
+| `BOND.md` | Relationship framing and working agreements |
+| `CAPABILITIES.md` | Declared agent capabilities |
+| `CREED.md` | Operating principles and values |
+| `INDEX.md` | Directory of sanctum contents |
+| `LORE.md` | Project knowledge and architecture |
+| `MEMORY.md` | Persistent notes and learnings |
+| `PERSONA.md` | Agent identity and communication style |
+| `PULSE.md` | Health signals and operational status |
+
+Over time the reference templates evolve — new guidance sections are added, outdated framing is revised, and obsolete sections are retired. Your scaffolded files stay as you left them. **Content drift** is the gap between what your sanctum files say and what the current templates recommend.
+
+The `aim-content-drift` skill detects this gap deterministically (anchored fingerprints, unit-by-unit comparison) and surfaces batched, severity-ranked recommendations with rationale. It is **read-only for sanctum content** in v1 — nothing changes until you choose.
+
+For the precise mechanics (unit parsing, fingerprint comparison, classification, ack bookkeeping), see the skill's own reference: `_ai-memory/pov/skills/aim-content-drift/SKILL.md`.
+
+---
+
+## When to Run
+
+Run `/aim-content-drift` when:
+
+- **Session start** — quick drift check before beginning significant work in a new session.
+- **After template updates** — the reference templates ship with the module; after installing an update, check whether your sanctum has fallen behind.
+- **On operator request** — whenever you want to know if your sanctum is current with the standard.
+
+---
+
+## Drift Classes
+
+Every recommendation belongs to one of three actionable classes. Two classification results — **MATCH** (current, no action) and **CUSTOMIZED** (operator-authored, protected) — produce no finding.
+
+### MISSING · severity MEDIUM
+
+**What it means:** A section that exists in the current reference template is absent from your sanctum file. This is a gap — you are not getting the guidance that section provides.
+
+**Operator action:** Review the reference framing (shown with `--show-diff`) and add the section to your sanctum file if it applies to your use case.
+
+---
+
+### SUPERSEDED · severity HIGH
+
+**What it means:** Your sanctum file contains a section whose framing matches an *older* version of the reference. The template has since updated it with new or corrected guidance, but your file still reflects the prior framing.
+
+This is the highest-severity class because you may be relying on stale guidance — following advice the template has since revised.
+
+**Operator action:** Review the current reference framing alongside your existing section. Update your file to incorporate the new guidance, keeping any operator-added content you wish to preserve.
+
+---
+
+### ORPHAN · severity LOW
+
+**What it means:** A section that was once in the reference template has since been removed from it. Your sanctum file still contains this section, and it looks like the original unmodified scaffold text — suggesting you may not have added your own content to it.
+
+**Operator action:** Consider removing the section if it was never customised. If you have come to rely on it for your own purposes, keep it — that is a valid choice and the skill will respect it (see [The Anti-Clobber Guarantee](#the-anti-clobber-guarantee) and [Known Limitation](#known-v1-limitation-orphan-heuristic) below).
+
+---
+
+## The Anti-Clobber Guarantee
+
+**Operator content is never recommended for removal.**
+
+The classification logic iterates over *reference-owned unit IDs only*. Content you have authored — sections you added yourself, or sections where you replaced the reference framing with your own writing — is structurally invisible to the remove path. The guarantee is enforced by design, not by a runtime check.
+
+Specifically:
+
+- **MISSING** and **SUPERSEDED** only fire for sections the *reference* owns and tracks. If you have replaced the reference framing entirely, the section is classified **CUSTOMIZED** (kept, no finding).
+- **ORPHAN** fires only when your section's content is a *pristine scaffold remnant* — the reference framing with each `{placeholder}` resolved to a short value such as a name or date, and nothing else added. If you have added any operator prose, the section is **CUSTOMIZED** (kept, no finding).
+- The only files the skill writes are its own per-project ack sidecar (see [Acknowledging Intentional Divergence](#acknowledging-intentional-divergence)). Sanctum files and templates are never touched.
+
+---
+
+## Acknowledging Intentional Divergence
+
+Sometimes a recommendation is correct — the reference changed — but the divergence is intentional. You want to keep your sanctum as-is and stop being reminded about it. That is what `--ack` is for.
+
+### How acks work
+
+An ack entry suppresses a specific recommendation until the *reference unit itself changes again*. It is keyed to the current reference fingerprint, so if the template is later updated and the unit drifts again, the recommendation re-surfaces automatically.
+
+Ack entries are stored in a per-project sidecar file `content-drift-ack.json` located alongside the sanctum dir under your project's `_ai-memory/` directory. The file is designed to be committed and reviewed in diffs (the ESLint bulk-suppressions model).
+
+### The ack workflow
+
+**Step 1 — Detect drift:**
+
+```bash
+# Default: severity-ranked count + pointer (index-not-log)
+python3 scripts/content_drift.py <sanctum-path>
+
+# Add --show-diff to preview the full recommended change for each finding
+python3 scripts/content_drift.py <sanctum-path> --show-diff
+```
+
+Output looks like:
+
+```
+content drift: 2 recommendation(s) (HIGH 1 · MEDIUM 1 · LOW 0)
+
+  [HIGH] SUPERSEDED  LORE.md → ## System Architecture
+    Your 'System Architecture' section matches an earlier version of the reference
+    framing; the template has since updated it. Review the change.
+    ack with: --ack LORE.md::system-architecture
+
+  [MEDIUM] MISSING  CREED.md → ## Conflict Resolution
+    The reference template added the 'Conflict Resolution' section; your CREED.md
+    does not have it. Consider adding it.
+    ack with: --ack CREED.md::conflict-resolution
+
+  (re-run with --show-diff to preview each change)
+
+  Nothing changes until you choose. v1 is detect + acknowledge only.
+```
+
+**Step 2 — Acknowledge a unit you are intentionally keeping as-is:**
+
+```bash
+python3 scripts/content_drift.py <sanctum-path> --ack LORE.md::system-architecture
+```
+
+The ack key format is `<filename>::<unit-slug>` — the skill prints the exact key in each recommendation's output.
+
+Multiple units can be acked in one command by repeating the flag:
+
+```bash
+python3 scripts/content_drift.py <sanctum-path> \
+  --ack LORE.md::system-architecture \
+  --ack CREED.md::conflict-resolution
+```
+
+**Step 3 — Verify:**
+
+```bash
+python3 scripts/content_drift.py <sanctum-path>
+```
+
+Acknowledged units no longer appear. A sanctum with no outstanding recommendations reports:
+
+```
+content drift: 0 recommendation(s) (HIGH 0 · MEDIUM 0 · LOW 0)
+  no action recommended — your sanctum is current.
+```
+
+### Pruning stale acks
+
+When a reference unit no longer drifts (because you updated your sanctum to match), its ack entry is no longer needed. Run `--prune-ack` to drop these stale entries and keep the ack file clean:
+
+```bash
+python3 scripts/content_drift.py <sanctum-path> --prune-ack
+```
+
+---
+
+## Known v1 Limitation: ORPHAN Heuristic
+
+The **ORPHAN** class — the only one that recommends *removing* a section — relies on a bounded heuristic to determine whether a section is a "pristine scaffold remnant".
+
+The test checks whether your section's content is exactly the original reference framing, with each `{placeholder}` resolved to a short, value-shaped fill (a name, a date, a language — up to five sub-tokens). If the fill fits this pattern and nothing else was added, the section is treated as pristine and the ORPHAN recommendation fires.
+
+**The known edge case:** A short fill that happens to look like a simple value (e.g. a one-word entry where a name was expected) can make a section read as pristine even if you intended that fill as operator content. When this happens the skill will suggest you consider removing the section.
+
+This is safe by design:
+- Detection is read-only — no automatic edit can result from a false ORPHAN.
+- The recommendation is phrased as a suggestion ("if that is right, you may remove it"), not a directive.
+- If you have genuinely customised the section — added your own prose, used a longer fill, or used punctuation-joined phrasing — the section classifies as **CUSTOMIZED** (kept, no finding). The heuristic's bias is always toward *keeping* content when ambiguous.
+
+A confirming `--apply` path, which would carry a stricter pre-apply check, is deferred to v1.1.
+
+---
+
+## `--apply` Deferred to v1.1
+
+v1 of `aim-content-drift` is **detect + acknowledge only**. There is no `--apply` flag.
+
+Applying a recommendation is always an operator-performed manual edit to the sanctum file. This is intentional — the operator reviews the proposed change, decides what to keep from their own content, and applies it by hand. An automated apply path is planned for v1.1 with an explicit pre-apply gate.
+
+---
+
+## CLI Reference
+
+All flags verified against `scripts/content_drift.py`:
+
+| Flag | Description |
+|------|-------------|
+| `<sanctum-path>` | Path to the sanctum directory (required) |
+| `--show-diff` | Show the full previewable diff for each recommendation (default: count + pointer) |
+| `--ack FILE::unit-id` | Acknowledge an intentional divergence; writes the per-project ack sidecar. Repeatable. |
+| `--prune-ack` | Drop ack entries whose unit no longer drifts; writes the ack sidecar. |
+| `--group-id ID` | Explicit project scope (group\_id). Resolved automatically when omitted. |
+| `--fingerprints-dir PATH` | Override the reference fingerprint sidecars location (default: runtime sanctum-init assets dir). |
+| `--ack-file PATH` | Override the ack sidecar path (default: `<project-root>/_ai-memory/content-drift-ack.json`). |
+| `--emit-fingerprints` | **Maintenance only.** Regenerate `*.fingerprints.json` sidecars from `*-template.md` files in `<path>`. Reads templates; never modifies them. |
+
+---
+
+## See Also
+
+- [`_ai-memory/pov/skills/aim-content-drift/SKILL.md`](_ai-memory/pov/skills/aim-content-drift/SKILL.md) — deterministic mechanics: unit parsing, fingerprint schema, classification rule, ack bookkeeping
+- [AI_MEMORY_ARCHITECTURE.md](AI_MEMORY_ARCHITECTURE.md) — overall system architecture

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -10,6 +10,7 @@
   - [PostToolUse](#posttooluse)
   - [PreCompact](#precompact)
   - [Stop](#stop)
+- [Tier 2 Per-Turn Context Injection](#tier-2-per-turn-context-injection)
 - [Activity Logging Hooks](#activity-logging-hooks)
   - [SessionEnd](#sessionend)
   - [UserPromptSubmit](#userpromptsubmit)
@@ -622,6 +623,321 @@ Fires after each response Claude generates.
 
 ---
 
+## 🔍 Tier 2 Per-Turn Context Injection
+
+**Adaptive semantic retrieval injected before each Claude response**
+
+### Overview
+
+The AI Memory Module uses a two-tier injection model:
+
+| Tier | Hook | Trigger | Purpose | Typical Token Budget |
+|------|------|---------|---------|----------------------|
+| **Tier 1 — Bootstrap** | `session_start.py` | `SessionStart` | Conventions + recent decisions, once per session | ~2–3 K tokens |
+| **Tier 2 — Per-turn** | `context_injection_tier2.py` | `UserPromptSubmit` | Adaptive semantic retrieval before every user turn | 500–1500 tokens |
+
+Tier 1 seeds the session with stable context at startup; Tier 2 keeps context fresh turn-by-turn by retrieving what is most relevant to the current prompt. Both tiers cooperate: point IDs injected by Tier 1 are tracked in `InjectionSessionState` so Tier 2 skips already-seen results on subsequent turns.
+
+### Trigger
+
+**Event:** `UserPromptSubmit` — fires before each user prompt is processed.
+
+**Script:** `.claude/hooks/scripts/context_injection_tier2.py`
+
+**Performance target:** <500ms total (NFR-P1, NFR-P5). Exit code always 0 — graceful degradation on any error, never blocks Claude.
+
+**Skip conditions (no injection, empty `additionalContext` returned):**
+- Prompt is empty or whitespace
+- Prompt is a slash command (matches `/[\w:./-]+`)
+- `injection_enabled = false` in config
+- Qdrant health check fails
+- Project ID cannot be resolved from `cwd`
+
+### Configuration
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/scripts/activity_logger.py --event user_prompt"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/scripts/context_injection_tier2.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Process Flow
+
+```
+UserPromptSubmit fires
+    ↓
+1.  Parse hook payload → prompt, session_id, cwd
+2.  resolve_project_id(cwd) → project group_id
+3.  Qdrant health check → graceful skip if unavailable
+4.  Skip if prompt is empty or a slash command
+5.  Load InjectionSessionState (cross-turn dedup + drift tracking)
+6.  route_collections(prompt) → target collection list
+7.  MemorySearch.search() per collection (fast_mode=True)
+8.  Apply freshness penalty to code-patterns results (score × penalty factor)
+9.  Re-sort all results by score descending
+10. Confidence gating → determine gating_mode
+11. compute_topic_drift(current_embedding, last_query_embedding)
+12. compute_adaptive_budget(best_score, results, session_state, config)
+13. Halve budget if gating_mode == "soft_gate" (min 50 tokens)
+14. select_results_greedy(results, budget, excluded_ids, ...)
+15. format_injection_output(selected, tier=2) → additionalContext
+16. Prepend remaining= reject marker if agent_handoff was budget-rejected
+17. log_injection_event(...) → .audit/logs/injection-log.jsonl
+18. Save updated InjectionSessionState
+    ↓
+Claude receives context via hookSpecificOutput.additionalContext
+```
+
+### Collection Routing (`route_collections`)
+
+`route_collections(prompt)` maps each prompt to one or more target collections, evaluated in priority order:
+
+| Priority | Condition | Collections targeted |
+|----------|-----------|----------------------|
+| 1. Keyword triggers | Decision / session / best-practices keyword detected | `discussions` and/or `conventions` |
+| 2. File path | Prompt contains a file path or recognized source extension | `code-patterns` |
+| 3. Intent detection | HOW / WHAT / WHY intent resolved | Intent-matched collection |
+| 4. Cascade (unknown) | None of the above match | `discussions` → `code-patterns` → `conventions` |
+
+When multiple keyword triggers resolve to the same collection (e.g., both a decision keyword and a session keyword match `discussions`), the duplicate route is deduplicated before searching. Keyword-trigger routing is backward-compatible with the old `unified_keyword_trigger.py` hook — no regression.
+
+### Adaptive Token Budget (`compute_adaptive_budget`)
+
+Budget is computed fresh each turn from three weighted signals:
+
+| Signal | Weight | Description |
+|--------|--------|-------------|
+| `quality_signal` | 50% | Best retrieval score (cosine similarity, 0–1) |
+| `density_signal` | 30% | Fraction of results above `injection_confidence_threshold` |
+| `drift_signal` | 20% | Topic drift from previous query — higher drift means a new topic and more context needed |
+
+```
+budget = floor + int((ceiling − floor) × (0.5 × quality + 0.3 × density + 0.2 × drift))
+```
+
+Result is clamped to `[injection_budget_floor, injection_budget_ceiling]` (configured in `MemoryConfig`). Typical range: 500–1500 tokens.
+
+### Confidence Gating Modes
+
+Before computing budget, the best retrieval score is evaluated against configured per-collection thresholds to determine the gating mode:
+
+| Mode | Condition | Effect |
+|------|-----------|--------|
+| `hard_skip` | `best_score < injection_hard_floor` | No injection; exit with empty context |
+| `soft_skip` | `best_score < threshold − 0.05` | No injection; exit with empty context |
+| `soft_gate` | `best_score < threshold` | Inject with budget halved (minimum 50 tokens) |
+| `full` | `best_score ≥ threshold` | Inject with full computed budget |
+
+The threshold compared against is collection-specific — `injection_threshold_discussions`, `injection_threshold_code_patterns`, or `injection_threshold_conventions` — falling back to `injection_confidence_threshold` when the best-scoring collection is unknown.
+
+### Topic Drift (`compute_topic_drift`)
+
+```python
+drift = compute_topic_drift(current_embedding, previous_embedding)
+# Returns float in [0.0, 1.0]
+# 0.0 → same topic as previous turn (cosine similarity = 1.0)
+# 1.0 → completely different topic (orthogonal embeddings)
+# 0.5 → neutral default (first turn, or zero-norm vectors)
+```
+
+Computed as cosine distance (1 − cosine_similarity) between the current prompt's 768-dim embedding and the previous turn's embedding stored in `InjectionSessionState`. High drift increases the adaptive budget so the model receives more re-orientation context when conversation topics shift sharply.
+
+### Greedy Fill (`select_results_greedy`)
+
+Results are packed into the budget from highest score to lowest. Individual results are never truncated — each chunk is fully included or fully skipped. Skip-and-continue allows smaller results to fill remaining budget after an oversized one is rejected.
+
+**Selection logic per candidate (in order):**
+1. Skip if point ID is in `InjectionSessionState.injected_point_ids` (cross-turn dedup — includes IDs from Tier 1)
+2. Skip if content is empty
+3. Skip if content hash already selected this turn (BUG-172 cross-type dedup)
+4. Skip if `result_score < best_score × score_gap_threshold` (BUG-173 low-relevance gap filter)
+5. If `tokens_used + result_tokens ≤ budget`: select; else skip-and-continue
+
+**Score gap filter:** Default threshold 0.7 (results more than 30% below the best semantic score are dropped as noise). Configurable via `INJECTION_SCORE_GAP_THRESHOLD` env var.
+
+**Freshness penalty:** `code-patterns` results marked stale receive a score multiplier before gating and gap filtering. Candidates driven to score 0.0 by the penalty are dropped at the gap filter step and logged with reason `freshness_block` (not `score_gap`) in reject records for accurate attribution.
+
+### Reject Marker (`remaining=`)
+
+When an `agent_handoff`-type result is rejected by `select_results_greedy` due to `budget_exceeded` or `ceiling_exceeded`, a diagnostic comment is prepended to the injected context:
+
+```
+# [tier-2 fallback: handoff-class result rejected reason=budget_exceeded tokens=3200 remaining=180 budget=900]
+```
+
+| Field | Description |
+|-------|-------------|
+| `reason` | `budget_exceeded` or `ceiling_exceeded` |
+| `tokens` | Token count of the rejected result |
+| `remaining` | Unused budget at rejection time (`budget − tokens_used`) |
+| `budget` | Total adaptive budget computed for this turn |
+
+This is observe-only — it does not change which results are selected. Tier 2 has no filesystem fallback path. The rejected `agent_handoff` becomes eligible again after the next `/compact` resets `InjectionSessionState.injected_point_ids`.
+
+### Audit Log (`injection-log.jsonl`)
+
+Every turn — including skipped injections — is appended to `.audit/logs/injection-log.jsonl` by `log_injection_event()`. Each line is a self-contained JSON object.
+
+**Top-level fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `timestamp` | string | ISO 8601 UTC timestamp |
+| `tier` | int | `2` for all Tier 2 events |
+| `trigger` | string | `"UserPromptSubmit"` |
+| `project` | string | Resolved project `group_id` |
+| `session_id` | string | Claude Code session identifier |
+| `results_considered` | int | Total candidates returned across all searched collections |
+| `results_selected` | int | Results that passed greedy fill |
+| `tokens_used` | int | Tokens actually injected this turn |
+| `budget` | int | Adaptive budget computed for this turn |
+| `utilization_pct` | int | `tokens_used / budget × 100` |
+| `best_score` | float | Highest retrieval score (4 decimal places) |
+| `skipped_confidence` | bool | `true` when gating mode is `hard_skip` or `soft_skip` |
+| `topic_drift` | float | Cosine drift from previous query (4 decimal places) |
+| `collections_searched` | list[str] | Collections queried this turn |
+| `gap_threshold` | float | Score gap filter multiplier used |
+| `gating_mode` | string | `"hard_skip"`, `"soft_skip"`, `"soft_gate"`, or `"full"` |
+| `rejects` | list[object] | Per-drop reject records (see below) |
+| `fallback_signaled` | bool | `true` if an `agent_handoff` was budget/ceiling rejected |
+| `per_source` | object | Per-collection budget ledger (see below) |
+
+**Reject record shape** (each entry in `rejects[]`):
+
+| Field | Description |
+|-------|-------------|
+| `type` | Memory type of the rejected result (e.g., `"decision"`, `"agent_handoff"`) |
+| `tokens` | Token count — present only for `budget_exceeded`, otherwise `null` |
+| `score` | Retrieval score at rejection time |
+| `reason` | One of: `already_injected`, `empty_content`, `dedup`, `score_gap`, `freshness_block`, `budget_exceeded` |
+| `tier` | `"2_injection"` |
+| `collection` | Source collection name |
+
+**Per-collection budget ledger (`per_source` object):**
+
+Keyed by collection name.
+
+| Field | Description |
+|-------|-------------|
+| `requested_tokens` | Sum of token counts for candidates that passed all pre-budget filters (`already_injected`, `empty_content`, `dedup`, `score_gap`, `freshness_block`) and reached the budget check |
+| `loaded_tokens` | Tokens actually selected from this collection |
+| `dropped` | Per-reason map accumulating **all** reject reasons: `already_injected`, `empty_content`, `dedup`, `score_gap`, `freshness_block` (`count` only); `budget_exceeded` (`count` + `tokens`) |
+
+Reconciliation per collection (budget-class only): `loaded_tokens + dropped["budget_exceeded"]["tokens"] == requested_tokens`.
+
+**Example entry:**
+
+```json
+{
+  "timestamp": "2026-06-14T10:30:00Z",
+  "tier": 2,
+  "trigger": "UserPromptSubmit",
+  "project": "my-project",
+  "session_id": "sess-abc123",
+  "results_considered": 12,
+  "results_selected": 3,
+  "tokens_used": 820,
+  "budget": 1100,
+  "utilization_pct": 74,
+  "best_score": 0.8821,
+  "skipped_confidence": false,
+  "topic_drift": 0.3142,
+  "collections_searched": ["discussions", "code-patterns"],
+  "gap_threshold": 0.7,
+  "gating_mode": "full",
+  "rejects": [
+    {
+      "type": "decision",
+      "tokens": null,
+      "score": 0.521,
+      "reason": "score_gap",
+      "tier": "2_injection",
+      "collection": "discussions"
+    }
+  ],
+  "fallback_signaled": false,
+  "per_source": {
+    "discussions": {
+      "requested_tokens": 650,
+      "loaded_tokens": 650,
+      "dropped": {}
+    },
+    "code-patterns": {
+      "requested_tokens": 510,
+      "loaded_tokens": 170,
+      "dropped": {"score_gap": {"count": 2}, "budget_exceeded": {"count": 1, "tokens": 340}}
+    }
+  }
+}
+```
+
+### Troubleshooting
+
+<details>
+<summary><strong>No context injected despite relevant session history</strong></summary>
+
+**Diagnosis:**
+```bash
+# Check gating mode and scores for recent turns
+tail -5 ~/.ai-memory/.audit/logs/injection-log.jsonl | jq '{gating_mode, best_score, results_selected, skipped_confidence}'
+```
+
+**Possible Causes:**
+1. `gating_mode: "hard_skip"` or `"soft_skip"` — retrieval scores below threshold
+2. `results_selected: 0` after dedup — all candidates were already injected this session
+3. Slash command prompt — injection skipped for `/...` invocations
+
+**Solution:**
+```bash
+# Check configured thresholds
+grep "injection_confidence_threshold\|injection_hard_floor" ~/.ai-memory/.env
+```
+</details>
+
+<details>
+<summary><strong>Seeing the <code>remaining=</code> marker in injected context</strong></summary>
+
+The `# [tier-2 fallback: handoff-class result rejected ...]` comment means an `agent_handoff` result was too large to fit the computed token budget. It is observe-only — no recovery action is needed on your part.
+
+**Diagnosis:**
+```bash
+tail -1 ~/.ai-memory/.audit/logs/injection-log.jsonl | jq '{budget, tokens_used, fallback_signaled, per_source}'
+```
+
+After the next `/compact`, `InjectionSessionState.injected_point_ids` resets and the handoff becomes eligible again.
+</details>
+
+<details>
+<summary><strong>Hook exceeds 500ms performance target</strong></summary>
+
+**Diagnosis:**
+```bash
+grep "tier2_injection_complete" ~/.ai-memory/logs/hooks.log | tail -5 | python3 -c "import sys,json; [print(json.loads(l).get('duration_ms')) for l in sys.stdin]"
+```
+
+**Solutions:**
+1. Reduce `MAX_RETRIEVALS` — fewer candidates fetched per collection
+2. Verify Qdrant is on localhost (network latency dominates over embedding time)
+3. Check embedding service is pre-warmed; cold start adds ~2s on first call
+</details>
+
+---
+
 ## 📊 Activity Logging Hooks
 
 Activity logging hooks track session events for analytics and debugging. They write to `~/.ai-memory/logs/activity.log` asynchronously.
@@ -659,9 +975,14 @@ Activity logging hooks track session events for analytics and debugging. They wr
 
 ### UserPromptSubmit
 
-**Purpose:** Log each user prompt for session tracking
+**Purpose:** Two hooks run on this event:
 
-**Configuration:**
+1. **`activity_logger.py --event user_prompt`** — logs session tracking data (turn count, prompt length, project). This is the activity-logging side documented here.
+2. **`context_injection_tier2.py`** — performs per-turn semantic retrieval and injects relevant memories as context before Claude responds. See [Tier 2 Per-Turn Context Injection](#tier-2-per-turn-context-injection) for the full injection pipeline.
+
+> **Common misconception:** `UserPromptSubmit` is not only a logging hook. The Tier 2 semantic retrieval hook also fires here on every turn.
+
+**Configuration (activity logging):**
 ```json
 {
   "hooks": {
@@ -671,6 +992,10 @@ Activity logging hooks track session events for analytics and debugging. They wr
           {
             "type": "command",
             "command": ".claude/hooks/scripts/activity_logger.py --event user_prompt"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/scripts/context_injection_tier2.py"
           }
         ]
       }
@@ -679,7 +1004,7 @@ Activity logging hooks track session events for analytics and debugging. They wr
 }
 ```
 
-**Logged Data:**
+**Logged Data (activity_logger.py):**
 - Timestamp
 - Session ID
 - Prompt length

--- a/docs/SANCTUM-SKILLS.md
+++ b/docs/SANCTUM-SKILLS.md
@@ -1,0 +1,191 @@
+# Sanctum Skills — Operator Guide
+
+Per-agent sanctum directories hold an agent's persistent identity, memory, and behavioral files across sessions. Three skills govern the full lifecycle: **`aim-agent-sanctum-init`** scaffolds the directory on first activation, **`aim-content-drift`** detects when scaffolded files drift from evolving reference templates, and **`aim-lore-hygiene`** keeps the always-injected memory files under their size cap.
+
+---
+
+## Table of Contents
+
+- [Sanctum Directory Layout](#sanctum-directory-layout)
+- [aim-agent-sanctum-init](#aim-agent-sanctum-init)
+- [aim-lore-hygiene](#aim-lore-hygiene)
+- [Skill Lifecycle — How the Three Relate](#skill-lifecycle--how-the-three-relate)
+
+---
+
+## Sanctum Directory Layout
+
+Each agent's sanctum lives at:
+
+```
+_ai-memory/sanctum/<agent_id>/
+```
+
+On initialization, the scaffold creates the root directory plus three subdirectories:
+
+```
+_ai-memory/sanctum/<agent_id>/
+├── CREED.md           # Agent identity: role, non-negotiable constraints, core principles
+├── PERSONA.md         # Communication style, tone, and behavioral personality
+├── INDEX.md           # Navigation index: what each sanctum file contains
+├── BOND.md            # Operator relationship: working agreements and mutual expectations
+├── LORE.md            # Accumulated project knowledge (always-injected; ~200-line cap)
+├── MEMORY.md          # Cross-session memory: key decisions and learned patterns (always-injected; ~200-line cap)
+├── CAPABILITIES.md    # Skill and tool inventory
+├── PULSE.md           # Session rhythm: how and when to check in with the operator
+├── capabilities/      # Extended capability detail (overflow from CAPABILITIES.md)
+├── sessions/          # Per-session summary archives
+└── references/        # Stable reference files copied in during scaffold (e.g. caps.md, decision-rule.md)
+```
+
+The eight root files (CREED, PERSONA, INDEX, BOND, LORE, MEMORY, CAPABILITIES, PULSE) are the required sanctum files. All eight must be present for an agent to be considered fully initialized.
+
+---
+
+## aim-agent-sanctum-init
+
+**Purpose:** Deterministic First Breath scaffolding — creates the sanctum folder structure and writes template-substituted files for any missing files.
+
+### When it runs
+
+`aim-agent-sanctum-init` runs automatically during **Parzival activation step 5** whenever any of the eight required sanctum files are absent. It also runs when `aim-agent-dispatch` spawns a memory-bearing domain agent that needs cross-session state.
+
+It can be invoked manually to re-scaffold:
+
+```bash
+python3 scripts/init-sanctum.py <project-root> <skill-path>
+```
+
+where `<skill-path>` resolves to `_ai-memory/pov/skills/aim-agent-sanctum-init/`.
+
+### File-level idempotency
+
+The script iterates through every entry in `TEMPLATE_FILES` and checks each file individually:
+
+- **File is missing** → create it from the template with substitution variables filled in.
+- **File exists** → preserve it exactly; no overwrite, no merge, no modification.
+
+This means re-running the script after partial initialization (e.g. after a failed First Breath) is always safe. It also means a tier upgrade — when new templates are added — automatically creates the new files without touching any existing ones.
+
+### What the script scaffolds
+
+The script reads configuration from two sources:
+
+| Config file | Variables supplied |
+|---|---|
+| `_ai-memory/core/config.yaml` | `{user_name}`, `{communication_language}`, `{birth_date}` |
+| `_ai-memory/pov/config.yaml` | `{project_root}`, `{sanctum_path}` |
+
+Templates live in the skill bundle under `assets/*-template.md`. Each template is substituted and written as `<NAME>.md` in the sanctum root. The script then copies any static reference files from the skill's `references/` directory into the sanctum's `references/` subdirectory.
+
+After the script exits 0, all eight required files are confirmed present.
+
+### Current scope
+
+`aim-agent-sanctum-init` is currently **Parzival-only** (single-agent scaffold). Multi-agent support (`--agent_id`, per-agent template selection, agent-type-driven seed content) is planned for v2.5.0+ when domain agents land.
+
+---
+
+## aim-lore-hygiene
+
+**Purpose:** Compact always-injected sanctum files (LORE.md, MEMORY.md) under the BP-159 ~200-line cap. This is **file-content compaction only** — it has no interaction with Qdrant. Qdrant point purging by age is handled by `aim-purge`, a separate domain (PLAN-028 P0-3).
+
+### When to run
+
+| Trigger | Threshold |
+|---|---|
+| File size check | A sanctum file crosses ~80% of its cap — 160 of 200 lines |
+| Scheduled hygiene pass | Session-stop hook or cron |
+| Operator request | Operator asks to prune or compact lore, or flags a stale or wrong entry |
+
+### Two-phase operation
+
+The script never mutates by default. Always run the dry-run first:
+
+**Phase 1 — Dry-run audit (default, read-only):**
+
+```bash
+python3 scripts/lore_hygiene.py <sanctum-path>
+```
+
+Reports per file: line count, percentage of cap, and the proposed prune / archive / dedup actions with a projected post-compaction line count. This is the verifiable intermediate output — review it before applying.
+
+**Phase 2 — Apply (only after reviewing the plan):**
+
+```bash
+python3 scripts/lore_hygiene.py <sanctum-path> --apply
+```
+
+Each mutated file receives a timestamped `.bak` sidecar before any write. Archived entries move to `references/lore-archive/<FILE>.archive.md` with a one-line pointer left in the hot file. Pass `--qdrant --group-id <project>` to also push archived entries to the Qdrant cold tier (best-effort, opt-in).
+
+A second `--apply` on an already-clean file is a no-op.
+
+### What gets compacted vs archived vs kept
+
+The script is **marker-driven** — it never guesses an entry is low-utility. Entries must be explicitly tagged:
+
+| Action | Markers |
+|---|---|
+| **Prune** (delete) | `[superseded]`, `[contradicted]`, `[wrong]`, `[obsolete]`, `[prune]`, `[expired:YYYY-MM-DD]` (past date), or full-entry strikethrough (`~~…~~` spanning all content) |
+| **Archive** (cold tier + one-line pointer) | `[stale]`, `[archive]` |
+| **Dedup** (collapse to first) | Exact-duplicate entries within the same `## section` |
+| **Keep** | Everything else |
+
+**Markers must be in the leading position** — immediately after the bullet or number prefix (`- [superseded] …`) or in the first cell of a table row (`| [superseded] row | … |`). A marker only mentioned in prose or at the end of a line is ignored and the entry is kept. This single, unambiguous convention prevents accidental pruning of explanatory text that references marker names.
+
+Tag entries during a Pulse, or when the operator says "that's not right anymore", so the next hygiene pass acts on them safely.
+
+### Structure-aware: what the script never touches
+
+The script passes these constructs through byte-for-byte without classifying, deduplicating, splitting, or rewriting them:
+
+| Construct | Rule |
+|---|---|
+| **Code fences** | The entire block (opening delimiter through closing delimiter, including the info string) is one opaque unit. A marker token inside a fence is example text, never an entry. |
+| **Table structure** | The header row and `\|---\|` separator are structural — never classified, so the separator is never orphaned. Only content rows below them are classified. For archived table content rows, the row is dropped in place (the table stays well-formed) with no inline pointer injected into the table body. |
+| **Thematic breaks** | `---`, `***`, `___` and similar delimiters — structural, never deduped. |
+| **Ambiguous constructs** | Blockquotes, indented code, raw HTML, and anything not confidently structural-or-content — kept opaque. The posture is keep-when-uncertain: because the skill mutates the operator's own memory, when it cannot confidently classify a block it preserves it intact. |
+
+### Line cap and `--cap` override
+
+LORE.md and MEMORY.md each carry a cap of ~200 lines. When scanning a sanctum directory the script uses each file's own cap. Passing `--cap N` overrides every file in the directory with a single value — useful when auditing a project-root `CLAUDE.md` at a different cap (e.g. `--cap 300`). `--cap` must be a positive integer.
+
+---
+
+## Skill Lifecycle — How the Three Relate
+
+The three skills cover distinct phases of the sanctum lifecycle without overlap:
+
+```
+First Breath
+    │
+    ▼
+aim-agent-sanctum-init
+    Scaffolds the 8 required files from reference templates.
+    File-level idempotency: missing → create, existing → preserve.
+    │
+    │  (templates evolve over time)
+    ▼
+aim-content-drift
+    Detects when an operator's already-scaffolded files have drifted
+    from updated reference templates. Surfaces recommended add/remove
+    with rationale — never a silent overwrite, never auto-apply.
+    Operator reviews recommendations and applies manually.
+    │
+    │  (LORE.md / MEMORY.md grow through normal session use)
+    ▼
+aim-lore-hygiene
+    Compacts LORE.md and MEMORY.md under the ~200-line cap.
+    Marker-driven: prunes superseded entries, archives stale ones,
+    deduplicates exact copies within sections.
+    FILE-CONTENT only — has no interaction with Qdrant.
+    (Qdrant point purging by age = aim-purge, a separate domain.)
+```
+
+In practice:
+
+1. **First Breath** → `aim-agent-sanctum-init` runs automatically when any of the 8 files are missing and scaffolds everything from templates in one deterministic pass.
+2. **Templates evolve** → `aim-content-drift` runs on session-start or on demand to compare the operator's files against the latest reference templates and surface divergences. The operator decides which recommendations to apply.
+3. **Files grow** → `aim-lore-hygiene` runs when a file approaches 160 lines (80% of cap), compacting it back under the limit so always-injected context stays focused.
+
+The skills do not call each other — each is invoked independently by Parzival or by the operator. `aim-purge` is an entirely separate skill in a different domain (Qdrant vector store maintenance) and shares no overlap with any of the three above.


### PR DESCRIPTION
Closes the P1 documentation source-of-truth gaps surfaced by a docs-coverage audit (13 gaps across 30 system aspects; this PR covers the 8 P1 gaps).

## What
- **New `docs/CONTENT-DRIFT.md`** — operator guide for the `aim-content-drift` skill: the three drift classes, the never-clobber guarantee, the `--ack` workflow, the v1 ORPHAN heuristic limit, and the v1.1-deferred `--apply`.
- **New `docs/SANCTUM-SKILLS.md`** — the sanctum file lifecycle: `aim-agent-sanctum-init` (First Breath scaffold, 8 files, file-level idempotency) and `aim-lore-hygiene` (LORE/MEMORY compaction; distinct from `aim-purge`).
- **`docs/HOOKS.md`** — new "Tier 2 Per-Turn Context Injection" section documenting the per-turn semantic retrieval hook (adaptive budget, confidence gating, topic drift, collection routing, greedy fill, the per-source budget ledger, the `remaining=` reject marker, and the `injection-log.jsonl` schema). Also corrects the prior `UserPromptSubmit` description, which described only activity logging and omitted this hook.
- **`README.md`** — links four previously-unlinked docs (temporal features, multi-IDE support, backup/restore, architecture) and points the Parzival link at `README-POV.md`.

## Why
Several substantial docs were undiscoverable from the README, and two subsystems (content-drift, the Tier 2 injection budget/ledger) had no source-of-truth page. Each aspect of the system should have a discoverable SOT doc.

## Verification
Each new/changed section was reviewed for technical accuracy against the source (`injection.py`, `context_injection_tier2.py`, the skill `SKILL.md` files): symbol names, gating modes, the `per_source` ledger semantics, and the reconciliation example were verified against the code. All README link targets resolve.