### PR TITLE
aim-tracking-rotate: add fix action + auto-memory-index file-class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`aim-tracking-rotate` fix action** (`--fix <file>` / `--fix-all` / `--fix-memory-md` / `--include-memory-md`) — non-interactive cap remediation that brings an over-cap oversight tree to a `--check` PASS without losing any record. The algorithm is conformance-first (adds D2 front-matter from the template when absent), then cap-fixes by class (entry rotation for append-only logs and rotatable registers; archive-whole-verbatim for table-row registers (`blockers-log.md`, `risk-register.md`), non-rotatable registers (`task-tracker.md`), and multi-table live-indexes (`SESSION_WORK_INDEX.md`, `session-index/INDEX.md`); template front-matter refresh for heartbeats), then proves conservation (`lost == 0`) before returning. Every mutation path creates a timestamped backup first and writes atomically; no interactive confirmation is required.
+- **`auto-memory-index` file class** — fifth governed class for the Claude Code auto-memory `MEMORY.md`. Cap is 200 lines / 25 KB **whichever comes first** (load-window advisory). `--check` emits WARN (non-blocking) on cap or log-shape violations. `--fix-memory-md` triggers on **over-cap or log-shape** (log-shape: any entry > 2 non-blank lines or > 200 chars); a compliant MEMORY.md triggers no changes. When triggered, relocates over-long entries to hot sibling topic files (`feedback_*.md`, `project_*.md`, etc.) in the same `memory/` directory, leaving a one-line `- [Title](sibling.md) — hook` pointer; conservation is proved across the full union of `MEMORY.md` and all siblings. A `MEMORY.md` skeleton template (`templates/memory/MEMORY.md.template`) and detailed fix prose (`assets/memory_md_fix.md`, lazy-loaded) are shipped alongside.
+- **Conservation helper module** (`scripts/conservation.py`) — standalone, unit-testable module providing entry-ID manifest generation (`build_id_manifest`) and `assert_no_id_loss` for oversight classes, plus content-set generation (`build_content_set`) and `assert_no_content_loss` for the auto-memory-index class.
+
 ### Changed
+
+- **`aim-tracking-rotate` task-tracker cap** raised from 40 lines / 3 KB to **60 lines / 4.5 KB** (fits a full 10-line front-matter block plus a meaningful task body without false-positive cap failures).
+- **`aim-tracking-rotate` section-scaffold preservation** — both `--fix` and the session-close `--apply` now fence an unfenced `## Entry Format` example before rotating so the section scaffold (`## How to Use`, `## Entry Format`, `## Decisions`) survives and entries stay under `## Decisions`. `--fix` additionally adds any missing `## ` section headers from the template when the file lacks them.
 
 ### Fixed
 

--- a/_ai-memory/pov/skills/aim-tracking-rotate/SKILL.md
+++ b/_ai-memory/pov/skills/aim-tracking-rotate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aim-tracking-rotate
-description: Enforce oversight-file caps at session-close and rotate over-cap append-only-logs and registers into dated archive shards while preserving chronology and an O(1) by-id manifest. The rotate companion to aim-tracking-freshness.
+description: Enforce oversight-file caps at session-close, rotate over-cap append-only-logs and registers into dated archive shards, and fix over-cap files non-interactively (including MEMORY.md lossless relocation).
 allowed-tools: Bash
 ---
 
@@ -29,37 +29,54 @@ id-H3 append-only log it was verified against:
 | `session-index/INDEX.md` | ⛔ refused → TD-655 | `### [Month YYYY]` H3 sections + Current-Year and Archive tables (mixed) |
 
 For a ⛔ file, `--apply` makes **no changes** and exits non-zero with a manual
-remedy; rotate it by hand (move resolved/oldest rows into its archive
-table/shard). Field-aware safe auto-rotation for table-under-severity registers
-and multi-table live-indexes is deferred to **TD-655**. The refusal is enforced
-by rel-path (`MANUAL_ROTATION_FILES`), so a future cap-contract seed cannot
-re-enable an unsafe `--apply`.
+remedy; run `python $SCRIPT --fix {file} --oversight-root {oversight_path}`
+(archive-whole-verbatim + lean index rewrite) or trim by hand. Field-aware safe
+auto-rotation for table-under-severity registers and multi-table live-indexes is
+deferred to **TD-655**. The refusal is enforced by relative path (the fixed set:
+`blockers-log.md`, `risk-register.md`, `SESSION_WORK_INDEX.md`,
+`session-index/INDEX.md`), so a future cap-contract seed cannot re-enable an
+unsafe `--apply`.
 
 ---
 
 ## Usage
 
 ```bash
+SCRIPT=~/.ai-memory/_ai-memory/pov/skills/aim-tracking-rotate/scripts/tracking_rotate.py
+
 # Enforcement gate (session-close): exit non-zero if any governed file is over cap.
-python ~/.ai-memory/_ai-memory/pov/skills/aim-tracking-rotate/scripts/tracking_rotate.py \
-  --check \
-  --oversight-root /path/to/oversight
+python $SCRIPT --check --oversight-root /path/to/oversight
 
 # Rotate an over-cap file's oldest entries into a dated archive shard:
-python ~/.ai-memory/_ai-memory/pov/skills/aim-tracking-rotate/scripts/tracking_rotate.py \
-  --apply /path/to/oversight/tracking/decision-log.md \
-  --oversight-root /path/to/oversight
+python $SCRIPT --apply /path/to/oversight/tracking/decision-log.md \
+               --oversight-root /path/to/oversight
 
-# Oversight root can also come from the environment:
-AI_MEMORY_OVERSIGHT_ROOT=/path/to/oversight \
-  python ~/.ai-memory/_ai-memory/pov/skills/aim-tracking-rotate/scripts/tracking_rotate.py --check
+# Fix a single over-cap file (conformance + cap-fix + conservation proof):
+python $SCRIPT --fix /path/to/oversight/tracking/decision-log.md \
+               --oversight-root /path/to/oversight
+
+# Fix all governed oversight files (MEMORY.md excluded by default):
+python $SCRIPT --fix-all --oversight-root /path/to/oversight
+
+# Fix all governed files AND MEMORY.md:
+python $SCRIPT --fix-all --include-memory-md --oversight-root /path/to/oversight
+
+# Fix MEMORY.md only (lossless relocation to sibling topic files):
+python $SCRIPT --fix-memory-md
 ```
 
-Optional flags: `--entry-pattern '<regex>'` (entry-boundary line; resolution
-order is this flag → the file's contract `entry_pattern` → the built-in
-id-prefixed H3 default `^### [A-Z]{2,4}-`), `--keep <N>` (force the number of
-newest entries kept live), `--period YYYY-MM` (archive period override for
-deterministic runs).
+Optional flags (all modes): `--period YYYY-MM` (archive period override for
+deterministic runs). `--apply` additionally accepts `--entry-pattern '<regex>'`
+and `--keep <N>`. `--include-memory-md` (with `--fix-all` only): also fix the
+auto-memory `MEMORY.md`; skipped by default with a NOTICE. Oversight root can
+also come from `$AI_MEMORY_OVERSIGHT_ROOT`.
+
+**MEMORY.md fix details**: when you need the full step-by-step procedure for
+MEMORY.md relocation or collision resolution, read:
+
+```bash
+cat "$(dirname "$SCRIPT")/../assets/memory_md_fix.md"
+```
 
 ---
 
@@ -78,10 +95,37 @@ deterministic runs).
   verify counts. An archived entry whose id already exists in the shard with **identical** content is treated as a safe replay and skipped (so an interrupted `--apply` can be re-run idempotently); if the id matches with **different** content, `--apply` refuses — exiting non-zero with the colliding id(s), leaving the live file and shard untouched — so a body is never silently overwritten or dropped. Heartbeat / thin-register files (`rotation_trigger: none`) are
   check-only, and the table-under-severity registers / multi-table live-indexes
   are deferred to TD-655 (see the support table above) — `--apply` refuses both
-  non-destructively.
+  non-destructively. For `append-only-log` files, `--apply` also fences any
+  unfenced `## Entry Format` example before parsing, preventing scaffold-strip
+  (additive-only; no change to archived content).
+
+- **`--fix <file>` / `--fix-all`** — non-interactive fix: (1) add D2 front-matter
+  if missing (template-sourced), (2) cap-fix by class (`--apply` for
+  append-only-log / rotatable registers; archive-whole-verbatim + lean index
+  rewrite for table-row registers and multi-table live-indexes (`blockers-log.md`,
+  `risk-register.md`, `SESSION_WORK_INDEX.md`, `session-index/INDEX.md`); template
+  front-matter refresh for heartbeats), (3) prove conservation (`lost == 0`).
+  Always backup-first; emits a plan + conservation report. `--fix-all` iterates
+  over all governed oversight files; pass `--include-memory-md` to also fix
+  MEMORY.md (default: NOTICE + skip).
+
+- **`--fix-memory-md`** — lossless relocation for the Claude Code auto-memory
+  `MEMORY.md` (class `auto-memory-index`, cap 200 lines / 25 KB
+  whichever-comes-first). Triggers when MEMORY.md is over cap OR contains
+  log-shape violations (any entry > 2 non-blank lines or > 200 chars); a
+  compliant MEMORY.md triggers no changes. Moves over-long entries to sibling
+  topic files in the same `memory/` directory, leaves one-line
+  `- [Title](sibling.md) — hook` pointers. Proves conservation across the full union (`MEMORY.md ∪ memory/*.md`).
+  Does **not** use cold dated shards — sibling files stay hot and on-demand.
+  For the full procedure and collision resolution steps, read `assets/memory_md_fix.md`.
+
+- **`--check` MEMORY.md** — the cap check for `auto-memory-index` is a **WARN,
+  not a gate failure**. If MEMORY.md is over cap or has log-shape violations, the
+  check emits `WARN:` lines to stderr but still exits 0.
 
 Contract source of truth: `PARZIVAL-OVERSIGHT-SOT.md` §14 (caps) and BP-167
-Part C (rotation lifecycle). Caps are byte **and** line — either breach fails.
+Part C (rotation lifecycle). **Caps are byte and line — either breach triggers a
+violation** (the oversight classes; for `auto-memory-index` whichever-comes-first).
 
 ---
 

--- a/_ai-memory/pov/skills/aim-tracking-rotate/assets/memory_md_fix.md
+++ b/_ai-memory/pov/skills/aim-tracking-rotate/assets/memory_md_fix.md
@@ -1,0 +1,124 @@
+# MEMORY.md Fix Guide — Lossless Relocation
+
+Read this file only when a `--fix-memory-md` or a log-shape WARN for `MEMORY.md`
+requires hands-on resolution. The `--fix-memory-md` script action handles the
+common case automatically; this guide covers edge cases and the design rationale.
+
+---
+
+## What problem are we fixing
+
+Claude Code's auto-memory system loads `MEMORY.md` into context at session start.
+The load window is **200 lines OR 25 KB — whichever comes first**. Content past
+that boundary is silently truncated: the agent begins the session without the
+oldest remembered facts.
+
+The fix is structural, not lossy. Detail moves to sibling topic files
+(`feedback_*.md`, `project_*.md`, etc.) in the same `memory/` directory; a
+one-line pointer replaces each bulky entry in `MEMORY.md`. Siblings are
+loaded on demand, so no information is lost — it is just re-homed.
+
+---
+
+## When the script handles it automatically
+
+Run:
+
+```bash
+python ~/.ai-memory/_ai-memory/pov/skills/aim-tracking-rotate/scripts/tracking_rotate.py \
+  --fix-memory-md
+```
+
+The script:
+0. Checks if MEMORY.md is over cap OR has log-shape violations (entries > 2 non-blank
+   lines / > 200 chars). If neither condition holds, prints "already within cap — no
+   action needed" and exits.
+1. Reads `MEMORY.md` and all sibling `memory/*.md` files (conservation baseline).
+2. Backs up `MEMORY.md` to `MEMORY.md.<timestamp>.bak`.
+3. Parses the file into section blocks.
+4. For each block that is **over-length** (> 200 chars OR > 2 non-blank lines) and
+   NOT already a one-line pointer:
+   - Derives a deterministic sibling filename from the section header + entry text.
+   - Appends the block to the sibling (creating it if needed).
+   - Replaces the block in `MEMORY.md` with a `- [Title](sibling.md) — hook` pointer.
+5. Proves conservation: `union(after) ⊇ union(before)` — zero lines lost.
+
+---
+
+## Manual relocation procedure
+
+Use this when the automated fix hits a **sibling collision** (a slug conflict
+where the derived sibling name already exists with incompatible content).
+
+### Step 1 — Identify the over-long entries
+
+```bash
+wc -l ~/.claude/projects/<slug>/memory/MEMORY.md
+```
+
+Any entry body that is more than ~2 lines or ~200 characters is a candidate.
+
+### Step 2 — Choose a sibling filename
+
+| Section | Sibling convention |
+|---|---|
+| `## Feedback` | `feedback_<slug>.md` |
+| `## Active Project` / `## Build` | `project_<slug>.md` |
+| `## Next Steps` | `next_steps.md` |
+| Other | `<section-slug>_<entry-slug>.md` |
+
+Pick a name that is **unique to this entry's topic** and does not conflict with
+an existing sibling that covers a different topic.
+
+### Step 3 — Move the entry body
+
+Copy the full entry text verbatim to the sibling file. Do **not** summarise or
+lossy-compact it — the sibling is the live, searchable home of this detail.
+
+### Step 4 — Leave a pointer in MEMORY.md
+
+Replace the relocated body with exactly one line:
+
+```
+- [Short Title](sibling.md) — one-line hook describing the detail
+```
+
+The title and hook should give the agent enough context to know whether to read
+the sibling file for a given session topic.
+
+### Step 5 — Verify conservation
+
+```bash
+python ~/.ai-memory/_ai-memory/pov/skills/aim-tracking-rotate/scripts/tracking_rotate.py \
+  --check --oversight-root <path>
+```
+
+Pass `--oversight-root <path>` or set `$AI_MEMORY_OVERSIGHT_ROOT` first; without a
+configured oversight root the command errors before checking MEMORY.md.
+
+The MEMORY.md check is a WARN gate (non-blocking). After a successful fix, it
+should print no WARN lines for MEMORY.md.
+
+---
+
+## Collision resolution
+
+A **sibling collision** means a target filename already exists with content that
+does not match the entry being relocated. Options:
+
+1. **Different topic, same slug** — rename the sibling (`feedback_task_notes.md`
+   vs `feedback_task_tracker.md`). Re-run the script.
+2. **Same topic, stale sibling content** — the entry was previously relocated and
+   the sibling was manually edited. Merge the two bodies by hand, then re-run.
+3. **Duplicate entry in MEMORY.md** — the entry body appears twice. Remove the
+   duplicate, then re-run.
+
+---
+
+## Index-not-log constraint
+
+`MEMORY.md` is an **index**, not a session log. Each entry should be at most a
+one-line pointer or a two-line summary. If you find yourself writing three or
+more lines of session notes directly in `MEMORY.md`, write them in a sibling
+file instead and leave only a pointer. This keeps the load window useful for the
+breadth of all remembered topics, not monopolised by the depth of one session.

--- a/_ai-memory/pov/skills/aim-tracking-rotate/scripts/conservation.py
+++ b/_ai-memory/pov/skills/aim-tracking-rotate/scripts/conservation.py
@@ -1,0 +1,112 @@
+"""
+conservation.py — Conservation helpers for aim-tracking-rotate.
+
+Entry-ID mode (oversight classes):
+    build_id_manifest() collects entry-ID tokens across a set of files.
+    assert_no_id_loss() asserts every ID present before is present after,
+    with equal or greater count (multiset/count-based).
+
+Content-union mode (auto-memory-index class):
+    build_content_set() collects all non-empty stripped lines across files
+    as a Counter (multiset) so duplicate-line losses are detectable.
+    assert_no_content_loss() asserts every content line occurrence before
+    is present after.
+
+Both sets of functions are importable with no side effects on import.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from collections.abc import Iterable
+from pathlib import Path
+
+# Entry-ID token pattern: 2-4 uppercase letters, a dash, then alphanumeric+dash
+# (e.g. DEC-PM001-D1, BLK-042, RISK-003, TASK-076, TD-655).
+ENTRY_ID_RE = re.compile(r"\b([A-Z]{2,4}-[A-Za-z0-9][A-Za-z0-9-]*)\b")
+
+
+def build_id_manifest(
+    paths: Iterable[Path],
+    pattern: re.Pattern[str] = ENTRY_ID_RE,
+    *,
+    raise_on_error: bool = False,
+) -> Counter[str]:
+    """Return a Counter of entry-ID tokens found across all readable paths.
+
+    With ``raise_on_error=False`` (default), paths that do not exist or cannot
+    be decoded are silently skipped so callers can safely include not-yet-created
+    archive shards.  Use ``raise_on_error=True`` for BEFORE-baseline reads where
+    an unreadable source must never produce a silent false-pass.
+    """
+    counts: Counter[str] = Counter()
+    for p in paths:
+        try:
+            if p.is_file():
+                counts.update(pattern.findall(p.read_text(encoding="utf-8")))
+        except OSError:
+            if raise_on_error:
+                raise
+    return counts
+
+
+def assert_no_id_loss(before: Counter[str], after: Counter[str]) -> None:
+    """Assert that no ID count decreased from before to after (multiset check).
+
+    An ID is 'lost' when its after-count is less than its before-count.
+    Raises AssertionError listing up to ten lost IDs so the caller can
+    surface them in the conservation report.
+    """
+    lost = sorted(eid for eid, cnt in before.items() if after.get(eid, 0) < cnt)
+    if lost:
+        sample = ", ".join(lost[:10])
+        raise AssertionError(
+            f"Conservation FAILED — {len(lost)} entry ID(s) lost. " f"Sample: {sample}"
+        )
+
+
+def build_content_set(
+    paths: Iterable[Path],
+    *,
+    raise_on_error: bool = False,
+) -> Counter[str]:
+    """Return a Counter of all non-empty stripped lines across all readable paths.
+
+    Used for the auto-memory-index class where conservation is proven by hashing
+    the union of MEMORY.md and all sibling memory/*.md files.  A relocation moves
+    text from MEMORY.md to a sibling without deleting it, so every line present
+    before the fix is still present in the union after.
+
+    The Counter (multiset) representation catches duplicate-line losses that a
+    frozenset would miss.  With ``raise_on_error=True``, unreadable paths raise
+    instead of being silently skipped (use for BEFORE-baseline reads).
+    """
+    counts: Counter[str] = Counter()
+    for p in paths:
+        try:
+            if p.is_file():
+                for line in p.read_text(encoding="utf-8").splitlines():
+                    stripped = line.strip()
+                    if stripped:
+                        counts[stripped] += 1
+        except OSError:
+            if raise_on_error:
+                raise
+    return counts
+
+
+def assert_no_content_loss(before: Counter[str], after: Counter[str]) -> None:
+    """Assert that every content line occurrence present before is still present after.
+
+    Uses Counter subtraction so a line present N times before must appear at
+    least N times after; losing one of two identical lines raises.
+    Raises AssertionError with a count of lost occurrences and a short sample.
+    """
+    lost = before - after  # Counter subtraction: items where before[k] > after[k]
+    if lost:
+        sample = sorted(lost.keys())[:5]
+        raise AssertionError(
+            f"Content conservation FAILED — {sum(lost.values())} content line(s) lost. "
+            f"Sample: {sample!r}"
+        )

--- a/_ai-memory/pov/skills/aim-tracking-rotate/scripts/tracking_rotate.py
+++ b/_ai-memory/pov/skills/aim-tracking-rotate/scripts/tracking_rotate.py
@@ -40,6 +40,7 @@ per-seed values) and BP-167 Part C (rotation lifecycle).
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import os
 import re
 import sys
@@ -47,6 +48,19 @@ from collections import Counter
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
+
+
+def _load_conservation():
+    """Return the sibling conservation module (cached after first load)."""
+    cached = getattr(_load_conservation, "_cache", None)
+    if cached is None:
+        p = Path(__file__).with_name("conservation.py")
+        spec = importlib.util.spec_from_file_location("_aim_conservation", p)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        _load_conservation._cache = mod
+    return _load_conservation._cache
+
 
 # ---------------------------------------------------------------------------
 # Governed-file contract registry (fallback when front-matter is absent)
@@ -86,7 +100,7 @@ FALLBACK_REGISTRY: dict[str, Contract] = {
         archive_target="session-index/INDEX.md",
         entry_pattern=r"^\| ",
     ),
-    "tracking/task-tracker.md": Contract(40, 3, "register", False),
+    "tracking/task-tracker.md": Contract(60, 4.5, "register", False),
     "tracking/blockers-log.md": Contract(
         100,
         15,
@@ -160,6 +174,13 @@ MANUAL_ROTATION_FILES: frozenset[str] = frozenset(
 # (handoff archival is owned by close step-03).
 HANDOFF_CONTRACT = Contract(60, 8, "detail-record", False)
 HANDOFF_GLOB = "session-logs/SESSION_HANDOFF_*.md"
+
+# auto-memory-index class: Claude Code auto-memory MEMORY.md.
+# Cap = whichever-comes-first (line OR byte). Soft target ~ 180 lines so the
+# agent has a visible runway before hitting the 200-line load window.
+AUTO_MEMORY_CONTRACT = Contract(200, 25.0, "auto-memory-index", False)
+_MEMORY_LOG_SHAPE_MAX_LINES = 2  # non-blank lines per entry in an index
+_MEMORY_LOG_SHAPE_MAX_CHARS = 200  # total chars per entry in an index
 
 # Default entry boundary: an id-prefixed markdown H3 heading (DEC-/BUG-/BLK-/
 # RISK-/TD-…). Requiring an id prefix (2-4 uppercase letters + '-') avoids
@@ -411,6 +432,15 @@ def run_check(oversight_root: Path) -> int:
             )
         )
 
+    # auto-memory-index: WARN only — never blocks the gate; surface even when
+    # oversight files are over cap so both issues land in one check run.
+    memory_md = resolve_memory_md()
+    memory_warns: list[str] = []
+    if memory_md:
+        memory_warns = list(_check_memory_md(memory_md))
+    for warn in memory_warns:
+        print(f"  WARN: {warn}", file=sys.stderr)
+
     if breaches:
         print(
             "aim-tracking-rotate --check: FAIL — "
@@ -543,6 +573,8 @@ def select_kept_moved(
     """
     entries = parsed.entries
     n = len(entries)
+    # pointer_line is included in fixed so each candidate/live size probe matches
+    # what _render_live produces: front_matter + preamble + pointer + entries.
     fixed = parsed.front_matter + parsed.preamble + pointer_line
 
     if contract.klass == "register":
@@ -632,21 +664,18 @@ def _normalize_eol(text: str) -> str:
     return text.replace("\r\n", "\n").replace("\r", "\n")
 
 
-def append_to_shard(
-    shard: Path, moved: list[Entry], source_rel: str, entry_pattern: str
-) -> int:
-    """Append moved entries to the shard idempotently. Returns rows appended.
+def _compute_shard_append(
+    shard: Path,
+    moved: list[Entry],
+    source_rel: str,
+    entry_pattern: str,
+) -> tuple[str, int]:
+    """Compute the new shard text and count WITHOUT writing to disk.
 
-    Re-running --apply after an interruption must not double-append: an entry
-    whose id AND body already match an archived entry is a safe replay and is
-    skipped (mirrors the manifest dedup). But an entry whose id matches an
-    existing shard entry with a DIFFERENT body is a collision, not a replay —
-    silently skipping it would drop the live entry's content (the post-write
-    id-count check cannot catch this: the id stays conserved while its body is
-    lost). Such collisions raise ShardCollisionError so the caller aborts before
-    the live file is rewritten. Writes atomically.
+    Idempotent: same-id/same-body entries in the existing shard are skipped.
+    Raises ShardCollisionError on same-id/different-body.
+    Returns ``(new_shard_text, appended_count)``.
     """
-    shard.parent.mkdir(parents=True, exist_ok=True)
     moved_new = moved
     if shard.is_file():
         existing_text = shard.read_text(encoding="utf-8")
@@ -671,10 +700,9 @@ def append_to_shard(
             # exc.ids / the printed [:10] / the message must list it once.
             raise ShardCollisionError(shard, list(dict.fromkeys(collisions)))
         if not moved_new:
-            return 0
+            return existing_text, 0
         sep = "" if existing_text.endswith("\n") else "\n"
-        atomic_write(shard, existing_text + sep + "".join(e.block for e in moved_new))
-        return len(moved_new)
+        return existing_text + sep + "".join(e.block for e in moved_new), len(moved_new)
 
     header = (
         f"# Archive — rotated from `{source_rel}`\n\n"
@@ -682,8 +710,28 @@ def append_to_shard(
         "and never re-sorted: order is monotonic *within* a shard, but across "
         "shards/rotations it is not guaranteed (BP-167 Part C).\n\n"
     )
-    atomic_write(shard, header + "".join(e.block for e in moved_new))
-    return len(moved_new)
+    return header + "".join(e.block for e in moved_new), len(moved_new)
+
+
+def append_to_shard(
+    shard: Path, moved: list[Entry], source_rel: str, entry_pattern: str
+) -> int:
+    """Append moved entries to the shard idempotently. Returns rows appended.
+
+    Re-running --apply after an interruption must not double-append: an entry
+    whose id AND body already match an archived entry is a safe replay and is
+    skipped (mirrors the manifest dedup). But an entry whose id matches an
+    existing shard entry with a DIFFERENT body is a collision, not a replay —
+    silently skipping it would drop the live entry's content (the post-write
+    id-count check cannot catch this: the id stays conserved while its body is
+    lost). Such collisions raise ShardCollisionError so the caller aborts before
+    the live file is rewritten. Writes atomically.
+    """
+    new_text, appended = _compute_shard_append(shard, moved, source_rel, entry_pattern)
+    if appended > 0 or not shard.is_file():
+        shard.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write(shard, new_text)
+    return appended
 
 
 def update_manifest(manifest: Path, moved: list[Entry], shard_rel: str) -> int:
@@ -801,6 +849,9 @@ def run_apply(
 
     eff_pattern = effective_entry_pattern(contract, entry_pattern)
     text = file_path.read_text(encoding="utf-8")
+    # Fence an unfenced entry-format example BEFORE parsing to prevent scaffold
+    # strip: an unfenced ### DEC-[ID] example would be mis-parsed as Entry 0.
+    text, _apply_fenced = _fence_for_apply(text, rel)
     before_lines, before_bytes = measure(text)
     parsed = parse_entries(text, eff_pattern)
     if not parsed.entries:
@@ -834,11 +885,13 @@ def run_apply(
         )
         return 0
 
-    # 1. Archive shard (idempotent + atomic). A same-id/different-body clash is
-    #    refused here, BEFORE the live rewrite, so nothing is dropped.
+    # 0. Backup before any mutation.
+    _backup_file(file_path, now)
+
+    # 1. Compute shard text in memory (prove-before-write: shard not written yet).
     shard = oversight_root / shard_rel
     try:
-        appended = append_to_shard(shard, moved, rel, eff_pattern)
+        new_shard_text, appended = _compute_shard_append(shard, moved, rel, eff_pattern)
     except ShardCollisionError as exc:
         print(
             f"ERROR: shard collision in {shard_rel} — an entry being archived "
@@ -865,25 +918,18 @@ def run_apply(
         open_kept = sum(1 for e in kept if not is_resolved(e))
         new_preamble, banner_updated = update_banner(parsed, open_kept)
 
-    # 3. Rewrite live file atomically = front-matter + preamble + pointer + kept.
+    # 3. Compute new live text and prove conservation using in-memory shard text
+    #    (shard not yet written — abort leaves live file and shard both intact).
     new_text = _render_live(parsed.front_matter, new_preamble, pointer_line, kept)
-    atomic_write(file_path, new_text)
     after_lines, after_bytes = measure(new_text)
 
-    # 4. REAL post-write check: re-read live + shard and assert per-id count
-    #    conservation for every pre-write id (no entry lost, none duplicated /
-    #    double-appended). Replaces the old tautological slice/startswith asserts.
-    live_ids = [
-        entry_key(e)
-        for e in parse_entries(
-            file_path.read_text(encoding="utf-8"), eff_pattern
-        ).entries
+    computed_live_ids = Counter(
+        entry_key(e) for e in parse_entries(new_text, eff_pattern).entries
+    )
+    shard_parse_ids = [
+        entry_key(e) for e in parse_entries(new_shard_text, eff_pattern).entries
     ]
-    shard_ids = [
-        entry_key(e)
-        for e in parse_entries(shard.read_text(encoding="utf-8"), eff_pattern).entries
-    ]
-    after_counter = Counter(live_ids) + Counter(shard_ids)
+    after_counter = computed_live_ids + Counter(shard_parse_ids)
     violations = [
         (eid, cnt, after_counter.get(eid, 0))
         for eid, cnt in pre_ids.items()
@@ -891,7 +937,7 @@ def run_apply(
     ]
     if violations:
         print(
-            "ERROR: id-conservation check FAILED after rotation "
+            "ERROR: id-conservation check FAILED — aborting before live rewrite "
             f"({rel}) — an entry was lost or duplicated:",
             file=sys.stderr,
         )
@@ -900,7 +946,17 @@ def run_apply(
                 f"    {eid}: was {was} pre-write, now {now_count} live+shard",
                 file=sys.stderr,
             )
+        print(
+            "  Live file and shard are both unchanged.",
+            file=sys.stderr,
+        )
         return 1
+
+    # 4. Conservation proved — commit shard then live atomically.
+    if appended > 0:
+        shard.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write(shard, new_shard_text)
+    atomic_write(file_path, new_text)
 
     print(
         "\n".join(
@@ -912,7 +968,8 @@ def run_apply(
                 (
                     f"  manifest: {manifest_rows} row(s) → {contract.index_file}"
                     if contract.index_file
-                    else f"  banner:   {'updated' if banner_updated else 'none present'}"
+                    else "  banner:   "
+                    + ("updated" if banner_updated else "none present")
                 ),
                 "  pointer:  written",
                 f"  live now: {after_lines} lines / {after_bytes / 1024:.1f} KB "
@@ -942,6 +999,666 @@ def run_apply(
 
 
 # ---------------------------------------------------------------------------
+# --fix : conformance-first cap-fix with conservation proof
+# ---------------------------------------------------------------------------
+
+
+class SiblingCollisionError(Exception):
+    """A MEMORY.md entry's target sibling slug already holds a different body.
+
+    Raised when the sibling file exists but does not contain this exact block.
+    This mirrors ShardCollisionError: same identity, conflicting content —
+    BP-038 "do not silently merge." The caller must abort without mutation.
+    Normal cases: block absent (sibling does not exist) → create; block already
+    present (identical) → skip (idempotent); sibling exists + different body → raise.
+    """
+
+    def __init__(self, sibling: Path, preview: str) -> None:
+        self.sibling = sibling
+        super().__init__(
+            f"Sibling {sibling.name} already exists with different content "
+            f"for entry: {preview!r}"
+        )
+
+
+def _backup_file(path: Path, now: datetime) -> None:
+    """Write a timestamped .bak copy of path before any mutation."""
+    bak = path.with_name(f"{path.name}.{now.strftime('%Y%m%d%H%M%S')}.bak")
+    bak.write_bytes(path.read_bytes())
+
+
+def _resolve_template_dir() -> Path:
+    """Resolve the oversight template directory.
+
+    Prefers AI_MEMORY_INSTALL_DIR env var when its templates/ subtree exists;
+    otherwise derives from this script's location (six directory levels up
+    lands at the install root).  The existence check lets test environments
+    that set AI_MEMORY_INSTALL_DIR to a dummy path fall back safely.
+    """
+    install_dir = os.environ.get("AI_MEMORY_INSTALL_DIR")
+    if install_dir:
+        p = Path(install_dir).expanduser() / "templates" / "oversight"
+        if p.is_dir():
+            return p
+    # Fallback: script-relative (also covers test envs with a dummy install dir).
+    # scripts/ -> aim-tracking-rotate/ -> skills/ -> pov/ -> _ai-memory/ -> root/
+    return Path(__file__).resolve().parents[5] / "templates" / "oversight"
+
+
+def _read_template_fm(rel: str) -> str:
+    """Read the front-matter block from the template for rel, or empty string."""
+    tpl = _resolve_template_dir() / rel
+    if not tpl.is_file():
+        return ""
+    fm, _ = split_front_matter(tpl.read_text(encoding="utf-8"))
+    return fm
+
+
+def _contract_for_text(text: str, rel: str) -> Contract | None:
+    """Resolve contract from in-memory text without reading the file from disk."""
+    fm, _ = split_front_matter(text)
+    c = parse_contract_front_matter(fm)
+    if c is not None:
+        return c
+    return FALLBACK_REGISTRY.get(rel)
+
+
+def _fence_entry_format_section(text: str, tpl_body: str) -> tuple[str, bool]:
+    """Replace an unfenced ## Entry Format example with the template's fenced one."""
+    ef_pat = re.compile(
+        r"^(## Entry Format\n)(.*?)(?=^## |\Z)", re.MULTILINE | re.DOTALL
+    )
+    ef_m = ef_pat.search(text)
+    if not ef_m:
+        return text, False
+    ef_body = ef_m.group(2)
+    # Already fenced → nothing to do.
+    if re.search(r"^```", ef_body, re.MULTILINE):
+        return text, False
+    # Only repair if there's an unfenced ### DEC-style example.
+    if not re.search(r"^### [A-Z]{2,4}-", ef_body, re.MULTILINE):
+        return text, False
+    tpl_ef_m = ef_pat.search(tpl_body)
+    if not tpl_ef_m:
+        return text, False
+    new_text = text[: ef_m.start()] + tpl_ef_m.group(0) + text[ef_m.end() :]
+    return new_text, True
+
+
+def _repair_sections(text: str, tpl_body: str) -> tuple[str, list[str]]:
+    """Ensure all template ## sections present; fence entry-format example."""
+    repairs: list[str] = []
+
+    tpl_headers = re.findall(r"^## .+$", tpl_body, re.MULTILINE)
+    for hdr in tpl_headers:
+        if re.search(re.escape(hdr), text, re.MULTILINE):
+            continue
+        sec_pat = re.compile(
+            re.escape(hdr) + r"\n(.*?)(?=^## |\Z)", re.MULTILINE | re.DOTALL
+        )
+        m = sec_pat.search(tpl_body)
+        if m:
+            if not text.endswith("\n"):
+                text += "\n"
+            text += "\n" + m.group(0)
+            repairs.append(f"added missing section '{hdr}'")
+
+    text, fenced = _fence_entry_format_section(text, tpl_body)
+    if fenced:
+        repairs.append("fenced entry-format example in '## Entry Format'")
+
+    return text, repairs
+
+
+def _ensure_conformance(
+    file_path: Path,
+    rel: str,
+    text: str,
+) -> tuple[str, str]:
+    """Ensure D2 front-matter, required ## sections, and fenced entry-format example.
+
+    Returns ``(new_text, message_or_empty)``.
+    """
+    repairs: list[str] = []
+
+    # Step 1: Add D2 front-matter if absent.
+    fm, _ = split_front_matter(text)
+    if not fm:
+        tpl_fm = _read_template_fm(rel)
+        if tpl_fm:
+            text = tpl_fm + text
+            repairs.append("added D2 front-matter")
+
+    # Step 2: For append-only-log class, ensure required sections + fenced example.
+    # Resolve from in-memory text (front-matter may have just been added above).
+    contract = _contract_for_text(text, rel)
+    if contract is not None and contract.klass == "append-only-log":
+        tpl_path = _resolve_template_dir() / rel
+        if tpl_path.is_file():
+            _, tpl_body = split_front_matter(tpl_path.read_text(encoding="utf-8"))
+            text, sec_msgs = _repair_sections(text, tpl_body)
+            repairs.extend(sec_msgs)
+
+    return text, "; ".join(repairs) if repairs else ""
+
+
+def _fence_for_apply(text: str, rel: str) -> tuple[str, bool]:
+    """Fence an unfenced entry-format example before parsing in run_apply.
+
+    Only applied to append-only-log class files with a matching template.
+    The fence replaces the unfenced example with the template's fenced version
+    so the entry-boundary pattern ignores it during parsing.
+    Returns ``(possibly_modified_text, was_fenced)``.
+    """
+    contract = _contract_for_text(text, rel)
+    if contract is None or contract.klass != "append-only-log":
+        return text, False
+    tpl_path = _resolve_template_dir() / rel
+    if not tpl_path.is_file():
+        return text, False
+    _, tpl_body = split_front_matter(tpl_path.read_text(encoding="utf-8"))
+    return _fence_entry_format_section(text, tpl_body)
+
+
+def _archive_whole_and_rewrite_lean(
+    file_path: Path,
+    rel: str,
+    oversight_root: Path,
+    now: datetime,
+) -> tuple[Path, str]:
+    """Archive the whole file verbatim to a timestamped shard.
+
+    Rewrites the live file as a minimal index + pointer. Returns
+    ``(shard_path, shard_rel)``.
+    """
+    stem = Path(rel).stem
+    parent_rel = str(Path(rel).parent.as_posix())
+    shard_rel = (
+        f"{parent_rel}/archive/{stem}-ARCHIVE-{now.strftime('%Y-%m-%d_%H%M%S')}.md"
+    )
+    shard = oversight_root / shard_rel
+
+    text = file_path.read_text(encoding="utf-8")
+    atomic_write(shard, text)
+
+    # Lean live: template front-matter + extracted title + pointer
+    tpl_fm = _read_template_fm(rel)
+    title_match = re.search(r"^#+ (.+)$", text, re.MULTILINE)
+    title = (
+        title_match.group(1).strip() if title_match else stem.replace("-", " ").title()
+    )
+    pointer_ln = f"\n> All prior records archived → `{shard_rel}`. {POINTER_MARKER}\n"
+    atomic_write(file_path, tpl_fm + f"# {title}\n" + pointer_ln)
+
+    return shard, shard_rel
+
+
+def run_fix(
+    file_path: Path,
+    oversight_root: Path,
+    now: datetime,
+) -> int:
+    """Fix one oversight file: conformance → cap-fix by class → conservation proof."""
+    if not file_path.is_file():
+        print(f"ERROR: file not found: {file_path}", file=sys.stderr)
+        return 1
+
+    rel = (
+        file_path.resolve().relative_to(oversight_root.resolve()).as_posix()
+        if file_path.resolve().is_relative_to(oversight_root.resolve())
+        else file_path.name
+    )
+
+    if rel in FRESHNESS_OWNED:
+        print(f"SKIPPED: {rel} is owned by aim-tracking-freshness.", file=sys.stderr)
+        return 0
+
+    resolved = resolve_contract(file_path, rel)
+    if resolved is None:
+        print(
+            f"ERROR: {rel} is not a governed file (no contract).",
+            file=sys.stderr,
+        )
+        return 1
+    contract, _ = resolved
+
+    if contract.klass == "detail-record":
+        print(
+            f"SKIPPED: {rel} is class 'detail-record' — rotation owned by "
+            "session-close step-03.",
+            file=sys.stderr,
+        )
+        return 0
+
+    text = file_path.read_text(encoding="utf-8")
+    lines, nbytes = measure(text)
+    print(
+        f"aim-tracking-rotate --fix: {rel}\n"
+        f"  before: {lines} lines / {nbytes / 1024:.1f} KB "
+        f"(cap {contract.cap_lines} / {contract.cap_kb})"
+    )
+
+    if not over_cap(lines, nbytes, contract):
+        print("  already within cap — no action needed.")
+        return 0
+
+    # Pre-check: refuse early for append-only-log with rotation_trigger: none
+    # to avoid mutating (conformance fence) before a guaranteed error in run_apply.
+    if contract.klass == "append-only-log" and not contract.rotatable:
+        print(
+            f"  ERROR: {rel} is an append-only-log with rotation_trigger: none — "
+            "cannot auto-fix. Trim by hand.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Conservation baseline — captured before any write; fail loudly if unreadable.
+    conservation = _load_conservation()
+    before_ids = conservation.build_id_manifest(
+        [file_path], conservation.ENTRY_ID_RE, raise_on_error=True
+    )
+
+    _backup_file(file_path, now)
+
+    # Step 2a: add D2 front-matter if missing.
+    text, conf_msg = _ensure_conformance(file_path, rel, text)
+    if conf_msg:
+        atomic_write(file_path, text)
+        print(f"  conformance: {conf_msg}")
+        resolved = resolve_contract(file_path, rel)
+        if resolved is not None:
+            contract, _ = resolved
+
+    # Step 2b: cap-fix by class.
+    archive_path: Path | None = None
+    if contract.klass == "append-only-log" or (
+        contract.klass == "register"
+        and rel not in MANUAL_ROTATION_FILES
+        and contract.rotatable
+    ):
+        rc = run_apply(file_path, oversight_root, None, None, now)
+        if rc != 0:
+            return rc
+        if contract.archive_target:
+            archive_path = oversight_root / render_period(contract.archive_target, now)
+    elif (
+        rel in MANUAL_ROTATION_FILES
+        or contract.klass == "live-index"
+        or (contract.klass == "register" and not contract.rotatable)
+    ):
+        _, shard_rel = _archive_whole_and_rewrite_lean(
+            file_path, rel, oversight_root, now
+        )
+        archive_path = oversight_root / shard_rel
+        print(f"  archived whole → {shard_rel}")
+    elif contract.klass == "heartbeat":
+        tpl_fm = _read_template_fm(rel)
+        if tpl_fm:
+            _, body = split_front_matter(text)
+            new_hb_text = tpl_fm + body
+            atomic_write(file_path, new_hb_text)
+            print("  heartbeat: refreshed front-matter from template")
+            hl, hb = measure(new_hb_text)
+            if over_cap(hl, hb, contract):
+                print(
+                    f"  ERROR: heartbeat body still over cap "
+                    f"({hl}L / {hb / 1024:.1f}KB, cap "
+                    f"{contract.cap_lines} / {contract.cap_kb}KB). "
+                    "Trim the body by hand.",
+                    file=sys.stderr,
+                )
+                return 1
+        else:
+            print(
+                f"  heartbeat: no template for {rel} — trim by hand.",
+                file=sys.stderr,
+            )
+            return 1
+    else:
+        print(
+            f"  class '{contract.klass}': no automatic fix — trim by hand.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Step 2c: conservation proof.
+    check_paths = [file_path]
+    if archive_path and archive_path.is_file():
+        check_paths.append(archive_path)
+    after_ids = conservation.build_id_manifest(check_paths, conservation.ENTRY_ID_RE)
+    try:
+        conservation.assert_no_id_loss(before_ids, after_ids)
+    except AssertionError as exc:
+        print(f"ERROR: conservation FAILED: {exc}", file=sys.stderr)
+        return 1
+
+    new_text = file_path.read_text(encoding="utf-8")
+    new_lines, new_bytes = measure(new_text)
+    n_before = sum(before_ids.values())
+    n_after = sum(after_ids.values())
+    print(
+        f"  after:        {new_lines} lines / {new_bytes / 1024:.1f} KB\n"
+        f"  conservation: {n_before} ID tokens before → {n_after} after, 0 lost ✓"
+    )
+    if over_cap(new_lines, new_bytes, contract):
+        print(
+            "  WARNING: still over cap — run again or trim by hand.",
+            file=sys.stderr,
+        )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# auto-memory-index class: MEMORY.md lossless relocation
+# ---------------------------------------------------------------------------
+
+# One-line pointer format recognised by MEMORY.md index: - [Title](file.md) — hook
+_POINTER_LINE_RE = re.compile(
+    r"^\s*[-*]\s+\[[^\]]+\]\([^)]+\)\s*[—–-]\s*.+$"  # noqa: RUF001
+)
+
+
+def _is_memory_pointer(line: str) -> bool:
+    return bool(_POINTER_LINE_RE.match(line.strip()))
+
+
+def _has_log_shape_violation(text: str) -> bool:
+    """True if ``text`` contains at least one block that needs relocation."""
+    for block in _split_into_blocks(text):
+        if _entry_needs_relocation(block):
+            return True
+    return False
+
+
+def _entry_needs_relocation(block: str) -> bool:
+    """True if a content block should be relocated to a sibling file.
+
+    A list of pointer-format lines (``- [Title](file.md) — hook``) is the
+    conformant index format and is never marked for relocation, regardless
+    of how many pointer lines appear in one block.
+    """
+    stripped = block.strip()
+    if not stripped:
+        return False
+    non_blank = [ln for ln in stripped.splitlines() if ln.strip()]
+    # All lines are already pointers → conformant; no relocation.
+    if all(_is_memory_pointer(ln) for ln in non_blank):
+        return False
+    return (
+        len(stripped) > _MEMORY_LOG_SHAPE_MAX_CHARS
+        or len(non_blank) > _MEMORY_LOG_SHAPE_MAX_LINES
+    )
+
+
+def _slugify(text: str) -> str:
+    """Derive a lowercase filesystem-safe slug from text."""
+    clean = re.sub(r"[*_`\[\]()#>~|]", " ", text)
+    clean = re.sub(r"\s+", "_", clean.strip().lower())
+    clean = re.sub(r"[^a-z0-9_]", "", clean)
+    return clean[:40].strip("_") or "entry"
+
+
+def _sibling_name_for(section_header: str, entry_text: str) -> str:
+    """Derive a deterministic sibling filename from section context + entry text."""
+    section = section_header.lstrip("#").strip().lower()
+    first_line = next((ln.strip() for ln in entry_text.splitlines() if ln.strip()), "")
+    slug = _slugify(first_line[:80])
+
+    if "feedback" in section:
+        return f"feedback_{slug}.md"
+    if any(w in section for w in ("project", "active", "task", "sprint", "build")):
+        return f"project_{slug}.md"
+    if "next" in section or "step" in section:
+        return "next_steps.md"
+    section_slug = _slugify(section[:25])
+    return f"{section_slug}_{slug}.md"
+
+
+def _make_pointer(entry_text: str, sibling_name: str) -> str:
+    """Build a one-line ``- [Title](sibling.md) — hook`` pointer."""
+    lines = [ln.strip() for ln in entry_text.splitlines() if ln.strip()]
+    first_line = lines[0] if lines else "Detail"
+    title = re.sub(r"[*_`]", "", first_line)[:60].strip()
+    hook_src = lines[1] if len(lines) > 1 else first_line
+    hook = re.sub(r"[*_`]", "", hook_src)[:80].strip()
+    return f"- [{title}]({sibling_name}) — {hook}\n"
+
+
+def _parse_memory_sections(text: str) -> list[tuple[str, str]]:
+    """Split MEMORY.md into ``(section_header, section_body)`` pairs.
+
+    Content before the first ``##`` header uses ``""`` as the header key.
+    """
+    sections: list[tuple[str, str]] = []
+    current_header = ""
+    current_lines: list[str] = []
+
+    for line in text.splitlines(keepends=True):
+        if line.startswith("## "):
+            sections.append((current_header, "".join(current_lines)))
+            current_header = line.rstrip("\n")
+            current_lines = []
+        else:
+            current_lines.append(line)
+
+    sections.append((current_header, "".join(current_lines)))
+    return sections
+
+
+def _split_into_blocks(content: str) -> list[str]:
+    """Split section content into paragraph blocks, preserving blank-line tokens."""
+    result: list[str] = []
+    current: list[str] = []
+    for line in content.splitlines(keepends=True):
+        if line.strip():
+            current.append(line)
+        else:
+            if current:
+                result.append("".join(current))
+                current = []
+            result.append(line)
+    if current:
+        result.append("".join(current))
+    return result
+
+
+def _block_in_file(block_norm: str, file_text: str) -> bool:
+    """True iff block_norm exactly matches one of the paragraph blocks in file_text."""
+    for existing in _split_into_blocks(file_text):
+        if _normalize_eol(existing).strip() == block_norm:
+            return True
+    return False
+
+
+def _fix_section(
+    section_content: str,
+    section_header: str,
+    memory_dir: Path,
+    pending_writes: dict[Path, str],
+) -> tuple[str, bool]:
+    """Relocate over-long entries in one section to sibling files.
+
+    Appends to an existing sibling if the block is not already there
+    (idempotent on re-run: already-present blocks are not duplicated).
+    Writes are staged in ``pending_writes``; the caller commits them once
+    the full pass succeeds.
+    Returns ``(new_content, was_changed)``.
+    """
+    blocks = _split_into_blocks(section_content)
+    new_blocks: list[str] = []
+    changed = False
+
+    for block in blocks:
+        if not block.strip():
+            new_blocks.append(block)
+            continue
+        if not _entry_needs_relocation(block):
+            new_blocks.append(block)
+            continue
+
+        sibling_name = _sibling_name_for(section_header, block)
+        sibling_path = memory_dir / sibling_name
+        block_norm = _normalize_eol(block).strip()
+
+        # Resolve current sibling content: prefer staged (not-yet-written) over disk.
+        if sibling_path in pending_writes:
+            current = pending_writes[sibling_path]
+        elif sibling_path.is_file():
+            current = sibling_path.read_text(encoding="utf-8")
+        else:
+            current = ""
+
+        if current and _block_in_file(block_norm, current):
+            # Already present — idempotent replay, just write the pointer.
+            pass
+        elif current:
+            # Sibling exists but holds a different body — refuse (BP-038).
+            raise SiblingCollisionError(sibling_path, block[:60])
+        else:
+            # New sibling.
+            pending_writes[sibling_path] = block
+
+        new_blocks.append(_make_pointer(block, sibling_name))
+        changed = True
+
+    return "".join(new_blocks), changed
+
+
+def _reassemble_memory(sections: list[tuple[str, str]]) -> str:
+    """Reassemble section pairs back into a MEMORY.md text."""
+    parts: list[str] = []
+    for header, body in sections:
+        if header:
+            parts.append(header + "\n")
+        parts.append(body)
+    return "".join(parts)
+
+
+def run_fix_memory_md(memory_md: Path, now: datetime) -> int:
+    """Fix MEMORY.md: relocate over-long entries to sibling files."""
+    memory_dir = memory_md.parent
+    conservation = _load_conservation()
+
+    # Conservation baseline — BEFORE reads; fail loudly if unreadable.
+    before_set = conservation.build_content_set(
+        list(memory_dir.glob("*.md")), raise_on_error=True
+    )
+
+    text = memory_md.read_text(encoding="utf-8")
+    lines, nbytes = measure(text)
+    print(
+        f"aim-tracking-rotate --fix-memory-md: {memory_md}\n"
+        f"  before: {lines} lines / {nbytes / 1024:.1f} KB "
+        f"(cap {AUTO_MEMORY_CONTRACT.cap_lines} / {AUTO_MEMORY_CONTRACT.cap_kb})"
+    )
+
+    log_shaped = _has_log_shape_violation(text)
+    if not over_cap(lines, nbytes, AUTO_MEMORY_CONTRACT) and not log_shaped:
+        print("  already within cap and no log-shape entries — no action needed.")
+        return 0
+
+    _backup_file(memory_md, now)
+
+    sections = _parse_memory_sections(text)
+    new_sections: list[tuple[str, str]] = []
+    changed = False
+    # Sibling writes are staged here; committed atomically after the full pass
+    # so a mid-run error never leaves orphaned siblings while MEMORY.md is intact.
+    pending_writes: dict[Path, str] = {}
+
+    try:
+        for header, content in sections:
+            new_content, sec_changed = _fix_section(
+                content, header, memory_dir, pending_writes
+            )
+            new_sections.append((header, new_content))
+            changed = changed or sec_changed
+    except SiblingCollisionError as exc:
+        print(
+            f"ERROR: sibling collision — {exc}. "
+            "MEMORY.md was NOT modified; relocate or rename the sibling by hand.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not changed:
+        print(
+            "  no relocatable entries found (all blocks ≤2 lines / ≤200 chars "
+            "or already pointer-format) — no action taken."
+        )
+        return 0
+
+    # Compute new MEMORY.md text and build virtual after-state (prove before write).
+    new_text = _reassemble_memory(new_sections)
+
+    all_md_after: dict[Path, str] = {}
+    for p in memory_dir.glob("*.md"):
+        all_md_after[p] = p.read_text(encoding="utf-8")
+    all_md_after[memory_md] = new_text
+    all_md_after.update(pending_writes)
+
+    after_set: Counter[str] = Counter()
+    for _text in all_md_after.values():
+        for _line in _text.splitlines():
+            _s = _line.strip()
+            if _s:
+                after_set[_s] += 1
+    try:
+        conservation.assert_no_content_loss(before_set, after_set)
+    except AssertionError as exc:
+        print(f"ERROR: conservation FAILED: {exc}", file=sys.stderr)
+        return 1
+
+    # Conservation proved — commit sibling writes then MEMORY.md atomically.
+    for sib_path, sib_content in pending_writes.items():
+        atomic_write(sib_path, sib_content)
+    atomic_write(memory_md, new_text)
+
+    new_lines, new_bytes = measure(new_text)
+    print(
+        f"  after:        {new_lines} lines / {new_bytes / 1024:.1f} KB\n"
+        f"  conservation: union before ⊆ union after, 0 lines lost ✓"
+    )
+    if over_cap(new_lines, new_bytes, AUTO_MEMORY_CONTRACT):
+        print(
+            "  WARNING: still over cap — run again or trim by hand.",
+            file=sys.stderr,
+        )
+    return 0
+
+
+def run_fix_all(
+    oversight_root: Path, now: datetime, include_memory_md: bool = False
+) -> int:
+    """Fix every governed oversight file, then MEMORY.md if opted in."""
+    governed = discover_governed(oversight_root)
+    results: list[int] = []
+    for gf in governed:
+        rc = run_fix(gf.path, oversight_root, now)
+        results.append(rc)
+
+    memory_md = resolve_memory_md()
+    if memory_md:
+        if include_memory_md:
+            results.append(run_fix_memory_md(memory_md, now))
+        else:
+            print(
+                f"NOTICE: --fix-all skipped auto-memory MEMORY.md at {memory_md}.\n"
+                "  Pass --include-memory-md to include it."
+            )
+
+    if not results:
+        print("aim-tracking-rotate --fix-all: no governed files found.")
+        return 0
+    errors = sum(1 for r in results if r != 0)
+    print(
+        f"\naim-tracking-rotate --fix-all: {len(results)} file(s) processed, "
+        f"{errors} error(s)."
+    )
+    return max(results)
+
+
+# ---------------------------------------------------------------------------
 # Oversight-root resolution + entry point
 # ---------------------------------------------------------------------------
 
@@ -964,6 +1681,72 @@ def resolve_oversight_root(args: argparse.Namespace) -> Path:
     return p
 
 
+def resolve_memory_md(project_cwd: Path | None = None) -> Path | None:
+    """Resolve the auto-memory MEMORY.md path for the current project.
+
+    Resolution order: ``$autoMemoryDirectory``  or
+    ``~/.claude/projects/<slug>/memory/``, where ``<slug>`` = project cwd
+    with every ``/`` replaced by ``-``.  Returns ``None`` when the file does
+    not exist (MEMORY.md is optional — not every project uses it).
+    """
+    cwd = project_cwd or Path.cwd()
+    auto_memory_dir = os.environ.get("autoMemoryDirectory")  # noqa: SIM112
+    if auto_memory_dir:
+        base = Path(auto_memory_dir).expanduser()
+    else:
+        slug = str(cwd).replace("/", "-")
+        base = Path.home() / ".claude" / "projects" / slug / "memory"
+    candidate = base / "MEMORY.md"
+    return candidate if candidate.is_file() else None
+
+
+def _check_memory_md(memory_md: Path) -> list[str]:
+    """Return WARN strings for cap or log-shape issues in MEMORY.md.
+
+    Issues are warnings (not gate failures): MEMORY.md is not an oversight
+    file and its cap is a load-window advisory, not a hard enforcement gate.
+    """
+    warnings: list[str] = []
+    text = memory_md.read_text(encoding="utf-8")
+    lines, nbytes = measure(text)
+
+    if over_cap(lines, nbytes, AUTO_MEMORY_CONTRACT):
+        warnings.append(
+            f"MEMORY.md over cap: {lines} lines / {nbytes / 1024:.1f} KB "
+            f"(cap {AUTO_MEMORY_CONTRACT.cap_lines}L"
+            f" / {AUTO_MEMORY_CONTRACT.cap_kb}KB) — run `--fix-memory-md`"
+        )
+
+    # Log-shape: any paragraph block > allowed per-entry limits.
+    # A block of pointer-format lines is the conformant index shape — skip it.
+    section_header_re = re.compile(r"^#{1,3} ")
+    for block in _split_into_blocks(text):
+        stripped = block.strip()
+        if not stripped:
+            continue
+        block_lines = [ln for ln in stripped.splitlines() if ln.strip()]
+        # A lone section header (no body) is structural, not a log entry.
+        if len(block_lines) == 1 and section_header_re.match(stripped):
+            continue
+        non_blank = [ln for ln in stripped.splitlines() if ln.strip()]
+        if all(_is_memory_pointer(ln) for ln in non_blank):
+            continue  # list of pointers is conformant, not a log-shape violation
+        if (
+            len(non_blank) > _MEMORY_LOG_SHAPE_MAX_LINES
+            or len(stripped) > _MEMORY_LOG_SHAPE_MAX_CHARS
+        ):
+            preview = stripped[:60].replace("\n", " ")
+            warnings.append(
+                f"MEMORY.md index-not-log violation: "
+                f"{len(non_blank)} lines / {len(stripped)} chars in entry "
+                f"(max {_MEMORY_LOG_SHAPE_MAX_LINES} lines / "
+                f"{_MEMORY_LOG_SHAPE_MAX_CHARS} chars): {preview!r}…"
+            )
+            break  # first violation only — avoid output spam
+
+    return warnings
+
+
 def resolve_now(period: str | None) -> datetime:
     """Deterministic period override for tests; else wall-clock."""
     if period:
@@ -984,9 +1767,10 @@ def resolve_now(period: str | None) -> datetime:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
-            "Enforce oversight-file caps at session-close (--check) and rotate "
+            "Enforce oversight-file caps at session-close (--check), rotate "
             "an over-cap file's oldest entries into a dated archive shard "
-            "(--apply)."
+            "(--apply), or fix an over-cap file non-interactively (--fix / "
+            "--fix-all / --fix-memory-md)."
         )
     )
     mode = parser.add_mutually_exclusive_group(required=True)
@@ -999,6 +1783,27 @@ def main(argv: list[str] | None = None) -> int:
         "--apply",
         metavar="FILE",
         help="Rotate the oldest entries of FILE into a dated archive shard.",
+    )
+    mode.add_argument(
+        "--fix",
+        metavar="FILE",
+        help=(
+            "Fix FILE non-interactively: add front-matter, cap-fix by class, "
+            "prove conservation. Archive-only; emits a plan + conservation report."
+        ),
+    )
+    mode.add_argument(
+        "--fix-all",
+        action="store_true",
+        help="Fix all governed oversight files, then MEMORY.md if resolvable.",
+    )
+    mode.add_argument(
+        "--fix-memory-md",
+        action="store_true",
+        help=(
+            "Fix MEMORY.md only: relocate over-long entries to sibling files "
+            "and prove conservation across the full union."
+        ),
     )
     parser.add_argument(
         "--oversight-root",
@@ -1025,19 +1830,47 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Archive period override (YYYY-MM or YYYY-MM-DD); default = today.",
     )
+    parser.add_argument(
+        "--include-memory-md",
+        action="store_true",
+        default=False,
+        help=(
+            "With --fix-all: also fix the real auto-memory MEMORY.md. "
+            "Skipped by default since --fix-all is usually scoped to "
+            "--oversight-root."
+        ),
+    )
     args = parser.parse_args(argv)
 
+    # --fix-memory-md does not need an oversight root.
+    if args.fix_memory_md:
+        memory_md = resolve_memory_md()
+        if memory_md is None:
+            print(
+                "ERROR: MEMORY.md not found. "
+                "Set $autoMemoryDirectory or run from the project root.",
+                file=sys.stderr,
+            )
+            return 1
+        return run_fix_memory_md(memory_md, resolve_now(args.period))
+
     oversight_root = resolve_oversight_root(args)
+    now = resolve_now(args.period)
 
     if args.check:
         return run_check(oversight_root)
-    return run_apply(
-        Path(args.apply).expanduser(),
-        oversight_root,
-        args.entry_pattern,
-        args.keep,
-        resolve_now(args.period),
-    )
+    if args.apply:
+        return run_apply(
+            Path(args.apply).expanduser(),
+            oversight_root,
+            args.entry_pattern,
+            args.keep,
+            now,
+        )
+    if args.fix:
+        return run_fix(Path(args.fix).expanduser(), oversight_root, now)
+    # --fix-all
+    return run_fix_all(oversight_root, now, getattr(args, "include_memory_md", False))
 
 
 if __name__ == "__main__":

--- a/_ai-memory/pov/workflows/session/close/checklist.md
+++ b/_ai-memory/pov/workflows/session/close/checklist.md
@@ -41,7 +41,7 @@ description: 'Quality gate rubric for session-close'
 
 ### Step 4: Enforce Caps (step-04-enforce-caps)
 - [ ] `aim-tracking-rotate --check` run against the oversight root
-- [ ] Any over-cap file rotated (`--apply`) until `--check` reports PASS
+- [ ] Any over-cap file remediated (`--fix <file>`, `--fix-all`, or `--apply` for decision-log.md) until `--check` reports PASS
 - [ ] Closeout not advanced to save while any governed file is over cap
 
 ### Step 5: Save and Confirm (step-05-save-and-confirm)

--- a/_ai-memory/pov/workflows/session/close/instructions.md
+++ b/_ai-memory/pov/workflows/session/close/instructions.md
@@ -25,7 +25,7 @@ Unlike session-handoff (which is a mid-session snapshot), session-close formally
 | 1 | `step-01-summarize-session.md` | Compile a summary of all work completed, decisions made, and blockers encountered this session |
 | 2 | `step-02-update-tracking.md` | Update `SESSION_WORK_INDEX.md`, `sprint-status.yaml`, and `blockers-log.md` with session outcomes |
 | 3 | `step-03-create-handoff.md` | Write the session closeout handoff document using the handoff template |
-| 4 | `step-04-enforce-caps.md` | Run `aim-tracking-rotate --check`; block closeout and rotate while any governed oversight file is over cap |
+| 4 | `step-04-enforce-caps.md` | Run `aim-tracking-rotate --check`; block closeout and remediate (`--fix`/`--fix-all` or `--apply` for decision-log.md) while any governed oversight file is over cap |
 | 5 | `step-05-save-and-confirm.md` | Attempt Qdrant save via `/parzival-save-handoff`; confirm session closure with the user |
 
 ## Key Decisions

--- a/_ai-memory/pov/workflows/session/close/steps-c/step-02-update-tracking.md
+++ b/_ai-memory/pov/workflows/session/close/steps-c/step-02-update-tracking.md
@@ -103,12 +103,12 @@ For blockers identified in Step 1:
 - When a blocker was resolved this session, **MOVE** it out of the live file to the dated archive — do not leave resolved entries inline
 - Update the reconciliation banner count to the number of blockers still open
 
-**Rotate at write**: if the live file is over cap after the update, rotate the
-oldest entries to the dated archive and refresh the banner:
+**Fix at write**: if the live file is over cap after the update, use `--fix` to
+archive the whole file verbatim and rewrite a lean index + pointer:
 
 ```bash
 python ~/.ai-memory/_ai-memory/pov/skills/aim-tracking-rotate/scripts/tracking_rotate.py \
-  --apply {oversight_path}/tracking/blockers-log.md \
+  --fix {oversight_path}/tracking/blockers-log.md \
   --oversight-root {oversight_path}
 ```
 

--- a/_ai-memory/pov/workflows/session/close/steps-c/step-04-enforce-caps.md
+++ b/_ai-memory/pov/workflows/session/close/steps-c/step-04-enforce-caps.md
@@ -64,12 +64,27 @@ pointer — chronology preserved.
 
 For a table-row / multi-table register or live-index (`blockers-log.md`,
 `risk-register.md`, `SESSION_WORK_INDEX.md`, `session-index/INDEX.md`) the gate
-**REFUSES** `--apply` — safe field-aware auto-rotation is deferred to TD-655.
-Hand-trim the oldest/resolved rows into the archive table by hand, then re-run.
+**REFUSES** `--apply` (field-aware safe rotation deferred to TD-655). Use `--fix`
+instead — it archives the whole file verbatim and rewrites a lean index + pointer:
 
-For a heartbeat / thin-register file (`rotation_trigger: none`, e.g.
-`project-status.md`, `task-tracker.md`) the gate likewise cannot rotate it: trim
-it by hand to the schema, then re-run.
+```bash
+python ~/.ai-memory/_ai-memory/pov/skills/aim-tracking-rotate/scripts/tracking_rotate.py \
+  --fix {over_cap_file} \
+  --oversight-root {oversight_path}
+```
+
+For a heartbeat or non-rotatable register (`project-status.md`, `task-tracker.md`),
+use `--fix` — it archives-whole-verbatim for non-rotatable registers, and refreshes
+the template front-matter for heartbeats:
+
+```bash
+python ~/.ai-memory/_ai-memory/pov/skills/aim-tracking-rotate/scripts/tracking_rotate.py \
+  --fix {over_cap_file} \
+  --oversight-root {oversight_path}
+```
+
+If `--fix` reports that a heartbeat body is still over cap after the front-matter
+refresh, trim the body by hand, then re-run.
 
 ### 3. Re-Run Until Clean
 

--- a/templates/memory/MEMORY.md.template
+++ b/templates/memory/MEMORY.md.template
@@ -1,0 +1,20 @@
+# [Project Name] — Session Memory
+
+> **Index, not log.** Each entry here is a one-line `- [Title](sibling.md) — hook`
+> pointer to a topic file in this `memory/` directory, or a ≤2-line summary for
+> very compact facts. Claude Code loads this file first (up to 200 lines / 25 KB);
+> sibling files are loaded on demand. Keep this index lean.
+
+---
+
+## Active Project
+
+- [Project status](project_status.md) — brief pointer to current initiative
+
+## Feedback
+
+- [Example feedback](feedback_example.md) — an example one-line pointer
+
+## Next Steps
+
+- First outstanding action

--- a/templates/oversight/tracking/task-tracker.md
+++ b/templates/oversight/tracking/task-tracker.md
@@ -2,8 +2,8 @@
 class: register
 read_path: section-anchored
 owns: "pointer to live sprint/task state"
-cap_lines: 40
-cap_kb: 3
+cap_lines: 60
+cap_kb: 4.5
 rotation_trigger: none
 archive_target: N/A
 index_file: N/A

--- a/tests/unit/test_conservation.py
+++ b/tests/unit/test_conservation.py
@@ -1,0 +1,253 @@
+"""
+Unit tests for the conservation.py helper module.
+
+Imported via importlib (same pattern as test_tracking_rotate_skill.py) so the
+module does not need to be on sys.path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module loading
+# ---------------------------------------------------------------------------
+
+_SCRIPTS_DIR = (
+    Path(__file__).resolve().parent.parent.parent
+    / "_ai-memory/pov/skills/aim-tracking-rotate/scripts"
+)
+_CONSERVATION_PATH = _SCRIPTS_DIR / "conservation.py"
+
+_cspec = importlib.util.spec_from_file_location("conservation", _CONSERVATION_PATH)
+_cmod = importlib.util.module_from_spec(_cspec)
+sys.modules["conservation"] = _cmod
+_cspec.loader.exec_module(_cmod)
+
+build_id_manifest = _cmod.build_id_manifest
+assert_no_id_loss = _cmod.assert_no_id_loss
+build_content_set = _cmod.build_content_set
+assert_no_content_loss = _cmod.assert_no_content_loss
+ENTRY_ID_RE = _cmod.ENTRY_ID_RE
+
+
+# ---------------------------------------------------------------------------
+# build_id_manifest
+# ---------------------------------------------------------------------------
+
+
+def test_build_id_manifest_empty_list() -> None:
+    counts = build_id_manifest([])
+    assert counts == Counter()
+
+
+def test_build_id_manifest_nonexistent_path(tmp_path: Path) -> None:
+    ghost = tmp_path / "does_not_exist.md"
+    counts = build_id_manifest([ghost])
+    assert counts == Counter()
+
+
+def test_build_id_manifest_single_file(tmp_path: Path) -> None:
+    f = tmp_path / "log.md"
+    f.write_text(
+        "### DEC-001 — First\ncontent\n\n### DEC-002 — Second\nmore\n",
+        encoding="utf-8",
+    )
+    counts = build_id_manifest([f])
+    assert counts["DEC-001"] == 1
+    assert counts["DEC-002"] == 1
+    assert counts.total() >= 2
+
+
+def test_build_id_manifest_multiple_files(tmp_path: Path) -> None:
+    live = tmp_path / "live.md"
+    shard = tmp_path / "shard.md"
+    live.write_text("### DEC-010 — Live\nstuff\n", encoding="utf-8")
+    shard.write_text(
+        "### DEC-001 — Old\narchived\n### DEC-002 — Older\narchived\n", encoding="utf-8"
+    )
+    counts = build_id_manifest([live, shard])
+    assert counts["DEC-010"] >= 1
+    assert counts["DEC-001"] >= 1
+    assert counts["DEC-002"] >= 1
+
+
+def test_build_id_manifest_token_variety(tmp_path: Path) -> None:
+    f = tmp_path / "register.md"
+    f.write_text(
+        "| BLK-001 | active |\n| RISK-042 | open |\n| TD-655 | open |\n",
+        encoding="utf-8",
+    )
+    counts = build_id_manifest([f])
+    assert "BLK-001" in counts
+    assert "RISK-042" in counts
+    assert "TD-655" in counts
+
+
+# ---------------------------------------------------------------------------
+# assert_no_id_loss
+# ---------------------------------------------------------------------------
+
+
+def test_assert_no_id_loss_identical() -> None:
+    before = Counter({"DEC-001": 1, "DEC-002": 1})
+    after = Counter({"DEC-001": 1, "DEC-002": 1})
+    assert_no_id_loss(before, after)  # must not raise
+
+
+def test_assert_no_id_loss_after_superset() -> None:
+    before = Counter({"DEC-001": 1})
+    after = Counter({"DEC-001": 2, "DEC-999": 5})
+    assert_no_id_loss(before, after)  # more copies in after is fine
+
+
+def test_assert_no_id_loss_no_loss_empty_before() -> None:
+    assert_no_id_loss(Counter(), Counter())
+
+
+def test_assert_no_id_loss_raises_on_loss() -> None:
+    before = Counter({"DEC-001": 1, "DEC-002": 1})
+    after = Counter({"DEC-001": 1})  # DEC-002 dropped
+    with pytest.raises(AssertionError, match="DEC-002"):
+        assert_no_id_loss(before, after)
+
+
+def test_assert_no_id_loss_raises_lists_up_to_ten(tmp_path: Path) -> None:
+    # More than 10 IDs lost — sample is capped at 10.
+    before = Counter({f"DEC-{i:03d}": 1 for i in range(15)})
+    after: Counter[str] = Counter()
+    with pytest.raises(AssertionError, match="15 entry ID"):
+        assert_no_id_loss(before, after)
+
+
+# ---------------------------------------------------------------------------
+# build_content_set
+# ---------------------------------------------------------------------------
+
+
+def test_build_content_set_empty() -> None:
+    result = build_content_set([])
+    assert result == Counter()
+
+
+def test_build_content_set_strips_blank_lines(tmp_path: Path) -> None:
+    f = tmp_path / "mem.md"
+    f.write_text("\nline one\n\nline two\n", encoding="utf-8")
+    result = build_content_set([f])
+    assert "line one" in result
+    assert "line two" in result
+    # Blank lines are NOT in the set
+    assert "" not in result
+
+
+def test_build_content_set_union_across_files(tmp_path: Path) -> None:
+    main_md = tmp_path / "MEMORY.md"
+    sibling = tmp_path / "feedback_example.md"
+    main_md.write_text(
+        "# Index\n- [Ex](feedback_example.md) — hook\n", encoding="utf-8"
+    )
+    sibling.write_text("Full detail text about the example.\n", encoding="utf-8")
+    result = build_content_set([main_md, sibling])
+    assert "# Index" in result
+    assert "Full detail text about the example." in result
+
+
+def test_build_content_set_nonexistent_path_ignored(tmp_path: Path) -> None:
+    ghost = tmp_path / "ghost.md"
+    result = build_content_set([ghost])
+    assert result == Counter()
+
+
+# ---------------------------------------------------------------------------
+# assert_no_content_loss
+# ---------------------------------------------------------------------------
+
+
+def test_assert_no_content_loss_ok() -> None:
+    before = Counter({"line one": 1, "line two": 1})
+    after = Counter({"line one": 1, "line two": 1, "extra line": 1})
+    assert_no_content_loss(before, after)  # must not raise
+
+
+def test_assert_no_content_loss_same_set() -> None:
+    c = Counter({"a": 1, "b": 1, "c": 1})
+    assert_no_content_loss(c, c)  # must not raise
+
+
+def test_assert_no_content_loss_raises() -> None:
+    before = Counter({"line one": 1, "line two": 1, "line three": 1})
+    after = Counter({"line one": 1})  # two lines missing
+    with pytest.raises(AssertionError, match="2 content line"):
+        assert_no_content_loss(before, after)
+
+
+def test_assert_no_content_loss_relocation_scenario(tmp_path: Path) -> None:
+    """Prove that a relocation (move body from MEMORY.md to sibling) passes."""
+    memory_md = tmp_path / "MEMORY.md"
+    sibling = tmp_path / "project_build.md"
+
+    # Before: dense session note lives inline in MEMORY.md.
+    dense_body = (
+        "Build v2.7.0 details: Phase 1 done, Phase 2 in progress.\n"
+        "Key decision: use option A for the integration path.\n"
+    )
+    memory_md.write_text(f"# Index\n{dense_body}", encoding="utf-8")
+
+    before_set = build_content_set([memory_md])
+
+    # After relocation: body moves to sibling; MEMORY.md keeps only a pointer.
+    sibling.write_text(dense_body, encoding="utf-8")
+    memory_md.write_text(
+        "# Index\n- [Build v2.7.0](project_build.md) — Phase 1+2 progress\n",
+        encoding="utf-8",
+    )
+
+    after_set = build_content_set([memory_md, sibling])
+    assert_no_content_loss(before_set, after_set)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Multiset-specific tests (count-based correctness)
+# ---------------------------------------------------------------------------
+
+
+def test_assert_no_id_loss_raises_on_count_reduction() -> None:
+    """A count reduction (2→1) must fail even though the ID is still present.
+
+    The presence-only check (count>0 before, count>0 after) would silently
+    pass; the count-based check catches the partial loss.
+    """
+    before = Counter({"DEC-001": 2})
+    after = Counter({"DEC-001": 1})
+    with pytest.raises(AssertionError, match="DEC-001"):
+        assert_no_id_loss(before, after)
+
+
+def test_assert_no_id_loss_equal_count_passes() -> None:
+    before = Counter({"DEC-001": 2, "DEC-002": 3})
+    after = Counter({"DEC-001": 2, "DEC-002": 3})
+    assert_no_id_loss(before, after)  # must not raise
+
+
+def test_assert_no_content_loss_duplicate_line_loss() -> None:
+    """Losing one of two identical lines must raise.
+
+    The frozenset-based check would silently pass (the line is still present);
+    the Counter-based check catches the count reduction.
+    """
+    before = Counter({"repeated line": 2, "other line": 1})
+    after = Counter({"repeated line": 1, "other line": 1})
+    with pytest.raises(AssertionError, match="1 content line"):
+        assert_no_content_loss(before, after)
+
+
+def test_assert_no_content_loss_count_increase_passes() -> None:
+    """A line appearing MORE times after is fine (content added, not lost)."""
+    before = Counter({"line a": 1})
+    after = Counter({"line a": 3, "line b": 2})
+    assert_no_content_loss(before, after)  # must not raise

--- a/tests/unit/test_tracking_rotate_skill.py
+++ b/tests/unit/test_tracking_rotate_skill.py
@@ -57,6 +57,14 @@ MANUAL_ROTATION_FILES = _mod.MANUAL_ROTATION_FILES
 append_to_shard = _mod.append_to_shard
 Entry = _mod.Entry
 ShardCollisionError = _mod.ShardCollisionError
+AUTO_MEMORY_CONTRACT = _mod.AUTO_MEMORY_CONTRACT
+run_fix_memory_md = _mod.run_fix_memory_md
+run_fix = _mod.run_fix
+_check_memory_md = _mod._check_memory_md
+_entry_needs_relocation = _mod._entry_needs_relocation
+_has_log_shape_violation = _mod._has_log_shape_violation
+_sibling_name_for = _mod._sibling_name_for
+SiblingCollisionError = _mod.SiblingCollisionError
 
 
 # ---------------------------------------------------------------------------
@@ -1012,3 +1020,710 @@ def test_front_matter_parse_requires_caps() -> None:
     assert c is not None
     assert c.cap_lines == 10
     assert c.cap_kb == 2.0
+
+
+# ---------------------------------------------------------------------------
+# Friction #2: task-tracker cap raised to 60 lines / 4.5 KB
+# ---------------------------------------------------------------------------
+
+
+def test_friction2_task_tracker_cap() -> None:
+    """task-tracker fallback-registry cap must be 60 lines / 4.5 KB."""
+    contract = FALLBACK_REGISTRY["tracking/task-tracker.md"]
+    assert contract.cap_lines == 60
+    assert contract.cap_kb == 4.5
+
+
+def test_check_task_tracker_passes_at_new_cap(tmp_path: Path) -> None:
+    """A task-tracker file of 55 lines (old 40-line cap would have failed) passes."""
+    root = _make_oversight(tmp_path)
+    # 55 content lines: old cap=40 would have failed, new cap=60 should pass.
+    body = "\n".join(f"task-line {i}" for i in range(55)) + "\n"
+    (root / "tracking" / "task-tracker.md").write_text(body, encoding="utf-8")
+    result = _run("--check", "--oversight-root", str(root))
+    assert result.returncode == 0, result.stderr
+    assert "PASS" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Friction #3: section scaffold preserved after --apply (golden-reference shape)
+# ---------------------------------------------------------------------------
+
+_THREE_SECTION_HEAD = (
+    "# Decision Log\n\n"
+    "**Last Updated**: 2026-06-18\n\n"
+    "---\n\n"
+    "## How to Use\n\n"
+    "- Quick decisions go here.\n\n"
+    "## Entry Format\n\n"
+    "```md\n"
+    "### DEC-[ID]: [Decision Topic]\n"
+    "- **Status**: [Active/Superseded]\n"
+    "```\n\n"
+    "---\n\n"
+    "## Decisions\n\n"
+)
+
+
+def _three_section_log(n_entries: int) -> str:
+    """decision-log with the real three-section preamble (fenced entry example)."""
+    blocks = "".join(
+        f"### DEC-PM{i:03d}-D1: decision {i}\n"
+        f"- **Date**: 2026-06-{(i % 28) + 1:02d}\n"
+        f"- **Status**: Active\n\n"
+        for i in range(n_entries, 0, -1)
+    )
+    return _THREE_SECTION_HEAD + blocks
+
+
+def test_apply_preserves_section_scaffold(tmp_path: Path) -> None:
+    """Golden-reference shape: after --apply on a three-section decision-log,
+    all ## section headers survive and the pointer sits directly under
+    ## Decisions with kept entries beneath it.
+    """
+    root = _make_oversight(tmp_path)
+    log = root / "tracking" / "decision-log.md"
+    log.write_text(_three_section_log(60), encoding="utf-8")
+
+    result = _run(
+        "--apply", str(log), "--oversight-root", str(root), "--period", "2026-06"
+    )
+    assert result.returncode == 0, result.stderr
+
+    new_text = log.read_text(encoding="utf-8")
+
+    # All three ## section headers must survive.
+    assert "## How to Use" in new_text, "## How to Use header stripped"
+    assert "## Entry Format" in new_text, "## Entry Format header stripped"
+    assert "## Decisions" in new_text, "## Decisions header stripped"
+
+    # Pointer must be under ## Decisions (golden reference: pointer sits
+    # directly under ## Decisions with kept entries beneath it).
+    decisions_pos = new_text.index("## Decisions")
+    pointer_pos = new_text.index(POINTER_MARKER)
+    newest_pos = new_text.index("DEC-PM060-D1")
+
+    assert pointer_pos > decisions_pos, "pointer must come after ## Decisions"
+    assert newest_pos > pointer_pos, "kept entries must follow pointer"
+
+
+def test_apply_unfenced_log_scaffold_preserved(tmp_path: Path) -> None:
+    """Bare --apply on an over-cap decision-log with an unfenced entry-format
+    example must preserve all three ## section headers.
+
+    The scaffold-strip bug: an unfenced ### DEC-[ID]: example was mis-parsed as
+    Entry 0, causing ## Decisions to appear inside the kept block (mangled preamble,
+    pointer between ## Entry Format and ## Decisions). _fence_for_apply now fences
+    the example before parse_entries so the preamble is intact.
+
+    Non-vacuous assertions (item 2b): these fail WITHOUT the fence fix even on a
+    newest-first seed where ## Decisions stays 'visible' but in the wrong position.
+    """
+    root = _make_oversight(tmp_path)
+    log = root / "tracking" / "decision-log.md"
+    # _decision_log_seed has an UNFENCED entry-format example (the S102 trigger).
+    log.write_text(_decision_log_seed(80), encoding="utf-8")
+
+    result = _run(
+        "--apply", str(log), "--oversight-root", str(root), "--period", "2026-06"
+    )
+    assert result.returncode == 0, result.stderr
+
+    new_text = log.read_text(encoding="utf-8")
+    assert "## How to Use" in new_text, "## How to Use stripped by --apply"
+    assert "## Entry Format" in new_text, "## Entry Format stripped by --apply"
+    assert "## Decisions" in new_text, "## Decisions stripped by --apply"
+
+    # Non-vacuous structural assertions (fail without _fence_for_apply):
+    # 1. Entry-format example must be fenced in the output.
+    ef_pos = new_text.index("## Entry Format")
+    decisions_pos = new_text.index("## Decisions")
+    ef_body = new_text[ef_pos:decisions_pos]
+    assert "```" in ef_body, "entry-format example must be fenced after --apply"
+    # 2. Pointer must NOT sit between ## Entry Format and ## Decisions.
+    pointer_pos = new_text.index(POINTER_MARKER)
+    assert not (
+        ef_pos < pointer_pos < decisions_pos
+    ), "pointer sits between ## Entry Format and ## Decisions — preamble mangled"
+
+    # ID conservation across live + shard.
+    before_ids = set(re.findall(r"DEC-PM\d+-D1", _decision_log_seed(80)))
+    shard_files = list((root / "tracking" / "archive").glob("decision-log-*.md"))
+    assert shard_files, "Expected a shard file after --apply"
+    after_text = new_text + shard_files[0].read_text(encoding="utf-8")
+    after_ids = set(re.findall(r"DEC-PM\d+-D1", after_text))
+    assert before_ids == after_ids, f"ID loss: {before_ids - after_ids}"
+
+
+# ---------------------------------------------------------------------------
+# auto-memory-index class: --check WARN semantics
+# ---------------------------------------------------------------------------
+
+
+def _production_memory_md(lines: int = 240) -> str:
+    """Return a production-size MEMORY.md exceeding the 200-line cap.
+
+    The first ~120 lines hold a dense session-notes section (log-shape violations),
+    the remaining lines simulate feedback pointer entries (already pointer format).
+    """
+    # Dense session notes section (log-shape violations).
+    dense_section = "## Active Project: Build Phase\n\n"
+    for i in range(1, 50):
+        # Each block is 3+ lines — clearly over _MEMORY_LOG_SHAPE_MAX_LINES.
+        dense_section += (
+            f"**Session {i:03d} notes**: completed tasks {i}-{i+2}.\n"
+            f"Key decisions: used option A for integration path {i}.\n"
+            f"Next: verify component {i} passes all acceptance tests.\n"
+            f"\n"
+        )
+
+    # Feedback section with pointer-format entries (conformant — no relocation).
+    feedback_section = "## Feedback\n\n"
+    for i in range(1, 40):
+        feedback_section += (
+            f"- [feedback-rule-{i:03d}](feedback_rule_{i:03d}.md) "
+            f"— always follow rule {i}\n"
+        )
+
+    # Next steps (short, conformant).
+    next_section = "\n## Next Steps\n\n- Reinstate after review\n"
+
+    full_text = (
+        "# AI Memory — Session Memory\n\n"
+        + dense_section
+        + feedback_section
+        + next_section
+    )
+    # Pad to exactly `lines` lines if under; return as-is if already long enough.
+    current = full_text.count("\n")
+    if current < lines:
+        full_text += "\n" * (lines - current)
+    return full_text
+
+
+def test_check_memory_md_over_cap_is_warn_not_fail(tmp_path: Path, monkeypatch) -> None:
+    """--check must exit 0 (PASS gate) even when MEMORY.md is over cap; the
+    over-cap condition is surfaced as a WARN line on stderr, not a gate failure.
+    """
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    md = memory_dir / "MEMORY.md"
+    md.write_text(_production_memory_md(240), encoding="utf-8")
+
+    root = _make_oversight(tmp_path)
+    monkeypatch.setenv("autoMemoryDirectory", str(memory_dir))
+
+    result = _run("--check", "--oversight-root", str(root))
+    assert result.returncode == 0, f"--check must exit 0; stderr: {result.stderr}"
+    assert "WARN" in result.stderr
+    assert "MEMORY.md" in result.stderr
+
+
+def test_check_memory_md_log_shape_warn(tmp_path: Path, monkeypatch) -> None:
+    """A MEMORY.md with multi-line log-style entries triggers a log-shape WARN
+    even when the file is under the line cap.
+    """
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    md = memory_dir / "MEMORY.md"
+    # Under 200 lines but has a multi-line paragraph block
+    dense_entry = (
+        "Dense session entry that is well over 200 characters total "
+        "and also spans multiple non-blank lines in the file.\n"
+        "Second line of the same block — this exceeds the 2-line index limit.\n"
+        "Third line — clearly violates the index-not-log constraint.\n"
+    )
+    md.write_text(f"# Index\n\n{dense_entry}\n", encoding="utf-8")
+
+    root = _make_oversight(tmp_path)
+    monkeypatch.setenv("autoMemoryDirectory", str(memory_dir))
+
+    result = _run("--check", "--oversight-root", str(root))
+    assert result.returncode == 0
+    assert "WARN" in result.stderr
+    assert "index-not-log" in result.stderr
+
+
+def test_check_memory_md_hash3_dense_entry_warn(tmp_path: Path, monkeypatch) -> None:
+    """SHOULD #3: a ### Topic + dense-body block must trigger a log-shape WARN.
+
+    The dominant MEMORY.md shape has ### Topic headers with dense bodies; previously
+    the section_header_re skipped any ### -led block regardless of body size.
+    Only a lone ### header line (no body) should be treated as structural.
+    """
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    md = memory_dir / "MEMORY.md"
+    # Under cap (< 200 lines) but has a ### Topic + dense body (log-shape violation).
+    md.write_text(
+        "# Index\n\n"
+        "## Active Project\n\n"
+        "### Session notes\n"
+        "Completed Phase 1 tasks.\n"
+        "Key decision: use option A.\n"
+        "Next: verify integration passes.\n"
+        "\n",
+        encoding="utf-8",
+    )
+
+    root = _make_oversight(tmp_path)
+    monkeypatch.setenv("autoMemoryDirectory", str(memory_dir))
+
+    result = _run("--check", "--oversight-root", str(root))
+    assert result.returncode == 0, "--check must exit 0 (WARN not gate failure)"
+    assert "WARN" in result.stderr, "Expected WARN for ### -led dense entry"
+
+
+def test_check_memory_md_conformant_no_warn(tmp_path: Path, monkeypatch) -> None:
+    """A conformant MEMORY.md (under cap, all pointer lines) produces no WARN."""
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    md = memory_dir / "MEMORY.md"
+    # 10-line file, all one-line pointers
+    pointers = "".join(
+        f"- [Topic {i}](topic_{i}.md) — short hook for topic {i}\n" for i in range(10)
+    )
+    md.write_text(f"# Index\n\n## Feedback\n\n{pointers}", encoding="utf-8")
+
+    root = _make_oversight(tmp_path)
+    monkeypatch.setenv("autoMemoryDirectory", str(memory_dir))
+
+    result = _run("--check", "--oversight-root", str(root))
+    assert result.returncode == 0
+    assert "WARN" not in result.stderr
+
+
+def test_entry_needs_relocation_pointer_skipped() -> None:
+    """A single-line pointer-format block must NOT be marked for relocation."""
+    pointer = "- [Title](feedback_something.md) — short hook\n"
+    assert _entry_needs_relocation(pointer) is False
+
+
+def test_entry_needs_relocation_dense_block() -> None:
+    """A multi-line dense block IS marked for relocation."""
+    dense = (
+        "Dense session note spanning many lines.\n"
+        "Second line here.\n"
+        "Third line makes it clearly over the limit.\n"
+    )
+    assert _entry_needs_relocation(dense) is True
+
+
+# ---------------------------------------------------------------------------
+# --fix-memory-md: lossless relocation with production-size fixture
+# ---------------------------------------------------------------------------
+
+
+def test_fix_memory_md_reduces_to_under_cap(tmp_path: Path) -> None:
+    """--fix-memory-md on a 240-line MEMORY.md must bring it under the 200-line cap."""
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    md = memory_dir / "MEMORY.md"
+    md.write_text(_production_memory_md(240), encoding="utf-8")
+    from datetime import datetime
+
+    now = datetime(2026, 6, 18)
+    rc = run_fix_memory_md(md, now)
+    assert rc == 0
+
+    new_lines, new_bytes = measure(md.read_text(encoding="utf-8"))
+    assert new_lines <= AUTO_MEMORY_CONTRACT.cap_lines or new_bytes <= int(
+        AUTO_MEMORY_CONTRACT.cap_kb * 1024
+    ), f"still over cap: {new_lines} lines / {new_bytes} bytes"
+
+
+def test_fix_memory_md_conservation(tmp_path: Path) -> None:
+    """Every content line present before --fix-memory-md is present in the
+    union of MEMORY.md + siblings after — zero lines lost.
+    """
+    import importlib.util as _ilu
+
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    md = memory_dir / "MEMORY.md"
+    original_text = _production_memory_md(240)
+    md.write_text(original_text, encoding="utf-8")
+
+    # Load conservation module directly to build before-set.
+    _cpath = _SCRIPT_PATH.parent / "conservation.py"
+    _cs = _ilu.spec_from_file_location("conservation_test", _cpath)
+    _cm = _ilu.module_from_spec(_cs)
+    _cs.loader.exec_module(_cm)
+
+    before_set = _cm.build_content_set(list(memory_dir.glob("*.md")))
+
+    from datetime import datetime
+
+    rc = run_fix_memory_md(md, datetime(2026, 6, 18))
+    assert rc == 0
+
+    after_set = _cm.build_content_set(list(memory_dir.glob("*.md")))
+    _cm.assert_no_content_loss(before_set, after_set)
+
+
+def test_fix_memory_md_idempotent(tmp_path: Path) -> None:
+    """Running --fix-memory-md a second time on an already-fixed MEMORY.md
+    must be a no-op: same file content, no extra siblings created.
+    """
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    md = memory_dir / "MEMORY.md"
+    md.write_text(_production_memory_md(240), encoding="utf-8")
+
+    from datetime import datetime
+
+    now1 = datetime(2026, 6, 18, 10, 0, 0)
+    now2 = datetime(2026, 6, 18, 10, 0, 1)
+
+    rc1 = run_fix_memory_md(md, now1)
+    assert rc1 == 0
+
+    text_after_first = md.read_text(encoding="utf-8")
+    siblings_after_first = set(memory_dir.glob("*.md")) - {md}
+
+    rc2 = run_fix_memory_md(md, now2)
+    assert rc2 == 0
+
+    text_after_second = md.read_text(encoding="utf-8")
+    siblings_after_second = set(memory_dir.glob("*.md")) - {md}
+
+    # No new siblings on second run (ignoring .bak files).
+    md_siblings_second = {p for p in siblings_after_second if p.suffix == ".md"}
+    md_siblings_first = {p for p in siblings_after_first if p.suffix == ".md"}
+    assert (
+        md_siblings_second == md_siblings_first
+    ), "Second run created unexpected new sibling files"
+    # MEMORY.md content unchanged.
+    assert text_after_second == text_after_first
+
+
+def test_fix_memory_md_sibling_collision_refused(tmp_path: Path) -> None:
+    """When a target sibling already exists with different content,
+    --fix-memory-md must refuse and leave MEMORY.md unmodified (MUST #2 / BP-038).
+    """
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    md = memory_dir / "MEMORY.md"
+    # Must be over the 200-line cap to trigger relocation.
+    md.write_text(_production_memory_md(240), encoding="utf-8")
+
+    # Pick the first dense block from _production_memory_md to pre-create the sibling.
+    entry_001 = (
+        "**Session 001 notes**: completed tasks 1-3.\n"
+        "Key decisions: used option A for integration path 1.\n"
+        "Next: verify component 1 passes all acceptance tests.\n"
+    )
+    sibling_name = _sibling_name_for("## Active Project: Build Phase", entry_001)
+    sibling = memory_dir / sibling_name
+    prior_content = "Totally different content that conflicts.\n"
+    sibling.write_text(prior_content, encoding="utf-8")
+
+    original_md = md.read_text(encoding="utf-8")
+
+    from datetime import datetime
+
+    rc = run_fix_memory_md(md, datetime(2026, 6, 18))
+    assert rc != 0, "Expected non-zero rc on sibling collision"
+    assert (
+        md.read_text(encoding="utf-8") == original_md
+    ), "MEMORY.md must be unchanged on collision"
+    assert (
+        sibling.read_text(encoding="utf-8") == prior_content
+    ), "Sibling must be unchanged"
+
+
+# ---------------------------------------------------------------------------
+# --fix: oversight files (decision log via --apply delegation)
+# ---------------------------------------------------------------------------
+
+
+def test_fix_decision_log_over_cap(tmp_path: Path) -> None:
+    """--fix on an over-cap decision log must bring it within cap and pass
+    a subsequent --check.
+    """
+    root = _make_oversight(tmp_path)
+    log = root / "tracking" / "decision-log.md"
+    # 80 entries → well over the 150-line cap for decision-log.
+    log.write_text(_decision_log_seed(80), encoding="utf-8")
+
+    result = _run(
+        "--fix", str(log), "--oversight-root", str(root), "--period", "2026-06"
+    )
+    assert result.returncode == 0, f"--fix failed: {result.stderr}"
+    assert "conservation" in result.stdout
+
+    # After fix, --check must pass.
+    check = _run("--check", "--oversight-root", str(root))
+    assert check.returncode == 0, f"--check failed after --fix: {check.stderr}"
+
+
+def test_fix_already_within_cap_is_noop(tmp_path: Path) -> None:
+    """--fix on a within-cap file must exit 0 without touching the file."""
+    root = _make_oversight(tmp_path)
+    log = root / "tracking" / "decision-log.md"
+    small = _decision_log_seed(5)
+    log.write_text(small, encoding="utf-8")
+
+    result = _run(
+        "--fix", str(log), "--oversight-root", str(root), "--period", "2026-06"
+    )
+    assert result.returncode == 0, result.stderr
+    assert "already within cap" in result.stdout
+    # File unchanged
+    assert log.read_text(encoding="utf-8") == small
+
+
+def test_fix_creates_backup(tmp_path: Path) -> None:
+    """--fix must create a timestamped .bak backup before writing."""
+    root = _make_oversight(tmp_path)
+    log = root / "tracking" / "decision-log.md"
+    log.write_text(_decision_log_seed(80), encoding="utf-8")
+
+    result = _run(
+        "--fix", str(log), "--oversight-root", str(root), "--period", "2026-06"
+    )
+    assert result.returncode == 0, result.stderr
+
+    bak_files = list((root / "tracking").glob("decision-log.md.*.bak"))
+    assert len(bak_files) >= 1, "No backup file created by --fix"
+
+
+def test_apply_creates_backup(tmp_path: Path) -> None:
+    """--apply must create a timestamped .bak backup before rewriting (Fix #5)."""
+    root = _make_oversight(tmp_path)
+    log = root / "tracking" / "decision-log.md"
+    log.write_text(_decision_log_seed(80), encoding="utf-8")
+
+    result = _run(
+        "--apply", str(log), "--oversight-root", str(root), "--period", "2026-06"
+    )
+    assert result.returncode == 0, result.stderr
+
+    bak_files = list((root / "tracking").glob("decision-log.md.*.bak"))
+    assert len(bak_files) >= 1, "No backup file created by --apply"
+
+
+def test_fix_task_tracker_over_cap_routes_to_archive(tmp_path: Path) -> None:
+    """--fix on an over-cap non-rotatable register (task-tracker.md, rotatable=False)
+    must route to archive-whole-verbatim rather than refusing (Fix #7).
+    """
+    root = _make_oversight(tmp_path)
+    tracker = root / "tracking" / "task-tracker.md"
+    # 80 lines > 60-line cap; plain text (no front-matter — relies on FALLBACK_REGISTRY)
+    lines = "\n".join(
+        f"TASK-{i:03d}: task description number {i}" for i in range(1, 81)
+    )
+    tracker.write_text(lines + "\n", encoding="utf-8")
+
+    result = _run(
+        "--fix", str(tracker), "--oversight-root", str(root), "--period", "2026-06"
+    )
+    assert result.returncode == 0, result.stderr
+
+    new_text = tracker.read_text(encoding="utf-8")
+    assert (
+        POINTER_MARKER in new_text
+    ), "--fix on task-tracker must write the pointer marker"
+
+    archive_files = list(
+        (root / "tracking" / "archive").glob("task-tracker-ARCHIVE-*.md")
+    )
+    assert (
+        len(archive_files) == 1
+    ), "Expected exactly one archive shard for task-tracker"
+
+
+def test_fix_decision_log_unfenced_scaffold_preserved(tmp_path: Path) -> None:
+    """--fix on a decision-log with an unfenced entry-format example must preserve
+    all three ## section headers in the live file after rotation.
+
+    The scaffold-strip bug: the unfenced ``### DEC-[ID]:`` in ``## Entry Format``
+    was treated as an entry boundary so ``## Decisions`` rode inside Entry 0's
+    block and was stripped when that block was archived.  _ensure_conformance now
+    fences the example first so parse_entries ignores it.
+
+    Genuine regression guard (item 2b): a simple substring check is vacuous on
+    newest-first seeds because ``## Decisions`` rides inside the kept Entry 0 block
+    regardless of the fix. The extra assertions below fail WITHOUT the fence fix.
+    """
+    root = _make_oversight(tmp_path)
+    log = root / "tracking" / "decision-log.md"
+    log.write_text(_decision_log_seed(80), encoding="utf-8")
+
+    result = _run(
+        "--fix", str(log), "--oversight-root", str(root), "--period", "2026-06"
+    )
+    assert result.returncode == 0, result.stderr
+
+    new_text = log.read_text(encoding="utf-8")
+    assert "## How to Use" in new_text, "## How to Use stripped by --fix"
+    assert "## Entry Format" in new_text, "## Entry Format stripped by --fix"
+    assert "## Decisions" in new_text, "## Decisions stripped by --fix"
+
+    # Non-vacuous structural assertions (fail without the fence fix):
+    # 1. The entry-format example must be fenced after --fix.
+    ef_pos = new_text.index("## Entry Format")
+    decisions_pos = new_text.index("## Decisions")
+    ef_body = new_text[ef_pos:decisions_pos]
+    assert "```" in ef_body, "entry-format example must be fenced by --fix"
+    # 2. Pointer must NOT sit between ## Entry Format and ## Decisions — without
+    #    the fix the pointer lands between them (example rendered as Entry 0).
+    pointer_pos = new_text.index(POINTER_MARKER)
+    assert not (
+        ef_pos < pointer_pos < decisions_pos
+    ), "pointer sits between ## Entry Format and ## Decisions — preamble not rebuilt"
+
+
+def test_fix_section_cx1_refuse_on_existing_sibling(tmp_path: Path) -> None:
+    """CX-1 regression: a block whose target sibling exists with different content
+    must REFUSE (not silently treat the block as already relocated via substring match).
+
+    With the old substring check: block embedded as substring of sibling was silently
+    treated as 'already relocated' — block dropped from MEMORY.md without appearing
+    as a standalone entry in the sibling. The fix: exact paragraph equality check +
+    refuse on collision (MUST #2 / BP-038).
+    """
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    md = memory_dir / "MEMORY.md"
+
+    cx1_entry = (
+        "**Session 001 notes**: completed tasks 1-3.\n"
+        "Key decisions: used option A for integration path 1.\n"
+        "Next: verify component 1 passes all acceptance tests.\n"
+    )
+    # Must be over the 200-line cap to trigger run_fix_memory_md's relocation pass.
+    md.write_text(_production_memory_md(240), encoding="utf-8")
+
+    sibling_name = _sibling_name_for("## Active Project: Build Phase", cx1_entry)
+    sibling = memory_dir / sibling_name
+    sibling.write_text(
+        "Embedded substring: **Session 001 notes**: completed tasks 1-3. more text.\n"
+        "Different paragraph with unrelated content.\n",
+        encoding="utf-8",
+    )
+
+    original_md = md.read_text(encoding="utf-8")
+    original_sib = sibling.read_text(encoding="utf-8")
+
+    from datetime import datetime
+
+    rc = run_fix_memory_md(md, datetime(2026, 6, 18))
+    assert rc != 0, "Expected non-zero rc on sibling collision (CX-1)"
+    assert md.read_text(encoding="utf-8") == original_md, "MEMORY.md must be unchanged"
+    assert (
+        sibling.read_text(encoding="utf-8") == original_sib
+    ), "Sibling must be unchanged"
+
+
+# ---------------------------------------------------------------------------
+# --fix-memory-md: log-shape trigger (under cap but log-shaped)
+# ---------------------------------------------------------------------------
+
+
+def test_fix_memory_md_log_shape_under_cap(tmp_path: Path) -> None:
+    """--fix-memory-md on an under-cap but log-shaped MEMORY.md must relocate
+    the log-shaped entries and produce a conformant index (BP-038 MAJOR-2).
+    """
+    from datetime import datetime
+
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    md = memory_dir / "MEMORY.md"
+    # Under 200 lines but has a multi-line log-shape block.
+    log_block = (
+        "**Session 001 notes**: completed tasks 1-3.\n"
+        "Key decisions: used option A for integration path 1.\n"
+        "Next: verify component 1 passes all acceptance tests.\n"
+    )
+    text = (
+        "# AI Memory\n\n"
+        "## Active Project\n\n" + log_block + "\n"
+        "## Feedback\n\n"
+        "- [rule-001](feedback_rule_001.md) — short pointer hook\n"
+    )
+    md.write_text(text, encoding="utf-8")
+    # Confirm fixture is under cap but has a log-shape violation.
+    assert measure(text)[0] < AUTO_MEMORY_CONTRACT.cap_lines
+    assert _has_log_shape_violation(text)
+
+    rc = run_fix_memory_md(md, datetime(2026, 6, 18))
+    assert rc == 0
+
+    new_text = md.read_text(encoding="utf-8")
+    # Log-shape block must have been relocated out of MEMORY.md.
+    assert log_block.strip() not in new_text
+    # A sibling must contain the relocated block.
+    siblings = [p for p in memory_dir.glob("*.md") if p != md and p.suffix == ".md"]
+    assert any(
+        log_block.strip() in p.read_text(encoding="utf-8") for p in siblings
+    ), "log-shape block must appear in a sibling file after relocation"
+
+    # Idempotent: second run is a no-op (conformant → no change).
+    rc2 = run_fix_memory_md(md, datetime(2026, 6, 18, 10, 0, 1))
+    assert rc2 == 0
+    assert md.read_text(encoding="utf-8") == new_text
+
+
+# ---------------------------------------------------------------------------
+# --fix: heartbeat and live-index branches
+# ---------------------------------------------------------------------------
+
+
+def test_fix_heartbeat_refreshes_front_matter(tmp_path: Path) -> None:
+    """--fix on an over-cap heartbeat (project-status.md) refreshes the
+    template front-matter and brings the file under cap when the body fits
+    within the template FM budget.
+    """
+    root = _make_oversight(tmp_path)
+    ps = root / "project-status.md"
+    # Bloated front-matter (~25 lines) + 40-line body → over the 60-line cap.
+    # Template FM is ~12 lines; 12 + 40 = 52 lines, under cap after refresh.
+    bloated_fm = (
+        "---\n"
+        + "".join(f"# verbose-padding-{i}: filler\n" for i in range(20))
+        + "cap_lines: 60\ncap_kb: 6\nclass: heartbeat\nrotation_trigger: none\n---\n"
+    )
+    body = "# project-status.md\n\n" + "".join(f"field_{i}: value\n" for i in range(40))
+    ps.write_text(bloated_fm + body, encoding="utf-8")
+
+    before_lines, _ = measure(ps.read_text(encoding="utf-8"))
+    assert before_lines > 60  # confirm over cap
+
+    result = _run(
+        "--fix", str(ps), "--oversight-root", str(root), "--period", "2026-06"
+    )
+    assert result.returncode == 0, result.stderr
+
+    after_lines, _ = measure(ps.read_text(encoding="utf-8"))
+    assert after_lines <= 60, f"heartbeat still over cap after fix: {after_lines} lines"
+    # Body content preserved.
+    assert "field_0: value" in ps.read_text(encoding="utf-8")
+
+
+def test_fix_live_index_archives_whole(tmp_path: Path) -> None:
+    """--fix on an over-cap live-index (SESSION_WORK_INDEX.md) archives the whole
+    file verbatim and rewrites a lean index with a pointer.
+    """
+    root = _make_oversight(tmp_path)
+    swi = root / "SESSION_WORK_INDEX.md"
+    # 120 lines > 80-line cap for SESSION_WORK_INDEX.md.
+    body = "".join(
+        f"| session-{i:03d} | task-{i:03d} | did thing {i} | done |\n"
+        for i in range(120)
+    )
+    swi.write_text(body, encoding="utf-8")
+
+    result = _run(
+        "--fix", str(swi), "--oversight-root", str(root), "--period", "2026-06"
+    )
+    assert result.returncode == 0, result.stderr
+
+    new_text = swi.read_text(encoding="utf-8")
+    assert POINTER_MARKER in new_text, "--fix must write the pointer marker"
+
+    archive_files = list((root / "archive").glob("SESSION_WORK_INDEX-ARCHIVE-*.md"))
+    assert (
+        len(archive_files) == 1
+    ), f"Expected 1 archive shard, found {len(archive_files)}"
+    assert "session-001" in archive_files[0].read_text(encoding="utf-8")


### PR DESCRIPTION
# aim-tracking-rotate: add `fix` action + `auto-memory-index` file-class

## Summary
Adds a non-interactive `fix` action to the `aim-tracking-rotate` skill and a fifth governed file-class for the Claude-Code auto-memory `MEMORY.md`. Brings an over-cap / non-conformant oversight tree to a `--check` PASS **without losing any record**, and keeps `MEMORY.md` an index-not-log by losslessly relocating over-long entries into sibling topic files. Branch base: `main @ 52972ee` (v2.7.0).

## What's included
- **`--fix <file>` / `--fix-all` / `--fix-memory-md`** on `tracking_rotate.py`: conformance-first → cap-fix by class → conservation proof. Archive-only; backup-first; no interactive confirm; emits the `--check` plan + a conservation report.
- **`auto-memory-index` class** for `MEMORY.md`: cap 200 lines / 25 KB (whichever comes first; load-window advisory → WARN, never a hard gate); resolution via `${autoMemoryDirectory:-~/.claude/projects/<slug>/memory}/MEMORY.md`; lossless **relocation** of over-long entries to hot sibling topic files (`feedback_*.md`, `project_*.md`, …) leaving a one-line pointer; conservation proved over the union of `MEMORY.md ∪ memory/*.md`. Ships a `MEMORY.md` template and a lazy-loaded fix-procedure asset (thin-SKILL).
- **Conservation helper** (`scripts/conservation.py`): standalone, unit-testable; multiset (Counter)-based entry-ID and content proofs so a count reduction can never report "0 lost".
- **Section-scaffold preservation**: rotation (both `--fix` and the session-close `--apply`) fences an unfenced `## Entry Format` example before parsing, so the `## How to Use` / `## Entry Format` / `## Decisions` scaffold is preserved and rotated `### DEC-` entries stay under their `## Decisions` wrapper.
- **Collision safety** for `MEMORY.md` siblings: append-if-absent (idempotent), refuse-and-report on a same-slug/different-body collision (no silent merge).
- **task-tracker cap** raised to 60 lines / 4.5 KB (fits the front-matter + a usable body); non-rotatable registers route to archive-whole-verbatim under `--fix`.
- **`--fix-all` scope guard**: skips the auto-memory `MEMORY.md` by default (it resolves outside `--oversight-root`); pass `--include-memory-md` to include it.

## Safety
- **Prove-then-commit**: `--apply` computes the result and proves conservation before promoting; a conservation failure leaves the original file byte-identical.
- **Backup-first + atomic writes** on every mutation path; idempotent re-runs are no-ops.
- Conservation is multiset-based and proved programmatically (`lost == 0`).

## Testing
- 76 unit tests (conservation + skill), incl. forced-conservation-failure (original-intact), multiset count-loss, collision-refuse, unfenced-scaffold preservation under both `--fix` and `--apply`, `###`-entry log-shape detection, and idempotency.
- Live-verified end-to-end on realistic fixtures: over-cap rotation with conservation, `--apply` scaffold-fence on a legacy unfenced log, `MEMORY.md` relocation to siblings with union conservation, idempotent re-run, and the `--fix-all` auto-memory scope guard.
- Lint: `ruff` / `black` / `isort` clean on the CI scope (`src/ tests/`).

## CHANGELOG
Added under `[Unreleased]`.
