### PR TITLE
Gate ambient injection on absolute relevance; make NAME/HANDLE redaction precision-first

### DIFF
--- a/.claude/hooks/scripts/context_injection_tier2.py
+++ b/.claude/hooks/scripts/context_injection_tier2.py
@@ -50,6 +50,7 @@ except ImportError:
 from memory.injection import (
     InjectionSessionState,
     compute_adaptive_budget,
+    compute_relevance_signals,
     compute_topic_drift,
     format_injection_output,
     log_injection_event,
@@ -340,6 +341,44 @@ def main() -> int:
             _best_collection, config.injection_confidence_threshold
         )
 
+        # BUG-319 / BP-174 — absolute-relevance gate signals (shadow-first).
+        # Computed from the raw_score channel (search.py _attach_raw_cosine), NOT
+        # the banded best_score above. Emitted on EVERY turn (including the
+        # existing-gate skip turns below) as the calibration substrate. The gate
+        # only changes behavior when config.injection_absolute_gate_enabled is True
+        # (the flip), and even then can only ADD a skip — never force injection.
+        _relevance_signals = compute_relevance_signals(all_results, config)
+        logger.info(
+            "tier2_relevance_shadow",
+            extra={
+                "session_id": session_id,
+                "turn": state.turn_count,
+                "banded_best_score": round(best_score, 4),
+                "gate_enabled": config.injection_absolute_gate_enabled,
+                **_relevance_signals,
+            },
+        )
+        if emit_trace_event:
+            with contextlib.suppress(Exception):
+                emit_trace_event(
+                    event_type="relevance_gate_shadow",
+                    data={
+                        "input": f"banded_best={round(best_score, 4)} collection={_best_collection}"[
+                            :TRACE_CONTENT_MAX
+                        ],
+                        "output": json.dumps(_relevance_signals)[:TRACE_CONTENT_MAX],
+                        "metadata": {
+                            "gate_enabled": config.injection_absolute_gate_enabled,
+                            "banded_best_score": round(best_score, 4),
+                            **_relevance_signals,
+                        },
+                    },
+                    trace_id=_tier2_trace_id,
+                    session_id=session_id,
+                    project_id=project_name,
+                    tags=["injection", "tier2", "relevance_gate"],
+                )
+
         if best_score < config.injection_hard_floor:
             gating_mode = "hard_skip"
         elif best_score < _conf_threshold - 0.05:
@@ -380,6 +419,55 @@ def main() -> int:
                 skipped_confidence=True,
                 gating_mode=gating_mode,
                 collections_searched=collection_names,
+                relevance_signals=_relevance_signals,
+            )
+            state.save()
+            print(
+                json.dumps(
+                    {
+                        "hookSpecificOutput": {
+                            "hookEventName": "UserPromptSubmit",
+                            "additionalContext": "",
+                        }
+                    }
+                )
+            )
+            return 0
+
+        # BUG-319 / BP-174 — absolute-relevance gate (the flip). Runs AFTER the
+        # banded 4-tier gate, so it can only ADD a skip: when no candidate clears
+        # the absolute floor + margin (Q1/Q2) or the top item is over the
+        # freshness cap (Q4), suppress same-domain-off-topic / stale injection
+        # that the banded gate (top-1 pinned ~0.95) would have let through.
+        # Shadow-only until config.injection_absolute_gate_enabled is True.
+        if (
+            config.injection_absolute_gate_enabled
+            and not _relevance_signals["would_inject"]
+        ):
+            logger.info(
+                "tier2_relevance_skip",
+                extra={
+                    "session_id": session_id,
+                    "turn": state.turn_count,
+                    "banded_best_score": round(best_score, 4),
+                    **_relevance_signals,
+                },
+            )
+            log_injection_event(
+                tier=2,
+                trigger="UserPromptSubmit",
+                project=project_name,
+                session_id=session_id,
+                results_considered=len(all_results),
+                results_selected=0,
+                tokens_used=0,
+                budget=0,
+                audit_dir=config.audit_dir,
+                best_score=best_score,
+                skipped_confidence=True,
+                gating_mode="relevance_skip",
+                collections_searched=collection_names,
+                relevance_signals=_relevance_signals,
             )
             state.save()
             print(
@@ -402,6 +490,7 @@ def main() -> int:
             results=all_results,
             session_state={"topic_drift": drift},
             config=config,
+            best_raw_score=_relevance_signals["best_raw"],
         )
 
         # Soft gating: halve budget for marginal confidence (threshold-0.05 to threshold)
@@ -486,8 +575,16 @@ def main() -> int:
         if _tier2_fallback_reject is not None:
             _r = _tier2_fallback_reject
             _meta_budget = _greedy_meta.get("budget", 0)
-            _meta_tokens_used = _greedy_meta.get("tokens_used", 0)
-            _remaining = _meta_budget - _meta_tokens_used
+            # BUG-302 field semantics: prefer the reject-time `remaining` snapshot
+            # captured in the reject record (budget free when THIS candidate was
+            # evaluated, which is what triggered reason=budget_exceeded). Fall back
+            # to the post-loop budget - tokens_used only for legacy records that
+            # predate the snapshot. budget = total tier budget; tokens = size of
+            # the rejected candidate; remaining = free budget at reject time, so
+            # tokens > remaining makes the reject self-evident.
+            _remaining = _r.get("remaining")
+            if _remaining is None:
+                _remaining = _meta_budget - _greedy_meta.get("tokens_used", 0)
             _marker = (
                 f"# [tier-2 fallback: handoff-class result rejected "
                 f"reason={_r.get('reason')} tokens={_r.get('tokens')} "
@@ -522,6 +619,7 @@ def main() -> int:
             rejects=_greedy_meta.get("rejects"),
             fallback_signaled=_greedy_meta.get("fallback_signaled", False),
             per_source=_greedy_meta.get("per_source"),
+            relevance_signals=_relevance_signals,
         )
 
         # SPEC-021: context_retrieval span — retrieval pipeline complete

--- a/.claude/hooks/scripts/context_injection_tier2.py
+++ b/.claude/hooks/scripts/context_injection_tier2.py
@@ -204,6 +204,9 @@ def main() -> int:
                     "group_id": gid,
                     "limit": config.max_retrievals,
                     "fast_mode": True,
+                    # BUG-319: only the Tier-2 relevance gate consumes raw_score, so
+                    # the extra dense raw-cosine query is opt-in here (off elsewhere).
+                    "attach_raw_cosine": True,
                 }
                 if route.collection == COLLECTION_DISCUSSIONS:
                     search_kwargs["memory_type"] = [
@@ -485,12 +488,22 @@ def main() -> int:
         drift = compute_topic_drift(current_embedding, state.last_query_embedding)
 
         # Compute adaptive budget
+        # BUG-319 F-3 (PM #344): pass the raw-cosine best ONLY when a real dense
+        # signal exists. On the defer routes (code-patterns, best_raw == 0.0) the
+        # drift suppressor must not fire — 0.0 < floor would wrongly zero drift and
+        # shrink the budget (~181 fewer tokens on code-patterns + drift turns), a
+        # behavior change DEC-PM343-D8 forbids on that route. None preserves legacy
+        # (drift always additive) on deferred turns.
         budget = compute_adaptive_budget(
             best_score=best_score,
             results=all_results,
             session_state={"topic_drift": drift},
             config=config,
-            best_raw_score=_relevance_signals["best_raw"],
+            best_raw_score=(
+                _relevance_signals["best_raw"]
+                if _relevance_signals["has_dense_signal"]
+                else None
+            ),
         )
 
         # Soft gating: halve budget for marginal confidence (threshold-0.05 to threshold)

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -228,6 +228,14 @@ INJECTION_BUDGET_CEILING=1500
 # INJECTION_THRESHOLD_CONVENTIONS=0.65
 # INJECTION_THRESHOLD_CODE_PATTERNS=0.55
 # INJECTION_THRESHOLD_DISCUSSIONS=0.60
+# BUG-319 / BP-174 — absolute-relevance injection gate (raw cosine floor +
+# scale-free margin + freshness cap). Shadow-only until ENABLED=true; calibrate
+# the floor against the shadow histogram (same-domain baseline ~0.76) first.
+# INJECTION_ABSOLUTE_GATE_ENABLED=false
+# INJECTION_ABSOLUTE_FLOOR=0.5
+# INJECTION_MARGIN_MIN=0.05
+# INJECTION_FRESHNESS_MAX_AGE_DAYS=0
+# INJECTION_DRIFT_SUPPRESSOR_THRESHOLD=0.5
 
 # --- 4.4 Decay Scoring ---
 # Blend: 0.7 semantic + 0.3 temporal

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -229,13 +229,16 @@ INJECTION_BUDGET_CEILING=1500
 # INJECTION_THRESHOLD_CODE_PATTERNS=0.55
 # INJECTION_THRESHOLD_DISCUSSIONS=0.60
 # BUG-319 / BP-174 — absolute-relevance injection gate (raw cosine floor +
-# scale-free margin + freshness cap). Shadow-only until ENABLED=true; calibrate
-# the floor against the shadow histogram (same-domain baseline ~0.76) first.
-# INJECTION_ABSOLUTE_GATE_ENABLED=false
-# INJECTION_ABSOLUTE_FLOOR=0.5
-# INJECTION_MARGIN_MIN=0.05
-# INJECTION_FRESHNESS_MAX_AGE_DAYS=0
-# INJECTION_DRIFT_SUPPRESSOR_THRESHOLD=0.5
+# scale-free margin + freshness cap). ENABLED + CALIBRATED per DEC-PM343-D7
+# (live read-only sweep; see oversight calibration.md). Floor 0.76 splits the
+# off-topic raw ceiling (~0.754) from the on-topic cluster (>=0.760). Margin and
+# freshness are off (0) — non-discriminative in a single-domain store. The gate
+# defers (no skip) when the top results have no dense neighbor (best_raw == 0.0).
+INJECTION_ABSOLUTE_GATE_ENABLED=true
+INJECTION_ABSOLUTE_FLOOR=0.76
+INJECTION_MARGIN_MIN=0.0
+INJECTION_FRESHNESS_MAX_AGE_DAYS=0
+INJECTION_DRIFT_SUPPRESSOR_THRESHOLD=0.5
 
 # --- 4.4 Decay Scoring ---
 # Blend: 0.7 semantic + 0.3 temporal

--- a/src/memory/config.py
+++ b/src/memory/config.py
@@ -557,6 +557,88 @@ class MemoryConfig(BaseSettings):
     )
 
     # =========================================================================
+    # BUG-319 / BP-174 — Absolute-relevance injection gate (PM #343, PLAN-028 P2-2)
+    # -------------------------------------------------------------------------
+    # The per-collection thresholds above gate on the BANDED score, which on the
+    # hybrid_rrf_decay path is min-max-normalized to [0.5, 0.95] per result-set
+    # (search.py PLAN-013/DEC-062 block) — so top-1 is always ~0.95 and the gate
+    # can never skip same-domain-off-topic content (F-1). These fields drive a
+    # SEPARATE absolute-relevance gate that consumes the raw cosine signal
+    # (memory["raw_score"]) instead of the banded score, per BP-174 Q1/Q2/Q4.
+    #
+    # SHADOW-FIRST: when injection_absolute_gate_enabled is False (default), the
+    # tier-2 hook still COMPUTES and EMITS the raw-cosine / margin / freshness
+    # signals (observe-only) but does NOT change selection or skip behavior. The
+    # absolute floor must be CALIBRATED against the shadow histogram (the
+    # single-domain same-domain baseline is ~0.76 per the PM #343 findings) before
+    # flipping this to True. The margin gate (Q2) is scale-free and needs no
+    # calibration. The absolute gate can only ADD skips, never force an injection.
+    # =========================================================================
+
+    injection_absolute_gate_enabled: bool = Field(
+        default=False,
+        description=(
+            "Enable the BP-174 absolute-relevance injection gate (raw cosine "
+            "floor + scale-free top-1/top-2 margin + freshness cap). When False, "
+            "the signals are computed and emitted shadow-only (observe-only) and "
+            "do not change behavior. Flip to True only after calibrating "
+            "injection_absolute_floor against the shadow histogram (BUG-319 / "
+            "PLAN-028 P2-2)."
+        ),
+    )
+
+    injection_absolute_floor: float = Field(
+        default=0.5,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Absolute raw-cosine floor for the BP-174 relevance gate. A candidate "
+            "whose raw_score is below this is treated as off-topic. CALIBRATE from "
+            "the shadow histogram: the single-domain same-domain baseline is ~0.76, "
+            "so on-topic items sit above it and same-domain-off-topic below. "
+            "Conservative default 0.5 (BUG-319 Q2)."
+        ),
+    )
+
+    injection_margin_min: float = Field(
+        default=0.05,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Minimum scale-free top-1/top-2 raw-cosine margin for the BP-174 "
+            "relevance gate (Q2). A high top-1 with a tiny gap to top-2 is an "
+            "ambiguous/distractor retrieval regardless of the absolute number; "
+            "invariant to the baseline so it fires whether the neighborhood sits "
+            "at 0.5 or 0.95. Single-result sets bypass the margin check."
+        ),
+    )
+
+    injection_freshness_max_age_days: int = Field(
+        default=0,
+        ge=0,
+        le=3650,
+        description=(
+            "Absolute freshness cap (days) for the BP-174 relevance gate (Q4). "
+            "When > 0, a top-1 candidate older than this is gated out so stale "
+            "items cannot survive to top-1 (distinct from DECAY_* ranking, which "
+            "only reorders). 0 disables the cap. Age is read from the point's "
+            "stored_at payload field (BUG-319 F-2)."
+        ),
+    )
+
+    injection_drift_suppressor_threshold: float = Field(
+        default=0.5,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Topic-drift level above which drift acts as a SUPPRESSOR rather than "
+            "a budget amplifier when no above-floor candidate exists (BP-174 Q3 / "
+            "BUG-319 F-3). Only consulted when injection_absolute_gate_enabled is "
+            "True."
+        ),
+    )
+
+    # =========================================================================
     # v2.0.6 — Audit Trail (SPEC-002 Section 5.2)
     # =========================================================================
 

--- a/src/memory/config.py
+++ b/src/memory/config.py
@@ -566,50 +566,54 @@ class MemoryConfig(BaseSettings):
     # SEPARATE absolute-relevance gate that consumes the raw cosine signal
     # (memory["raw_score"]) instead of the banded score, per BP-174 Q1/Q2/Q4.
     #
-    # SHADOW-FIRST: when injection_absolute_gate_enabled is False (default), the
-    # tier-2 hook still COMPUTES and EMITS the raw-cosine / margin / freshness
-    # signals (observe-only) but does NOT change selection or skip behavior. The
-    # absolute floor must be CALIBRATED against the shadow histogram (the
-    # single-domain same-domain baseline is ~0.76 per the PM #343 findings) before
-    # flipping this to True. The margin gate (Q2) is scale-free and needs no
-    # calibration. The absolute gate can only ADD skips, never force an injection.
+    # CALIBRATED + ENABLED (DEC-PM343-D7, BUG-319): the floor below was derived
+    # from a read-only calibration sweep against the live store (group_id
+    # dev-ai-memory) — see oversight/audits/PM343-injection-correctness/
+    # calibration.md. The shadow channel (raw-cosine / margin / freshness signals)
+    # stays emitted every turn for future refinement. The absolute gate can only
+    # ADD skips, never force an injection (it runs strictly after the v2.7.0
+    # 4-tier per-collection banded gate).
     # =========================================================================
 
     injection_absolute_gate_enabled: bool = Field(
-        default=False,
+        default=True,
         description=(
             "Enable the BP-174 absolute-relevance injection gate (raw cosine "
-            "floor + scale-free top-1/top-2 margin + freshness cap). When False, "
-            "the signals are computed and emitted shadow-only (observe-only) and "
-            "do not change behavior. Flip to True only after calibrating "
-            "injection_absolute_floor against the shadow histogram (BUG-319 / "
-            "PLAN-028 P2-2)."
+            "floor + scale-free top-1/top-2 margin + freshness cap). ENABLED per "
+            "DEC-PM343-D7 after calibrating injection_absolute_floor against a live "
+            "read-only sweep (BUG-319 / PLAN-028 P2-2). When the top results carry "
+            "no dense-cosine neighbor (best_raw == 0.0, e.g. the code-patterns "
+            "route), the gate defers to the banded gate instead of skipping."
         ),
     )
 
     injection_absolute_floor: float = Field(
-        default=0.5,
+        default=0.76,
         ge=0.0,
         le=1.0,
         description=(
             "Absolute raw-cosine floor for the BP-174 relevance gate. A candidate "
-            "whose raw_score is below this is treated as off-topic. CALIBRATE from "
-            "the shadow histogram: the single-domain same-domain baseline is ~0.76, "
-            "so on-topic items sit above it and same-domain-off-topic below. "
-            "Conservative default 0.5 (BUG-319 Q2)."
+            "whose raw_score is below this is treated as off-topic. CALIBRATED "
+            "(DEC-PM343-D7): in the live single-domain store the off-topic raw "
+            "ceiling (cross- and same-domain) sits at ~0.754 and the on-topic "
+            "cluster at >=0.760, so 0.76 splits that gap — blocks 100% of swept "
+            "off-topic, admits the on-topic cluster. Only applied when a dense "
+            "signal exists (best_raw > 0.0)."
         ),
     )
 
     injection_margin_min: float = Field(
-        default=0.05,
+        default=0.0,
         ge=0.0,
         le=1.0,
         description=(
             "Minimum scale-free top-1/top-2 raw-cosine margin for the BP-174 "
-            "relevance gate (Q2). A high top-1 with a tiny gap to top-2 is an "
-            "ambiguous/distractor retrieval regardless of the absolute number; "
-            "invariant to the baseline so it fires whether the neighborhood sits "
-            "at 0.5 or 0.95. Single-result sets bypass the margin check."
+            "relevance gate (Q2). CALIBRATED to 0.0 (effectively off): in this "
+            "single-domain store adjacent dense neighbors are near-tied (on-topic "
+            "margins 0.0003-0.06, mean ~0.01), so any positive margin floor causes "
+            "broad false skips — the absolute floor carries the gate. Retained as a "
+            "knob for multi-domain deployments where it discriminates. Single-"
+            "result sets bypass the margin check."
         ),
     )
 
@@ -621,8 +625,12 @@ class MemoryConfig(BaseSettings):
             "Absolute freshness cap (days) for the BP-174 relevance gate (Q4). "
             "When > 0, a top-1 candidate older than this is gated out so stale "
             "items cannot survive to top-1 (distinct from DECAY_* ranking, which "
-            "only reorders). 0 disables the cap. Age is read from the point's "
-            "stored_at payload field (BUG-319 F-2)."
+            "only reorders). 0 disables the cap. CALIBRATED to 0 for v1 "
+            "(DEC-PM343-D7): the sweep found no clean age separation between on- "
+            "and off-topic top-1 (both spanned ~2-35 days), so a hard cap would "
+            "false-skip legitimately-relevant older content; recency is left to "
+            "DECAY_* ranking. Age is read from the point's stored_at payload "
+            "field (BUG-319 F-2)."
         ),
     )
 

--- a/src/memory/injection.py
+++ b/src/memory/injection.py
@@ -755,7 +755,11 @@ def compute_relevance_signals(
       - ``second_raw``: second-highest raw_score (0.0 if < 2 results)
       - ``margin``: ``best_raw - second_raw`` (scale-free top-1/top-2 gap, Q2)
       - ``top_age_days``: age of the top-ranked (banded) result, or None
-      - ``floor_pass``: ``best_raw >= injection_absolute_floor`` (Q2 floor)
+      - ``has_dense_signal``: ``best_raw > 0.0`` — False when no top result has a
+        dense neighbor (the floor is then deferred; BUG-319 calibration)
+      - ``floor_pass``: ``best_raw >= injection_absolute_floor`` (Q2 floor); True
+        when there is no dense signal (defer to banded gate), False when there are
+        no results at all
       - ``margin_pass``: ``margin >= injection_margin_min``; True for a lone result
       - ``freshness_pass``: top item within ``injection_freshness_max_age_days``;
         True when the cap is disabled or the age is unknown (Q4)
@@ -775,7 +779,23 @@ def compute_relevance_signals(
     # Top item is results[0] — the caller sorts by (penalized) banded score desc.
     top_age_days = _result_age_days(results[0], now=now) if results else None
 
-    floor_pass = best_raw >= config.injection_absolute_floor
+    # BUG-319 calibration (DEC-PM343-D7): the absolute floor is only meaningful
+    # when the top results have a real dense-cosine neighbor. On routes whose
+    # banded ranking is driven entirely by sparse/colbert/decay — so no top result
+    # appears in the dense neighborhood and best_raw collapses to 0.0 (empirically
+    # the code-patterns route, whose post-filter dense space is near-orthogonal to
+    # natural-language queries in this single-domain store; also any
+    # _attach_raw_cosine failure) — the dense floor cannot judge relevance, so it
+    # must NOT add a skip. Defer to the banded 4-tier gate (the degrade-gracefully
+    # intent documented on search.py _attach_raw_cosine). A genuinely empty result
+    # set still fails the floor: there is nothing to inject.
+    has_dense_signal = best_raw > 0.0
+    if not raw_scores:
+        floor_pass = False
+    elif not has_dense_signal:
+        floor_pass = True
+    else:
+        floor_pass = best_raw >= config.injection_absolute_floor
     margin_pass = (len(raw_scores) < 2) or (margin >= config.injection_margin_min)
     if config.injection_freshness_max_age_days > 0 and top_age_days is not None:
         freshness_pass = top_age_days <= config.injection_freshness_max_age_days
@@ -787,6 +807,7 @@ def compute_relevance_signals(
         "second_raw": round(second_raw, 4),
         "margin": round(margin, 4),
         "top_age_days": (round(top_age_days, 2) if top_age_days is not None else None),
+        "has_dense_signal": has_dense_signal,
         "floor_pass": floor_pass,
         "margin_pass": margin_pass,
         "freshness_pass": freshness_pass,

--- a/src/memory/injection.py
+++ b/src/memory/injection.py
@@ -70,6 +70,7 @@ __all__ = [
     "InjectionSessionState",
     "RouteTarget",
     "compute_adaptive_budget",
+    "compute_relevance_signals",
     "compute_topic_drift",
     "format_injection_output",
     "init_session_state",
@@ -711,11 +712,95 @@ def route_collections(
     return [RouteTarget(target)]
 
 
+def _result_age_days(result: dict, *, now: datetime | None = None) -> float | None:
+    """Age of a result in days from its ``stored_at`` payload field, or None.
+
+    BUG-319 F-2 / BP-174 Q4: the absolute staleness signal for the freshness
+    gate, distinct from DECAY_* ranking. ``stored_at`` is an ISO-8601 UTC
+    timestamp on the point payload. Returns None when absent or unparseable.
+    """
+    stored_at = result.get("stored_at")
+    if not stored_at:
+        return None
+    try:
+        if isinstance(stored_at, str):
+            dt = datetime.fromisoformat(stored_at.replace("Z", "+00:00"))
+        elif isinstance(stored_at, datetime):
+            dt = stored_at
+        else:
+            return None
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        _now = now or datetime.now(tz=timezone.utc)
+        return max((_now - dt).total_seconds() / 86400.0, 0.0)
+    except (ValueError, TypeError):
+        return None
+
+
+def compute_relevance_signals(
+    results: list[dict],
+    config: MemoryConfig,
+    *,
+    now: datetime | None = None,
+) -> dict:
+    """Compute the BP-174 absolute-relevance gate signals (BUG-319 F-1/F-2).
+
+    Consumes the absolute ``raw_score`` channel (search.py ``_attach_raw_cosine``),
+    NOT the banded ordering score — so the gate can discriminate on-topic from
+    same-domain-off-topic in a single-domain store where the banded top-1 is
+    pinned near 0.95 regardless of true similarity.
+
+    Returns a dict:
+      - ``best_raw``: highest raw_score across results (0.0 if none)
+      - ``second_raw``: second-highest raw_score (0.0 if < 2 results)
+      - ``margin``: ``best_raw - second_raw`` (scale-free top-1/top-2 gap, Q2)
+      - ``top_age_days``: age of the top-ranked (banded) result, or None
+      - ``floor_pass``: ``best_raw >= injection_absolute_floor`` (Q2 floor)
+      - ``margin_pass``: ``margin >= injection_margin_min``; True for a lone result
+      - ``freshness_pass``: top item within ``injection_freshness_max_age_days``;
+        True when the cap is disabled or the age is unknown (Q4)
+      - ``would_inject``: ``floor_pass and margin_pass and freshness_pass``
+
+    Pure and side-effect-free: the signals are computed regardless of whether the
+    gate is enabled, so the tier-2 hook can emit them shadow-only before the flip.
+    """
+    raw_scores = sorted(
+        (float(r.get("raw_score", 0.0) or 0.0) for r in results),
+        reverse=True,
+    )
+    best_raw = raw_scores[0] if raw_scores else 0.0
+    second_raw = raw_scores[1] if len(raw_scores) > 1 else 0.0
+    margin = best_raw - second_raw
+
+    # Top item is results[0] — the caller sorts by (penalized) banded score desc.
+    top_age_days = _result_age_days(results[0], now=now) if results else None
+
+    floor_pass = best_raw >= config.injection_absolute_floor
+    margin_pass = (len(raw_scores) < 2) or (margin >= config.injection_margin_min)
+    if config.injection_freshness_max_age_days > 0 and top_age_days is not None:
+        freshness_pass = top_age_days <= config.injection_freshness_max_age_days
+    else:
+        freshness_pass = True
+
+    return {
+        "best_raw": round(best_raw, 4),
+        "second_raw": round(second_raw, 4),
+        "margin": round(margin, 4),
+        "top_age_days": (round(top_age_days, 2) if top_age_days is not None else None),
+        "floor_pass": floor_pass,
+        "margin_pass": margin_pass,
+        "freshness_pass": freshness_pass,
+        "would_inject": floor_pass and margin_pass and freshness_pass,
+    }
+
+
 def compute_adaptive_budget(
     best_score: float,
     results: list[dict],
     session_state: dict,
     config: MemoryConfig,
+    *,
+    best_raw_score: float | None = None,
 ) -> int:
     """Compute adaptive token budget for Tier 2 injection.
 
@@ -729,6 +814,11 @@ def compute_adaptive_budget(
         results: All search results (for density calculation)
         session_state: Session state dict with last_query_embedding
         config: Memory configuration with budget floor/ceiling
+        best_raw_score: Highest absolute raw-cosine score (BUG-319 F-3). When the
+            absolute gate is enabled and no candidate clears the absolute floor,
+            topic drift must NOT amplify the budget (BP-174 Q3). Legacy behavior
+            (drift always additive) is preserved when this is None or the gate is
+            disabled.
 
     Returns:
         Token budget as integer in [floor, ceiling] range.
@@ -759,6 +849,21 @@ def compute_adaptive_budget(
     # Signal 3: Session drift (20%) — topic drift from previous query
     # High drift = new topic = more context needed = higher budget
     drift_signal = session_state.get("topic_drift", 0.5)  # Default 0.5 (neutral)
+
+    # BUG-319 F-3 / BP-174 Q3: topic drift is a SUPPRESSOR, not an amplifier.
+    # When the absolute gate is enabled and no candidate clears the absolute floor
+    # (the off-topic-pivot case), high drift must not buy MORE budget to surface
+    # nearest-neighbor noise — zero the drift contribution so amplification only
+    # happens behind an above-floor candidate. Below-floor turns are normally
+    # skipped outright by the relevance gate upstream; this guards the marginal
+    # path. Legacy behavior is preserved when the gate is off or raw score absent.
+    if (
+        config.injection_absolute_gate_enabled
+        and best_raw_score is not None
+        and best_raw_score < config.injection_absolute_floor
+        and drift_signal > config.injection_drift_suppressor_threshold
+    ):
+        drift_signal = 0.0
 
     # Weighted combination
     combined = (
@@ -907,16 +1012,27 @@ def select_results_greedy(
         nonlocal fallback_signaled
         result_type = result.get("type", "unknown")
         collection_label = result.get("collection", "unknown") or "unknown"
-        rejects.append(
-            {
-                "type": result_type,
-                "tokens": result_tokens,
-                "score": result.get("score", 0),
-                "reason": reason,
-                "tier": tier_label,
-                "collection": collection_label,
-            }
-        )
+        # BUG-302 field semantics (BP-158 amendment pending — see oversight):
+        #   budget    = total token budget for this tier's injection (constant)
+        #   tokens    = token size of THIS rejected candidate (result_tokens)
+        #   remaining = budget tokens still free at the instant this candidate was
+        #               evaluated (budget - tokens_used so far). A budget_exceeded
+        #               reject means tokens > remaining. Captured here at reject
+        #               time so the tier-2 marker renders the remaining that
+        #               actually triggered the reject, not the post-loop final
+        #               value (greedy skip-and-continue may load smaller items
+        #               afterwards, shrinking the final remaining).
+        _reject = {
+            "type": result_type,
+            "tokens": result_tokens,
+            "score": result.get("score", 0),
+            "reason": reason,
+            "tier": tier_label,
+            "collection": collection_label,
+        }
+        if reason in ("budget_exceeded", "ceiling_exceeded"):
+            _reject["remaining"] = budget - tokens_used
+        rejects.append(_reject)
         # Per-source ledger: accumulate dropped count (and tokens for budget drops).
         _ps = per_source.setdefault(
             collection_label,
@@ -1204,6 +1320,7 @@ def log_injection_event(
     rejects: list[dict] | None = None,
     fallback_signaled: bool = False,
     per_source: dict | None = None,
+    relevance_signals: dict | None = None,
 ) -> None:
     """Log injection event to .audit/logs/injection-log.jsonl.
 
@@ -1239,6 +1356,13 @@ def log_injection_event(
             ``{requested_tokens, loaded_tokens, dropped: {reason: {count, tokens?}}}``.
             Reconciliation: ``loaded_tokens + dropped["budget_exceeded"]["tokens"]
             == requested_tokens`` per collection. Defaults to empty dict.
+        relevance_signals: BP-174 absolute-relevance gate signals from
+            ``compute_relevance_signals`` (``{best_raw, second_raw, margin,
+            top_age_days, floor_pass, margin_pass, freshness_pass,
+            would_inject}``). Persisted as the shadow-calibration substrate for
+            BUG-319 — lets the absolute floor/margin be tuned against the
+            measured raw-cosine histogram before the gate is flipped on.
+            Defaults to empty dict.
     """
     log_path = Path(audit_dir) / "logs" / "injection-log.jsonl"
 
@@ -1262,6 +1386,7 @@ def log_injection_event(
         "rejects": rejects or [],
         "fallback_signaled": fallback_signaled,
         "per_source": per_source or {},
+        "relevance_signals": relevance_signals or {},
     }
 
     try:

--- a/src/memory/injection.py
+++ b/src/memory/injection.py
@@ -1059,7 +1059,7 @@ def select_results_greedy(
         nonlocal fallback_signaled
         result_type = result.get("type", "unknown")
         collection_label = result.get("collection", "unknown") or "unknown"
-        # BUG-302 field semantics (BP-158 amendment pending — see oversight):
+        # BUG-302 field semantics — budget=TOTAL, surface remaining (BP-158 §3.5 / DEC-PM334-D2):
         #   budget    = total token budget for this tier's injection (constant)
         #   tokens    = token size of THIS rejected candidate (result_tokens)
         #   remaining = budget tokens still free at the instant this candidate was

--- a/src/memory/injection.py
+++ b/src/memory/injection.py
@@ -750,57 +750,83 @@ def compute_relevance_signals(
     same-domain-off-topic in a single-domain store where the banded top-1 is
     pinned near 0.95 regardless of true similarity.
 
+    Reference point (PM #344 F3): the floor, margin, AND freshness signals all key
+    off ONE reference item — the highest-raw candidate across the set. Previously
+    the floor/margin used max-raw while freshness used the banded ``results[0]``,
+    which could be a different item (an unrelated stale banded-top-1 could suppress
+    a fresh, on-topic, above-floor candidate). Max-raw is the calibration-faithful
+    reference (the live sweep keyed the floor on the top dense-cosine item) and
+    keeps union routes dominated by the discussions signal (calibration.md §5).
+
     Returns a dict:
       - ``best_raw``: highest raw_score across results (0.0 if none)
       - ``second_raw``: second-highest raw_score (0.0 if < 2 results)
       - ``margin``: ``best_raw - second_raw`` (scale-free top-1/top-2 gap, Q2)
-      - ``top_age_days``: age of the top-ranked (banded) result, or None
-      - ``has_dense_signal``: ``best_raw > 0.0`` — False when no top result has a
-        dense neighbor (the floor is then deferred; BUG-319 calibration)
+      - ``top_age_days``: age of the highest-raw reference item, or None
+      - ``has_dense_signal``: ``best_raw > 0.0`` — False when no result has a dense
+        neighbor (the gate then fully defers to the banded gate; BUG-319 calibration)
       - ``floor_pass``: ``best_raw >= injection_absolute_floor`` (Q2 floor); True
-        when there is no dense signal (defer to banded gate), False when there are
-        no results at all
+        when there is no dense signal (defer), False when there are no results
       - ``margin_pass``: ``margin >= injection_margin_min``; True for a lone result
-      - ``freshness_pass``: top item within ``injection_freshness_max_age_days``;
-        True when the cap is disabled or the age is unknown (Q4)
-      - ``would_inject``: ``floor_pass and margin_pass and freshness_pass``
+        and True on the defer path
+      - ``freshness_pass``: reference item within ``injection_freshness_max_age_days``;
+        True when the cap is disabled, the age is unknown, or on the defer path (Q4)
+      - ``would_inject``: ``floor_pass and margin_pass and freshness_pass``. On the
+        defer path all three are forced True, so the banded gate alone decides.
 
     Pure and side-effect-free: the signals are computed regardless of whether the
     gate is enabled, so the tier-2 hook can emit them shadow-only before the flip.
     """
-    raw_scores = sorted(
-        (float(r.get("raw_score", 0.0) or 0.0) for r in results),
+    # Rank by raw_score desc, preserving item identity so the floor, margin, AND
+    # freshness signals all key off ONE reference item — the highest-raw candidate
+    # (PM #344 F3 reference-point consistency).
+    ranked = sorted(
+        results,
+        key=lambda r: float(r.get("raw_score", 0.0) or 0.0),
         reverse=True,
     )
-    best_raw = raw_scores[0] if raw_scores else 0.0
-    second_raw = raw_scores[1] if len(raw_scores) > 1 else 0.0
+    best_raw = float(ranked[0].get("raw_score", 0.0) or 0.0) if ranked else 0.0
+    second_raw = (
+        float(ranked[1].get("raw_score", 0.0) or 0.0) if len(ranked) > 1 else 0.0
+    )
     margin = best_raw - second_raw
 
-    # Top item is results[0] — the caller sorts by (penalized) banded score desc.
-    top_age_days = _result_age_days(results[0], now=now) if results else None
+    # Freshness keys off the SAME highest-raw reference item the floor/margin
+    # selected — not the banded results[0], which may be a different item.
+    reference_item = ranked[0] if ranked else None
+    top_age_days = _result_age_days(reference_item, now=now) if reference_item else None
 
-    # BUG-319 calibration (DEC-PM343-D7): the absolute floor is only meaningful
-    # when the top results have a real dense-cosine neighbor. On routes whose
-    # banded ranking is driven entirely by sparse/colbert/decay — so no top result
-    # appears in the dense neighborhood and best_raw collapses to 0.0 (empirically
-    # the code-patterns route, whose post-filter dense space is near-orthogonal to
-    # natural-language queries in this single-domain store; also any
-    # _attach_raw_cosine failure) — the dense floor cannot judge relevance, so it
-    # must NOT add a skip. Defer to the banded 4-tier gate (the degrade-gracefully
-    # intent documented on search.py _attach_raw_cosine). A genuinely empty result
-    # set still fails the floor: there is nothing to inject.
+    # has_dense_signal conflates "no dense neighbor" with a genuine ~0.0 off-topic
+    # cosine (PM #344 F7); acceptable here because real off-topic clusters sit at
+    # ~0.65-0.75, not 0.0, so a true 0.0 means "absent from the dense top-K".
     has_dense_signal = best_raw > 0.0
-    if not raw_scores:
+    if not ranked:
+        # Empty result set: nothing to inject — fail the floor (and the gate).
         floor_pass = False
+        margin_pass = True
+        freshness_pass = True
     elif not has_dense_signal:
+        # BUG-319 calibration (DEC-PM343-D7) + PM #344 F1: on routes whose banded
+        # ranking is driven entirely by sparse/colbert/decay — so no result appears
+        # in the dense neighborhood and best_raw collapses to 0.0 (empirically the
+        # code-patterns route, whose post-filter dense space is near-orthogonal to
+        # natural-language queries in this single-domain store; also any
+        # _attach_raw_cosine failure) — the dense floor cannot judge relevance.
+        # FULLY defer to the banded 4-tier gate: short-circuit floor, margin AND
+        # freshness, not just the floor. Deferring only the floor would let a
+        # multi-domain injection_margin_min > 0 (margin is 0.0 on the all-zero-raw
+        # defer set) or a freshness cap silently suppress every deferred injection —
+        # the regression this guard exists to prevent.
         floor_pass = True
+        margin_pass = True
+        freshness_pass = True
     else:
         floor_pass = best_raw >= config.injection_absolute_floor
-    margin_pass = (len(raw_scores) < 2) or (margin >= config.injection_margin_min)
-    if config.injection_freshness_max_age_days > 0 and top_age_days is not None:
-        freshness_pass = top_age_days <= config.injection_freshness_max_age_days
-    else:
-        freshness_pass = True
+        margin_pass = (len(ranked) < 2) or (margin >= config.injection_margin_min)
+        if config.injection_freshness_max_age_days > 0 and top_age_days is not None:
+            freshness_pass = top_age_days <= config.injection_freshness_max_age_days
+        else:
+            freshness_pass = True
 
     return {
         "best_raw": round(best_raw, 4),

--- a/src/memory/search.py
+++ b/src/memory/search.py
@@ -212,6 +212,7 @@ class MemorySearch:
         _access_count_dedup: (
             list[str] | None
         ) = None,  # H-3: Cross-turn dedup list (mutated in-place)
+        attach_raw_cosine: bool = False,  # BUG-319: opt-in raw-cosine channel (tier-2 gate only)
     ) -> list[dict]:
         """Search for relevant memories using semantic similarity with project scoping.
 
@@ -241,6 +242,11 @@ class MemorySearch:
                       If False (default), use hnsw_ef=128 for accuracy (user searches).
             source: Optional namespace filter (e.g., "github"). When set to "github",
                    also applies is_current=True filter to exclude superseded points (BP-074).
+            attach_raw_cosine: When True, attach an absolute raw-cosine ``raw_score``
+                   to each result (BUG-319). Only the Tier-2 injection relevance gate
+                   consumes raw_score; it defaults to False so every other caller
+                   (aim-search, Tier-1, programmatic) avoids the extra dense query
+                   the hybrid/decay path would otherwise fire per search.
 
         Returns:
             List of memory dicts with score, id, and all payload fields.
@@ -675,15 +681,18 @@ class MemorySearch:
         # BUG-319 / BP-174 Q1: attach an absolute raw-cosine signal alongside the
         # (possibly banded) ordering score so the injection relevance gate can
         # discriminate on-topic from same-domain-off-topic. raw_score never feeds
-        # ordering — only the gate.
-        self._attach_raw_cosine(
-            memories,
-            search_mode=_search_mode,
-            collection=collection,
-            query_embedding=query_embedding,
-            query_filter=query_filter,
-            search_params=search_params,
-        )
+        # ordering — only the gate. Opt-in (default off): only the Tier-2 hook sets
+        # attach_raw_cosine=True, so other callers don't pay the extra dense query
+        # the hybrid/decay path fires here.
+        if attach_raw_cosine:
+            self._attach_raw_cosine(
+                memories,
+                search_mode=_search_mode,
+                collection=collection,
+                query_embedding=query_embedding,
+                query_filter=query_filter,
+                search_params=search_params,
+            )
 
         # Tag results with search mode for downstream observability
         for m in memories:

--- a/src/memory/search.py
+++ b/src/memory/search.py
@@ -672,6 +672,19 @@ class MemorySearch:
                         m["collection"], m["type"], m["score"]
                     )
 
+        # BUG-319 / BP-174 Q1: attach an absolute raw-cosine signal alongside the
+        # (possibly banded) ordering score so the injection relevance gate can
+        # discriminate on-topic from same-domain-off-topic. raw_score never feeds
+        # ordering — only the gate.
+        self._attach_raw_cosine(
+            memories,
+            search_mode=_search_mode,
+            collection=collection,
+            query_embedding=query_embedding,
+            query_filter=query_filter,
+            search_params=search_params,
+        )
+
         # Tag results with search mode for downstream observability
         for m in memories:
             m["search_mode"] = _search_mode
@@ -884,6 +897,62 @@ class MemorySearch:
             pass  # Remembrance protection failure must never affect search results
 
         return memories
+
+    def _attach_raw_cosine(
+        self,
+        memories: list[dict],
+        *,
+        search_mode: str,
+        collection: str,
+        query_embedding: list[float],
+        query_filter: Filter | None,
+        search_params: SearchParams | None,
+    ) -> None:
+        """Attach an absolute raw-cosine relevance signal to each memory.
+
+        BUG-319 / BP-174 Q1: the banded score on the hybrid_rrf_decay path is a
+        per-result-set rank-normalization artifact (top-1 pinned near 0.95), NOT
+        an absolute relevance measure. The injection relevance gate must consume
+        an absolute cosine signal kept SEPARATE from the banded score (which is
+        retained for ordering/display only). This sets ``memory["raw_score"]`` to
+        the dense cosine similarity of the query against each result.
+
+        - Plain ``dense`` mode already returns cosine in ``score`` → copy it.
+        - ``hybrid_*`` / ``decay`` modes return RRF (rank-only) or decay-adjusted
+          scores → run one bounded dense query (reusing the query embedding, no
+          re-embed) and map cosine by point id. Results absent from the dense
+          neighborhood get ``raw_score`` 0.0 (correct gating semantics: a
+          top-by-RRF/sparse item with no dense neighbor is weakly relevant).
+
+        No score_threshold is applied to the raw query so below-threshold cosines
+        are still measured honestly for the floor/margin computation. Failures
+        degrade gracefully (raw_score 0.0) — the gate falls back to the banded
+        score path and never raises into the search hot path.
+        """
+        if not memories:
+            return
+        if search_mode == "dense":
+            for m in memories:
+                m["raw_score"] = m.get("score", 0.0)
+            return
+        raw_by_id: dict = {}
+        try:
+            resp = self.client.query_points(
+                collection_name=collection,
+                query=query_embedding,
+                query_filter=query_filter,
+                limit=max(len(memories), 50),
+                with_payload=False,
+                search_params=search_params,
+            )
+            raw_by_id = {p.id: p.score for p in resp.points}
+        except Exception as e:
+            logger.warning(
+                "raw_cosine_attach_failed",
+                extra={"collection": collection, "error": str(e)},
+            )
+        for m in memories:
+            m["raw_score"] = raw_by_id.get(m["id"], 0.0)
 
     def _build_hybrid_prefetch(
         self,

--- a/src/memory/security_scanner.py
+++ b/src/memory/security_scanner.py
@@ -336,6 +336,10 @@ _TECHNICAL_PROPER_NOUNS = frozenset(
         "numpy",
         "terraform",
         "tesla",
+        "apache",
+        "celery",
+        "django",
+        "flask",
     }
 )
 
@@ -423,10 +427,11 @@ def _line_containing(content: str, start: int, end: int) -> str:
 _GIT_DIFF_FILE_HEADER = re.compile(r"^[+-]{3} [ab]/")
 
 # Git unified-diff "index <old>..<new> <mode>" metadata line. Anchored to the
-# blob-sha "<hex>..<hex>" form so a prose line that merely starts with "index "
-# ("index 42: contact John Smith about this") is NOT treated as structural and
-# can still be decided by PII context.
-_GIT_INDEX_LINE = re.compile(r"^index [0-9a-f]{4,}\.\.[0-9a-f]{4,}")
+# blob-sha "<hex>..<hex>" form with optional trailing octal mode bits, then
+# end-of-line, so a crafted line that shares a valid hex prefix but carries
+# trailing prose ("index deadbeef..feedface contact John Smith") is NOT treated
+# as structural and can be decided by PII context.
+_GIT_INDEX_LINE = re.compile(r"^index [0-9a-f]{4,}\.\.[0-9a-f]{4,}( [0-7]{6})?$")
 
 
 def _is_structural_line(

--- a/src/memory/security_scanner.py
+++ b/src/memory/security_scanner.py
@@ -90,7 +90,10 @@ class ScanFinding:
     finding_type: FindingType
     layer: int  # 1=regex, 2=detect-secrets, 3=SpaCy
     original_text: str  # For logging only — NOT stored in Qdrant
-    replacement: str | None  # Masked replacement (None if BLOCK)
+    # Masked replacement, or None when the finding is recorded but not masked:
+    # None for BLOCKED secrets and for low-precision NAME/HANDLE candidates that
+    # the precision gate (BUG-320) clears so stored content is preserved.
+    replacement: str | None
     confidence: float  # 0.0-1.0
     start: int  # Character offset
     end: int  # Character offset
@@ -322,26 +325,17 @@ _TECHNICAL_PROPER_NOUNS = frozenset(
     }
 )
 
-# Personal-data context cues; at least one must appear near a NAME candidate
-# (within _PII_CONTEXT_WINDOW chars) for it to be treated as genuine PII.
+# Personal-data context cues. A NAME candidate is treated as genuine PII only
+# when one of these is ADJACENT to it (the word immediately before or after the
+# candidate — see _has_pii_context). H-A: the set is curated to HIGH-PRECISION
+# cues only. Code-ubiquitous words (name, client, manager, person, customer,
+# employee, called, met, …) are deliberately EXCLUDED — they mis-fired on
+# technical content ("Kafka client", "Grafana manager") and re-admitted the
+# BUG-320 corruption. M-C: gerund/inflected forms of the retained verb families
+# (contact/call/meet/message/reach/phone) are included.
 _PII_CONTEXT_TRIGGERS = frozenset(
     {
-        "name",
-        "named",
-        "contact",
-        "contacted",
-        "email",
-        "emailed",
-        "phone",
-        "phoned",
-        "tel",
-        "mobile",
-        "person",
-        "customer",
-        "client",
-        "employee",
-        "manager",
-        "patient",
+        # honorifics
         "mr",
         "mrs",
         "ms",
@@ -350,17 +344,33 @@ _PII_CONTEXT_TRIGGERS = frozenset(
         "prof",
         "sir",
         "madam",
+        # correspondence / sign-off
         "dear",
         "regards",
         "sincerely",
         "signed",
         "wrote",
-        "spoke",
-        "called",
-        "met",
+        # contact-info nouns
+        "phone",
+        "tel",
+        "email",
+        # contact/communication verb families + inflected forms (M-C)
+        "contact",
+        "contacted",
+        "contacting",
+        "call",
+        "calling",
+        "meet",
+        "meeting",
+        "message",
+        "messaging",
+        "reach",
+        "reaching",
+        "phoned",
+        "phoning",
+        "emailed",
     }
 )
-_PII_CONTEXT_WINDOW = 40
 
 # Code-identifier / structural markers in a candidate token that mean it is not a
 # personal name (underscores, digits, brackets, path/format separators).
@@ -377,39 +387,69 @@ def _line_containing(content: str, start: int, end: int) -> str:
     return content[line_start:line_end]
 
 
-def _is_structural_line(content: str, start: int, end: int) -> bool:
-    """True if the candidate sits on a diff hunk header, markdown heading, or
-    code-comment line — categorically not personal data."""
+# Git unified-diff file-header lines, e.g. "--- a/foo.py" / "+++ b/foo.py".
+# Anchored to the "[ab]/" form (H-B/M-B) so an email/Jira reply header such as
+# "--- John Smith wrote:" is NOT treated as structural.
+_GIT_DIFF_FILE_HEADER = re.compile(r"^[+-]{3} [ab]/")
+
+
+def _is_structural_line(
+    content: str, start: int, end: int, *, for_name: bool = False
+) -> bool:
+    """True if the candidate sits on a diff hunk header or diff-metadata line —
+    categorically not personal data.
+
+    for_name: when True (NAME candidates), a markdown heading / "#"-comment line
+    is NOT treated as structural — a heading can legitimately carry a real name
+    (e.g. "# Contact: Jane Doe"), so NAME masking is decided by PII context
+    instead (M-B). For HANDLE candidates (for_name=False) the "#"-heading
+    exemption is retained (intentional behavior, tested downstream).
+    """
     line = _line_containing(content, start, end)
-    if "@@" in line:  # diff hunk header, e.g. "@@ -205,7 +205,9 @@"
-        return True
-    # markdown heading / "#"-style code comment, or a diff metadata line
     stripped = line.lstrip()
-    return stripped.startswith(("#", "diff --git", "index ", "+++ ", "--- "))
+    if stripped.startswith("@@"):  # diff hunk header, e.g. "@@ -205,7 +205,9 @@"
+        return True
+    if stripped.startswith(("diff --git", "index ")):
+        return True
+    if _GIT_DIFF_FILE_HEADER.match(stripped):
+        return True
+    # markdown heading / "#"-comment: structural for HANDLE only, not NAME (M-B)
+    return not for_name and stripped.startswith("#")
 
 
 def _is_technical_token(text: str) -> bool:
-    """True if the candidate text is a filename, ALLCAPS doc name, path, or code
-    identifier rather than a personal name."""
+    """True if the candidate text is a filename, path, or code identifier rather
+    than a personal name. These are HARD signals (a name never contains them).
+
+    The ALLCAPS rule is deliberately NOT here — ALLCAPS is a weak signal that
+    PII context must be able to override (M-A: "contact JOHN SMITH urgently"),
+    so it is handled separately in _should_mask_low_precision_pii."""
     t = text.strip()
     if not t:
         return True
     if _FILE_EXTENSION.search(t):  # CLAUDE.md, foo.py
         return True
-    if t.isupper() and len(t) > 1:  # ALLCAPS doc filename / acronym
-        return True
     # underscores, digits, brackets, path/format separators
     return bool(_CODE_IDENTIFIER_CHARS.search(t))
 
 
+def _is_allcaps_token(text: str) -> bool:
+    """True if the candidate is an ALLCAPS run (doc filename / acronym, e.g.
+    README, AGENTS). Weak signal — see M-A handling in the predicate."""
+    t = text.strip()
+    return t.isupper() and len(t) > 1
+
+
 def _has_pii_context(content: str, start: int, end: int) -> bool:
-    """True if a personal-data cue appears within _PII_CONTEXT_WINDOW chars of the
-    candidate span."""
-    window_start = max(0, start - _PII_CONTEXT_WINDOW)
-    window_end = min(len(content), end + _PII_CONTEXT_WINDOW)
-    window = content[window_start:start] + " " + content[end:window_end]
-    tokens = set(re.findall(r"[a-z]+", window.lower()))
-    return bool(tokens & _PII_CONTEXT_TRIGGERS)
+    """True if a personal-data cue is ADJACENT to the candidate span — the word
+    immediately before it (honorific/verb) or immediately after it (e.g. a
+    "wrote"/sign-off cue). Adjacency is far higher precision than the previous
+    40-char window, which mis-fired on incidental nearby words (H-A)."""
+    before = re.findall(r"[A-Za-z]+", content[:start])
+    after = re.findall(r"[A-Za-z]+", content[end:])
+    preceding = before[-1].lower() if before else ""
+    following = after[0].lower() if after else ""
+    return preceding in _PII_CONTEXT_TRIGGERS or following in _PII_CONTEXT_TRIGGERS
 
 
 def _should_mask_low_precision_pii(content: str, finding: "ScanFinding") -> bool:
@@ -421,13 +461,22 @@ def _should_mask_low_precision_pii(content: str, finding: "ScanFinding") -> bool
     text = finding.original_text
 
     if finding.finding_type == FindingType.PII_NAME:
+        # L-C: the allow-list wins over PII context by design (BP-174 Q5) — a
+        # known technical proper noun ("Claude") is never masked even with an
+        # adjacent cue, since the false-positive cost outweighs the rare miss.
         if text.strip().lower() in _TECHNICAL_PROPER_NOUNS:
             return False
+        if _is_structural_line(content, finding.start, finding.end, for_name=True):
+            return False
+        # Hard technical signals (filename / code identifier) always veto.
         if _is_technical_token(text):
             return False
-        if _is_structural_line(content, finding.start, finding.end):
+        # M-A: ALLCAPS is a weak signal — it vetoes only when no PII context is
+        # present, so "contact JOHN SMITH urgently" still masks.
+        has_context = _has_pii_context(content, finding.start, finding.end)
+        if _is_allcaps_token(text) and not has_context:
             return False
-        return _has_pii_context(content, finding.start, finding.end)
+        return has_context
 
     if finding.finding_type == FindingType.PII_HANDLE:
         # Structural exclusion only: a handle on a diff/heading/comment line is
@@ -792,6 +841,10 @@ class SecurityScanner:
                 in (FindingType.PII_NAME, FindingType.PII_HANDLE)
                 and not _should_mask_low_precision_pii(content, finding)
             ):
+                # Mutates the finding in place: `findings` is the same list that
+                # is returned on ScanResult.findings, so the cleared replacement
+                # is intentionally visible to callers (observability — the
+                # candidate is still surfaced, just not masked into content).
                 finding.replacement = None
         pii_findings = [f for f in findings if f.replacement is not None]
         pii_findings.sort(key=lambda f: f.start, reverse=True)

--- a/src/memory/security_scanner.py
+++ b/src/memory/security_scanner.py
@@ -322,17 +322,34 @@ _TECHNICAL_PROPER_NOUNS = frozenset(
         "black",
         "isort",
         "parzival",
+        "kafka",
+        "jenkins",
+        "cassandra",
+        "watson",
+        "maven",
+        "pinecone",
+        "splunk",
+        "datadog",
+        "webpack",
+        "ansible",
+        "pandas",
+        "numpy",
+        "terraform",
+        "tesla",
     }
 )
 
 # Personal-data context cues. A NAME candidate is treated as genuine PII only
 # when one of these is ADJACENT to it (the word immediately before or after the
-# candidate — see _has_pii_context). H-A: the set is curated to HIGH-PRECISION
-# cues only. Code-ubiquitous words (name, client, manager, person, customer,
+# candidate — see _has_pii_context). The set is curated to HIGH-PRECISION cues
+# only. Code-ubiquitous words (name, client, manager, person, customer,
 # employee, called, met, …) are deliberately EXCLUDED — they mis-fired on
 # technical content ("Kafka client", "Grafana manager") and re-admitted the
-# BUG-320 corruption. M-C: gerund/inflected forms of the retained verb families
-# (contact/call/meet/message/reach/phone) are included.
+# BUG-320 corruption.
+#
+# Strong cues mask regardless of candidate shape: honorifics, correspondence /
+# sign-off cues, and contact-info label nouns are rarely adjacent to a lone
+# capitalized technical token.
 _PII_CONTEXT_TRIGGERS = frozenset(
     {
         # honorifics
@@ -354,21 +371,34 @@ _PII_CONTEXT_TRIGGERS = frozenset(
         "phone",
         "tel",
         "email",
-        # contact/communication verb families + inflected forms (M-C)
+    }
+)
+
+# High-ambiguity communication-verb cues. These double as common verbs/nouns in
+# technical prose ("contacting the service", "calling the API", "reaching the
+# broker"), so on their own they over-mask adjacent single-token technical names
+# that SpaCy mis-tags PERSON (BUG-320). They mask ONLY when the candidate is a
+# multi-token name (e.g. "John Smith") — a lone capitalized technical token
+# ("Kafka", "Watson", "Cassandra") never matches. This is the BP-174 Q5 /
+# DEC-PM343-D5 precision-first tradeoff: under-masking a bare "call Bob" is the
+# accepted cost of never corrupting technical content (off-write-path recall
+# recovery is deferred to TD-661). The bare noun/verb forms that collide with
+# multi-token names too ("call"/"meet"/"meeting"/"reach"/"message") are dropped
+# entirely; only the unambiguous gerund/inflected forms are retained. "from"
+# covers "From:" reply headers (GitHub/Jira threads) without firing on Python
+# "from x import" (single-token, lowercase, not PERSON-tagged).
+_PII_CONTEXT_VERB_TRIGGERS = frozenset(
+    {
         "contact",
         "contacted",
         "contacting",
-        "call",
         "calling",
-        "meet",
-        "meeting",
-        "message",
         "messaging",
-        "reach",
         "reaching",
         "phoned",
         "phoning",
         "emailed",
+        "from",
     }
 )
 
@@ -392,6 +422,12 @@ def _line_containing(content: str, start: int, end: int) -> str:
 # "--- John Smith wrote:" is NOT treated as structural.
 _GIT_DIFF_FILE_HEADER = re.compile(r"^[+-]{3} [ab]/")
 
+# Git unified-diff "index <old>..<new> <mode>" metadata line. Anchored to the
+# blob-sha "<hex>..<hex>" form so a prose line that merely starts with "index "
+# ("index 42: contact John Smith about this") is NOT treated as structural and
+# can still be decided by PII context.
+_GIT_INDEX_LINE = re.compile(r"^index [0-9a-f]{4,}\.\.[0-9a-f]{4,}")
+
 
 def _is_structural_line(
     content: str, start: int, end: int, *, for_name: bool = False
@@ -409,7 +445,9 @@ def _is_structural_line(
     stripped = line.lstrip()
     if stripped.startswith("@@"):  # diff hunk header, e.g. "@@ -205,7 +205,9 @@"
         return True
-    if stripped.startswith(("diff --git", "index ")):
+    if stripped.startswith("diff --git"):
+        return True
+    if _GIT_INDEX_LINE.match(stripped):
         return True
     if _GIT_DIFF_FILE_HEADER.match(stripped):
         return True
@@ -440,16 +478,28 @@ def _is_allcaps_token(text: str) -> bool:
     return t.isupper() and len(t) > 1
 
 
-def _has_pii_context(content: str, start: int, end: int) -> bool:
+def _has_pii_context(content: str, start: int, end: int, candidate: str) -> bool:
     """True if a personal-data cue is ADJACENT to the candidate span — the word
     immediately before it (honorific/verb) or immediately after it (e.g. a
     "wrote"/sign-off cue). Adjacency is far higher precision than the previous
-    40-char window, which mis-fired on incidental nearby words (H-A)."""
+    40-char window, which mis-fired on incidental nearby words (H-A).
+
+    A strong cue (_PII_CONTEXT_TRIGGERS) masks any candidate. A high-ambiguity
+    communication-verb cue (_PII_CONTEXT_VERB_TRIGGERS) masks only when the
+    candidate is a multi-token name ("John Smith"), so a lone technical token
+    next to "calling"/"contacting"/"reaching" is never corrupted (BUG-320)."""
     before = re.findall(r"[A-Za-z]+", content[:start])
     after = re.findall(r"[A-Za-z]+", content[end:])
     preceding = before[-1].lower() if before else ""
     following = after[0].lower() if after else ""
-    return preceding in _PII_CONTEXT_TRIGGERS or following in _PII_CONTEXT_TRIGGERS
+    if preceding in _PII_CONTEXT_TRIGGERS or following in _PII_CONTEXT_TRIGGERS:
+        return True
+    if (
+        preceding in _PII_CONTEXT_VERB_TRIGGERS
+        or following in _PII_CONTEXT_VERB_TRIGGERS
+    ):
+        return len(candidate.split()) >= 2
+    return False
 
 
 def _should_mask_low_precision_pii(content: str, finding: "ScanFinding") -> bool:
@@ -473,7 +523,7 @@ def _should_mask_low_precision_pii(content: str, finding: "ScanFinding") -> bool
             return False
         # M-A: ALLCAPS is a weak signal — it vetoes only when no PII context is
         # present, so "contact JOHN SMITH urgently" still masks.
-        has_context = _has_pii_context(content, finding.start, finding.end)
+        has_context = _has_pii_context(content, finding.start, finding.end, text)
         if _is_allcaps_token(text) and not has_context:
             return False
         return has_context

--- a/src/memory/security_scanner.py
+++ b/src/memory/security_scanner.py
@@ -261,6 +261,184 @@ def _is_github_id_context(content: str, start: int, end: int) -> bool:
     return any(re.search(pattern + r"$", prefix_window) for pattern in safe_prefixes)
 
 
+# =============================================================================
+# BUG-320 / BP-174 Q5: precision controls for low-precision PII recognizers
+# =============================================================================
+# The NAME (SpaCy PERSON -> [NAME_REDACTED]) and HANDLE (@handle regex ->
+# [HANDLE_REDACTED]) recognizers have high false-positive rates on technical
+# proper nouns, filenames, code identifiers, and markup (SpaCy tags "Docker" and
+# diff hunk headers as PERSON). Because masking runs DESTRUCTIVELY on the
+# storage-write path, every false positive permanently corrupts the stored point
+# and is later injected as garbled text. These two classes are therefore made
+# precision-first: an allow-listed technical token, a structural/technical
+# pattern, or a NAME with no nearby PII context is left UNMASKED — the finding is
+# still recorded (observability) but its replacement is cleared so content is
+# preserved.
+#
+# Placement note (BP-174 Q5 #5): fully relocating this masking off the write path
+# (detect-at-read, or unredacted-canonical + redacted view) spans the storage and
+# read paths and is out of scope for this change (security_scanner.py only); it is
+# tracked separately. High-precision classes (EMAIL/IP/CC/SSN and all SECRET_*
+# blocking) are never routed through this gate and stay strict (CLAUDE.md §7 /
+# TD-548).
+
+# Known technical proper nouns / product / tool names SpaCy PERSON NER commonly
+# mis-tags. Compared case-insensitively against the candidate span text.
+_TECHNICAL_PROPER_NOUNS = frozenset(
+    {
+        "claude",
+        "claude code",
+        "anthropic",
+        "docker",
+        "qdrant",
+        "jina",
+        "langfuse",
+        "prometheus",
+        "grafana",
+        "github",
+        "gitlab",
+        "jira",
+        "confluence",
+        "presidio",
+        "spacy",
+        "python",
+        "markdown",
+        "kubernetes",
+        "redis",
+        "postgres",
+        "postgresql",
+        "nginx",
+        "ubuntu",
+        "linux",
+        "bash",
+        "slack",
+        "openai",
+        "ollama",
+        "pytest",
+        "ruff",
+        "black",
+        "isort",
+        "parzival",
+    }
+)
+
+# Personal-data context cues; at least one must appear near a NAME candidate
+# (within _PII_CONTEXT_WINDOW chars) for it to be treated as genuine PII.
+_PII_CONTEXT_TRIGGERS = frozenset(
+    {
+        "name",
+        "named",
+        "contact",
+        "contacted",
+        "email",
+        "emailed",
+        "phone",
+        "phoned",
+        "tel",
+        "mobile",
+        "person",
+        "customer",
+        "client",
+        "employee",
+        "manager",
+        "patient",
+        "mr",
+        "mrs",
+        "ms",
+        "miss",
+        "dr",
+        "prof",
+        "sir",
+        "madam",
+        "dear",
+        "regards",
+        "sincerely",
+        "signed",
+        "wrote",
+        "spoke",
+        "called",
+        "met",
+    }
+)
+_PII_CONTEXT_WINDOW = 40
+
+# Code-identifier / structural markers in a candidate token that mean it is not a
+# personal name (underscores, digits, brackets, path/format separators).
+_CODE_IDENTIFIER_CHARS = re.compile(r"[_/\\()\[\]{}<>:=@]|\d")
+_FILE_EXTENSION = re.compile(r"\.[A-Za-z0-9]{1,8}$")
+
+
+def _line_containing(content: str, start: int, end: int) -> str:
+    """Return the full line of `content` that contains the [start:end] span."""
+    line_start = content.rfind("\n", 0, start) + 1
+    line_end = content.find("\n", end)
+    if line_end == -1:
+        line_end = len(content)
+    return content[line_start:line_end]
+
+
+def _is_structural_line(content: str, start: int, end: int) -> bool:
+    """True if the candidate sits on a diff hunk header, markdown heading, or
+    code-comment line — categorically not personal data."""
+    line = _line_containing(content, start, end)
+    if "@@" in line:  # diff hunk header, e.g. "@@ -205,7 +205,9 @@"
+        return True
+    # markdown heading / "#"-style code comment, or a diff metadata line
+    stripped = line.lstrip()
+    return stripped.startswith(("#", "diff --git", "index ", "+++ ", "--- "))
+
+
+def _is_technical_token(text: str) -> bool:
+    """True if the candidate text is a filename, ALLCAPS doc name, path, or code
+    identifier rather than a personal name."""
+    t = text.strip()
+    if not t:
+        return True
+    if _FILE_EXTENSION.search(t):  # CLAUDE.md, foo.py
+        return True
+    if t.isupper() and len(t) > 1:  # ALLCAPS doc filename / acronym
+        return True
+    # underscores, digits, brackets, path/format separators
+    return bool(_CODE_IDENTIFIER_CHARS.search(t))
+
+
+def _has_pii_context(content: str, start: int, end: int) -> bool:
+    """True if a personal-data cue appears within _PII_CONTEXT_WINDOW chars of the
+    candidate span."""
+    window_start = max(0, start - _PII_CONTEXT_WINDOW)
+    window_end = min(len(content), end + _PII_CONTEXT_WINDOW)
+    window = content[window_start:start] + " " + content[end:window_end]
+    tokens = set(re.findall(r"[a-z]+", window.lower()))
+    return bool(tokens & _PII_CONTEXT_TRIGGERS)
+
+
+def _should_mask_low_precision_pii(content: str, finding: "ScanFinding") -> bool:
+    """Precision gate for low-precision NAME/HANDLE findings (BUG-320 / BP-174 Q5).
+
+    Returns True only when the candidate should still be masked. High-precision
+    classes are never routed here (the caller pre-filters by finding_type).
+    """
+    text = finding.original_text
+
+    if finding.finding_type == FindingType.PII_NAME:
+        if text.strip().lower() in _TECHNICAL_PROPER_NOUNS:
+            return False
+        if _is_technical_token(text):
+            return False
+        if _is_structural_line(content, finding.start, finding.end):
+            return False
+        return _has_pii_context(content, finding.start, finding.end)
+
+    if finding.finding_type == FindingType.PII_HANDLE:
+        # Structural exclusion only: a handle on a diff/heading/comment line is
+        # not PII. Ordinary @mention masking is intentional, tested behavior with
+        # downstream consumers (exempt_handle_pii), so handle context-gating is
+        # left unchanged here — see the placement note above.
+        return not _is_structural_line(content, finding.start, finding.end)
+
+    return True
+
+
 def _mask_for_audit_log(text: str) -> str:
     """Partially mask sensitive text for audit log (SEC-3).
 
@@ -604,6 +782,17 @@ class SecurityScanner:
         self, content: str, findings: list[ScanFinding]
     ) -> tuple[str, ScanAction]:
         """Apply PII masks and determine final action. Used by both scan() and scan_batch()."""
+        # BUG-320 / BP-174 Q5: clear the replacement for low-precision NAME/HANDLE
+        # false positives so they are recorded but not masked into the stored
+        # content. High-precision classes are untouched (replacement preserved).
+        for finding in findings:
+            if (
+                finding.replacement is not None
+                and finding.finding_type
+                in (FindingType.PII_NAME, FindingType.PII_HANDLE)
+                and not _should_mask_low_precision_pii(content, finding)
+            ):
+                finding.replacement = None
         pii_findings = [f for f in findings if f.replacement is not None]
         pii_findings.sort(key=lambda f: f.start, reverse=True)
         masked_content = content

--- a/tests/test_pm343_relevance_gate.py
+++ b/tests/test_pm343_relevance_gate.py
@@ -22,13 +22,20 @@ the signals are computed shadow-only otherwise. Tests target the pure decision
 surfaces the tier-2 hook consumes, on production-size fixtures.
 """
 
+import importlib.util
+import io
+import json
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from memory.chunking.truncation import count_tokens
+from memory.config import COLLECTION_DISCUSSIONS
 from memory.injection import (
+    InjectionSessionState,
+    RouteTarget,
     compute_adaptive_budget,
     compute_relevance_signals,
     select_results_greedy,
@@ -73,7 +80,7 @@ def _budget_config(**overrides):
         injection_density_weight=0.3,
         injection_drift_weight=0.2,
         injection_absolute_gate_enabled=True,
-        injection_absolute_floor=0.78,
+        injection_absolute_floor=CALIBRATED_FLOOR,
         injection_drift_suppressor_threshold=0.5,
     )
     for k, v in overrides.items():
@@ -276,6 +283,26 @@ class TestFreshnessGate:
         assert sig["top_age_days"] is None
         assert sig["freshness_pass"] is True
 
+    def test_freshness_keys_off_max_raw_not_banded_top1(self):
+        """PM #344 F3 reference-point consistency: freshness must gate the SAME
+        item the floor/margin selected (highest-raw), not the banded results[0].
+        Here the banded top-1 is stale but low-raw, while the fresh above-floor
+        item is the real injection candidate — it must NOT be suppressed by the
+        unrelated stale banded top-1's age."""
+        cfg = _gate_config(floor=0.78, max_age_days=45)
+        # Banded order (caller-sorted): top-1 stale+low-raw, top-2 fresh+high-raw.
+        results = [
+            _result(0.95, 0.50, age_days=400),  # banded top-1: stale, below floor
+            _result(0.90, 0.88, age_days=5),  # highest raw: fresh, above floor
+        ]
+        sig = compute_relevance_signals(results, cfg, now=_now())
+        assert sig["best_raw"] == 0.88
+        # Age comes from the highest-raw reference item (5d), not banded top-1 (400d).
+        assert sig["top_age_days"] == pytest.approx(5.0, abs=0.01)
+        assert sig["floor_pass"] is True
+        assert sig["freshness_pass"] is True
+        assert sig["would_inject"] is True
+
 
 # ---------------------------------------------------------------------------
 # F-3 (Q3): drift is a suppressor, not a budget amplifier
@@ -345,6 +372,57 @@ class TestDriftSuppressor:
             config=cfg_off,
         )
         assert gated == legacy
+
+    def test_defer_turn_passes_none_and_does_not_suppress_drift(self):
+        """PM #344 fix 1(b): on the code-patterns defer route every raw_score is
+        0.0, so has_dense_signal is False and the hook passes best_raw_score=None.
+        With None the drift suppressor never fires — the budget matches the legacy
+        (gate-off) budget, NOT the suppressed budget the old best_raw=0.0 wiring
+        produced (which zeroed drift → ~181 fewer tokens, violating DEC-PM343-D8's
+        'code-patterns route = no behavior change')."""
+        gate_cfg = _gate_config()  # calibrated floor 0.76
+        code_results = [
+            _result(b, 0.0, type_="implementation", collection="code-patterns")
+            for b in (0.95, 0.90)
+        ]
+        sig = compute_relevance_signals(code_results, gate_cfg, now=_now())
+        assert sig["has_dense_signal"] is False
+
+        # Replicate the hook wiring: best_raw_score is None on the defer route.
+        best_raw_arg = sig["best_raw"] if sig["has_dense_signal"] else None
+        assert best_raw_arg is None
+
+        bcfg = _budget_config(
+            injection_absolute_gate_enabled=True, injection_absolute_floor=0.76
+        )
+        drift = {"topic_drift": 1.0}
+        budget_results = [{"score": 0.95}]
+        deferred = compute_adaptive_budget(
+            best_score=0.95,
+            results=budget_results,
+            session_state=drift,
+            config=bcfg,
+            best_raw_score=best_raw_arg,
+        )
+        legacy = compute_adaptive_budget(
+            best_score=0.95,
+            results=budget_results,
+            session_state=drift,
+            config=_budget_config(injection_absolute_gate_enabled=False),
+            best_raw_score=None,
+        )
+        assert deferred == legacy
+
+        # Counterfactual: the OLD wiring (best_raw=0.0 < floor) would have zeroed
+        # drift and shrunk the budget. Prove the fix avoids that regression.
+        old_wiring = compute_adaptive_budget(
+            best_score=0.95,
+            results=budget_results,
+            session_state=drift,
+            config=bcfg,
+            best_raw_score=0.0,
+        )
+        assert old_wiring < deferred
 
 
 # ---------------------------------------------------------------------------
@@ -559,3 +637,230 @@ class TestBug302RejectTimeRemaining:
         dedup = [r for r in meta["rejects"] if r["reason"] == "dedup"]
         assert dedup
         assert "remaining" not in dedup[0]
+
+
+# ---------------------------------------------------------------------------
+# Hook-level gate ordering — additive-only invariant + BUG-302 marker render
+# ---------------------------------------------------------------------------
+# These tests drive the real tier-2 hook main() over mocked I/O boundaries
+# (config / qdrant / search results / routing) so the genuine gate-ordering and
+# marker-render code paths are exercised end-to-end, not just the pure decision
+# surfaces. F-5 (additive-only) and F-4 (BUG-302 marker) are about hook behavior,
+# so they are asserted at the hook, not only at the data layer.
+
+_HOOK_PATH = (
+    Path(__file__).resolve().parents[1]
+    / ".claude"
+    / "hooks"
+    / "scripts"
+    / "context_injection_tier2.py"
+)
+
+
+@pytest.fixture(scope="module")
+def hook_module():
+    spec = importlib.util.spec_from_file_location("ci_tier2_under_test", _HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _FakeSearch:
+    """Stand-in for MemorySearch: returns a fixed result set, no live store."""
+
+    def __init__(self, results):
+        self._results = results
+        self.embedding_client = SimpleNamespace(embed=lambda prompts: [[0.1] * 768])
+
+    def search(self, **kwargs):
+        return [dict(r) for r in self._results]
+
+    def close(self):
+        pass
+
+
+def _run_hook(
+    mod,
+    monkeypatch,
+    capsys,
+    tmp_path,
+    *,
+    results,
+    gate_enabled,
+    session_id,
+    budget_floor=500,
+    budget_ceiling=1500,
+    prompt="tell me about the tier-2 relevance gate decision",
+):
+    """Invoke the hook main() with mocked boundaries; return additionalContext."""
+    cfg = SimpleNamespace(
+        injection_enabled=True,
+        injection_absolute_gate_enabled=gate_enabled,
+        injection_absolute_floor=0.76,
+        injection_margin_min=0.0,
+        injection_freshness_max_age_days=0,
+        injection_drift_suppressor_threshold=0.5,
+        injection_hard_floor=0.30,
+        injection_threshold_conventions=0.6,
+        injection_threshold_code_patterns=0.6,
+        injection_threshold_discussions=0.6,
+        injection_confidence_threshold=0.6,
+        max_retrievals=10,
+        injection_score_gap_threshold=0.7,
+        injection_budget_floor=budget_floor,
+        injection_budget_ceiling=budget_ceiling,
+        injection_quality_weight=0.5,
+        injection_density_weight=0.3,
+        injection_drift_weight=0.2,
+        audit_dir=tmp_path,
+        get_freshness_penalty=lambda fs: 1.0,
+    )
+    monkeypatch.setattr(mod, "get_config", lambda: cfg)
+    monkeypatch.setattr(mod, "get_qdrant_client", lambda c: object())
+    monkeypatch.setattr(mod, "check_qdrant_health", lambda c: True)
+    monkeypatch.setattr(mod, "resolve_project_id", lambda cwd: "proj")
+    monkeypatch.setattr(mod, "MemorySearch", lambda c: _FakeSearch(results))
+    monkeypatch.setattr(
+        mod, "route_collections", lambda p: [RouteTarget(COLLECTION_DISCUSSIONS)]
+    )
+    monkeypatch.setattr(mod, "emit_trace_event", None, raising=False)
+    monkeypatch.setattr(mod, "push_hook_metrics_async", lambda **k: None, raising=False)
+
+    # Deterministic reruns: clear any persisted cross-turn injection state.
+    state_path = InjectionSessionState._state_path(session_id)
+    if state_path.exists():
+        state_path.unlink()
+
+    stdin_payload = json.dumps(
+        {"prompt": prompt, "session_id": session_id, "cwd": str(tmp_path)}
+    )
+    monkeypatch.setattr("sys.stdin", io.StringIO(stdin_payload))
+
+    rc = mod.main()
+    assert rc == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    return payload["hookSpecificOutput"]["additionalContext"]
+
+
+class TestAdditiveOnlyInvariant:
+    """F-5: the absolute gate can only ADD a skip — never force an injection the
+    banded gate would have skipped, and never apply when shadow-only (disabled)."""
+
+    def test_banded_skip_suppresses_regardless_of_would_inject(
+        self, hook_module, monkeypatch, capsys, tmp_path
+    ):
+        # Banded best 0.20 < hard_floor 0.30 → hard_skip BEFORE the absolute gate.
+        # raw 0.86 would make would_inject True, but the banded gate already skips.
+        results = [_result(0.20, 0.86)]
+        ctx = _run_hook(
+            hook_module,
+            monkeypatch,
+            capsys,
+            tmp_path,
+            results=results,
+            gate_enabled=True,
+            session_id="pm344-additive-bandedskip",
+        )
+        assert ctx == ""
+
+    def test_gate_enabled_would_inject_false_suppresses(
+        self, hook_module, monkeypatch, capsys, tmp_path
+    ):
+        # Banded best 0.95 → full gate (banded would inject), but raw 0.50 < floor
+        # 0.76 → would_inject False → the absolute gate ADDS a skip.
+        results = [_result(0.95, 0.50)]
+        ctx = _run_hook(
+            hook_module,
+            monkeypatch,
+            capsys,
+            tmp_path,
+            results=results,
+            gate_enabled=True,
+            session_id="pm344-additive-relskip",
+        )
+        assert ctx == ""
+
+    def test_shadow_mode_would_inject_false_still_injects(
+        self, hook_module, monkeypatch, capsys, tmp_path
+    ):
+        # Same below-floor signal, but gate DISABLED (shadow) → injection proceeds.
+        results = [_result(0.95, 0.50)]
+        ctx = _run_hook(
+            hook_module,
+            monkeypatch,
+            capsys,
+            tmp_path,
+            results=results,
+            gate_enabled=False,
+            session_id="pm344-additive-shadow",
+        )
+        assert "<retrieved_context>" in ctx
+
+
+class TestBug302MarkerRender:
+    """F-4: assert the operator-visible tier-2 fallback marker f-string itself —
+    carrying the BUG-302 reject-time `remaining` — not just the reject record."""
+
+    def test_marker_renders_reject_time_remaining(
+        self, hook_module, monkeypatch, capsys, tmp_path
+    ):
+        big_content = "word " * 60  # loads first
+        handoff_content = "word " * 40  # rejected (doesn't fit)
+        small_content = "word " * 6  # loads AFTER the reject
+
+        t_big = count_tokens(big_content)
+        t_handoff = count_tokens(handoff_content)
+        t_small = count_tokens(small_content)
+        # Budget fits big + small but NOT big + handoff (handoff is the larger one).
+        budget = t_big + t_small + 1
+        assert t_handoff > t_small + 1  # precondition: handoff truly rejected
+
+        # raw 0.86 (> floor 0.76) so the absolute gate passes; banded scores stay
+        # within the score-gap window (0.85/0.95 = 0.89 > 0.7).
+        results = [
+            {
+                "id": "big",
+                "content": big_content,
+                "score": 0.95,
+                "raw_score": 0.86,
+                "type": "session",
+                "collection": "discussions",
+            },
+            {
+                "id": "h",
+                "content": handoff_content,
+                "score": 0.90,
+                "raw_score": 0.86,
+                "type": "agent_handoff",
+                "collection": "discussions",
+            },
+            {
+                "id": "small",
+                "content": small_content,
+                "score": 0.85,
+                "raw_score": 0.86,
+                "type": "decision",
+                "collection": "discussions",
+            },
+        ]
+        ctx = _run_hook(
+            hook_module,
+            monkeypatch,
+            capsys,
+            tmp_path,
+            results=results,
+            gate_enabled=True,
+            session_id="pm344-bug302-marker",
+            budget_floor=budget,
+            budget_ceiling=budget,
+        )
+
+        reject_time_remaining = budget - t_big  # free budget when handoff evaluated
+        assert "tier-2 fallback" in ctx
+        assert f"tokens={t_handoff}" in ctx
+        assert f"remaining={reject_time_remaining}" in ctx
+        assert f"budget={budget}" in ctx
+        # Marker precedes the injected context and is self-evident (tokens > remaining).
+        assert ctx.index("tier-2 fallback") < ctx.index("<retrieved_context>")
+        assert t_handoff > reject_time_remaining

--- a/tests/test_pm343_relevance_gate.py
+++ b/tests/test_pm343_relevance_gate.py
@@ -1,0 +1,504 @@
+"""PM #343 — BUG-319 (F-1/F-2/F-3) + BUG-302 (F-5) absolute-relevance gate tests.
+
+Covers the BP-174 absolute-relevance injection gate that fixes the F-1 root cause:
+the hybrid_rrf_decay path min-max-normalizes RRF scores to a [0.5, 0.95] band per
+result-set, so the banded top-1 is always ~0.95 and the per-collection confidence
+gate can never skip same-domain-off-topic content in a single-domain store.
+
+- F-1 (Q1): ``MemorySearch._attach_raw_cosine`` carries an absolute raw-cosine
+  signal alongside the banded score; the gate consumes raw_score, not the band.
+- F-1 (Q2): ``compute_relevance_signals`` applies a store-baseline floor + the
+  scale-free top-1/top-2 margin so a banded-0.95 same-domain-off-topic top-1 is
+  gated out.
+- F-2 (Q4): the freshness cap gates a stale top-1 out (distinct from DECAY_*).
+- F-3 (Q3): ``compute_adaptive_budget`` makes topic drift a suppressor — high
+  drift + no above-floor candidate no longer amplifies the budget.
+- F-5 (BUG-302): the budget_exceeded reject record carries the reject-time
+  ``remaining`` snapshot so the tier-2 marker renders the value that actually
+  triggered the reject (not the post-loop final remaining).
+
+The gate only changes behavior when ``injection_absolute_gate_enabled`` is True;
+the signals are computed shadow-only otherwise. Tests target the pure decision
+surfaces the tier-2 hook consumes, on production-size fixtures.
+"""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from memory.chunking.truncation import count_tokens
+from memory.injection import (
+    compute_adaptive_budget,
+    compute_relevance_signals,
+    select_results_greedy,
+)
+from memory.search import MemorySearch
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _gate_config(
+    *,
+    floor=0.78,
+    margin_min=0.05,
+    max_age_days=0,
+    enabled=True,
+    drift_suppressor=0.5,
+):
+    """Minimal config namespace carrying just the gate fields under test."""
+    return SimpleNamespace(
+        injection_absolute_gate_enabled=enabled,
+        injection_absolute_floor=floor,
+        injection_margin_min=margin_min,
+        injection_freshness_max_age_days=max_age_days,
+        injection_drift_suppressor_threshold=drift_suppressor,
+    )
+
+
+def _budget_config(**overrides):
+    cfg = SimpleNamespace(
+        injection_budget_floor=500,
+        injection_budget_ceiling=1500,
+        injection_confidence_threshold=0.6,
+        injection_quality_weight=0.5,
+        injection_density_weight=0.3,
+        injection_drift_weight=0.2,
+        injection_absolute_gate_enabled=True,
+        injection_absolute_floor=0.78,
+        injection_drift_suppressor_threshold=0.5,
+    )
+    for k, v in overrides.items():
+        setattr(cfg, k, v)
+    return cfg
+
+
+def _now():
+    return datetime(2026, 6, 17, tzinfo=timezone.utc)
+
+
+def _result(banded, raw, *, age_days=1, type_="decision", collection="discussions"):
+    stored_at = (_now() - timedelta(days=age_days)).isoformat().replace("+00:00", "Z")
+    return {
+        "id": f"p-{banded}-{raw}-{age_days}",
+        "content": "single-domain AI Memory internals content",
+        "score": banded,
+        "raw_score": raw,
+        "type": type_,
+        "collection": collection,
+        "stored_at": stored_at,
+    }
+
+
+# ---------------------------------------------------------------------------
+# F-1 (Q1): _attach_raw_cosine — absolute channel separate from banded score
+# ---------------------------------------------------------------------------
+
+
+class TestAttachRawCosine:
+    def _search(self):
+        # Skip __init__ (heavy deps); _attach_raw_cosine only touches self.client.
+        return MemorySearch.__new__(MemorySearch)
+
+    def test_dense_mode_copies_score_as_raw(self):
+        s = self._search()
+        s.client = None  # not used on the dense branch
+        memories = [{"id": "a", "score": 0.81}, {"id": "b", "score": 0.42}]
+        s._attach_raw_cosine(
+            memories,
+            search_mode="dense",
+            collection="discussions",
+            query_embedding=[0.1] * 768,
+            query_filter=None,
+            search_params=None,
+        )
+        assert memories[0]["raw_score"] == 0.81
+        assert memories[1]["raw_score"] == 0.42
+
+    def test_hybrid_mode_attaches_dense_cosine_not_banded(self):
+        """The banded score is pinned near 0.95; raw_score must reflect the
+        separate dense query — proving the gate input is decoupled from the band.
+        """
+        s = self._search()
+
+        class _Pt:
+            def __init__(self, id_, score):
+                self.id = id_
+                self.score = score
+
+        resp = SimpleNamespace(points=[_Pt("a", 0.86), _Pt("b", 0.71)])
+        s.client = SimpleNamespace(query_points=lambda **kw: resp)
+
+        # Banded scores (post min-max) are both high; raw cosines spread.
+        memories = [{"id": "a", "score": 0.95}, {"id": "b", "score": 0.50}]
+        s._attach_raw_cosine(
+            memories,
+            search_mode="hybrid_rrf_decay",
+            collection="discussions",
+            query_embedding=[0.1] * 768,
+            query_filter=None,
+            search_params=None,
+        )
+        assert memories[0]["raw_score"] == 0.86
+        assert memories[1]["raw_score"] == 0.71
+        # Banded score untouched (ordering/display only).
+        assert memories[0]["score"] == 0.95
+
+    def test_missing_from_dense_neighborhood_gets_zero(self):
+        s = self._search()
+        resp = SimpleNamespace(points=[SimpleNamespace(id="a", score=0.80)])
+        s.client = SimpleNamespace(query_points=lambda **kw: resp)
+        memories = [{"id": "a", "score": 0.95}, {"id": "sparse-only", "score": 0.90}]
+        s._attach_raw_cosine(
+            memories,
+            search_mode="hybrid_rrf_decay",
+            collection="discussions",
+            query_embedding=[0.1] * 768,
+            query_filter=None,
+            search_params=None,
+        )
+        assert memories[0]["raw_score"] == 0.80
+        assert memories[1]["raw_score"] == 0.0  # top-by-rank, no dense neighbor
+
+    def test_raw_query_failure_degrades_to_zero(self):
+        s = self._search()
+
+        def _boom(**kw):
+            raise RuntimeError("qdrant down")
+
+        s.client = SimpleNamespace(query_points=_boom)
+        memories = [{"id": "a", "score": 0.95}]
+        s._attach_raw_cosine(
+            memories,
+            search_mode="hybrid_rrf_decay",
+            collection="discussions",
+            query_embedding=[0.1] * 768,
+            query_filter=None,
+            search_params=None,
+        )
+        assert memories[0]["raw_score"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# F-1 (Q2): compute_relevance_signals — floor + margin discrimination
+# ---------------------------------------------------------------------------
+
+
+class TestRelevanceSignals:
+    def test_on_topic_passes(self):
+        cfg = _gate_config()
+        results = [_result(0.95, 0.86), _result(0.90, 0.74)]
+        sig = compute_relevance_signals(results, cfg, now=_now())
+        assert sig["floor_pass"] is True
+        assert sig["margin_pass"] is True
+        assert sig["would_inject"] is True
+
+    def test_same_domain_off_topic_blocked_despite_banded_095(self):
+        """The F-1 reproducer: banded top-1 is 0.95 (would clear every
+        per-collection threshold) but every raw cosine is below the floor, so the
+        absolute gate correctly injects nothing."""
+        cfg = _gate_config(floor=0.78)
+        results = [_result(0.95, 0.745), _result(0.90, 0.74), _result(0.85, 0.73)]
+        sig = compute_relevance_signals(results, cfg, now=_now())
+        assert sig["best_raw"] == 0.745
+        assert sig["floor_pass"] is False
+        assert sig["would_inject"] is False
+
+    def test_tiny_margin_blocked(self):
+        """High top-1 with a tiny gap to top-2 is an ambiguous/distractor
+        retrieval regardless of the absolute number (Q2 margin gate)."""
+        cfg = _gate_config(floor=0.78, margin_min=0.05)
+        results = [_result(0.95, 0.90), _result(0.92, 0.88)]
+        sig = compute_relevance_signals(results, cfg, now=_now())
+        assert sig["floor_pass"] is True
+        assert sig["margin"] == pytest.approx(0.02, abs=1e-6)
+        assert sig["margin_pass"] is False
+        assert sig["would_inject"] is False
+
+    def test_single_result_bypasses_margin(self):
+        cfg = _gate_config(floor=0.78)
+        results = [_result(0.95, 0.85)]
+        sig = compute_relevance_signals(results, cfg, now=_now())
+        assert sig["margin_pass"] is True
+        assert sig["would_inject"] is True
+
+    def test_empty_results(self):
+        cfg = _gate_config()
+        sig = compute_relevance_signals([], cfg, now=_now())
+        assert sig["best_raw"] == 0.0
+        assert sig["would_inject"] is False
+
+
+# ---------------------------------------------------------------------------
+# F-2 (Q4): freshness cap gates a stale top-1
+# ---------------------------------------------------------------------------
+
+
+class TestFreshnessGate:
+    def test_stale_top1_blocked_when_cap_enabled(self):
+        cfg = _gate_config(floor=0.78, max_age_days=45)
+        # Otherwise-injectable: high raw, good margin — but top-1 is 60 days old.
+        results = [_result(0.95, 0.88, age_days=60), _result(0.90, 0.74, age_days=2)]
+        sig = compute_relevance_signals(results, cfg, now=_now())
+        assert sig["floor_pass"] is True
+        assert sig["margin_pass"] is True
+        assert sig["top_age_days"] == pytest.approx(60.0, abs=0.01)
+        assert sig["freshness_pass"] is False
+        assert sig["would_inject"] is False
+
+    def test_fresh_top1_passes_with_cap(self):
+        cfg = _gate_config(floor=0.78, max_age_days=45)
+        results = [_result(0.95, 0.88, age_days=10), _result(0.90, 0.74)]
+        sig = compute_relevance_signals(results, cfg, now=_now())
+        assert sig["freshness_pass"] is True
+        assert sig["would_inject"] is True
+
+    def test_cap_disabled_ignores_age(self):
+        cfg = _gate_config(floor=0.78, max_age_days=0)
+        results = [_result(0.95, 0.88, age_days=400), _result(0.90, 0.74)]
+        sig = compute_relevance_signals(results, cfg, now=_now())
+        assert sig["freshness_pass"] is True
+        assert sig["would_inject"] is True
+
+    def test_missing_stored_at_does_not_block(self):
+        cfg = _gate_config(floor=0.78, max_age_days=45)
+        r = _result(0.95, 0.88)
+        r.pop("stored_at")
+        sig = compute_relevance_signals([r, _result(0.90, 0.74)], cfg, now=_now())
+        assert sig["top_age_days"] is None
+        assert sig["freshness_pass"] is True
+
+
+# ---------------------------------------------------------------------------
+# F-3 (Q3): drift is a suppressor, not a budget amplifier
+# ---------------------------------------------------------------------------
+
+
+class TestDriftSuppressor:
+    def test_high_drift_below_floor_does_not_amplify(self):
+        """Gate enabled + below-floor best raw + high drift → drift contribution
+        is zeroed, so the budget does not grow on an off-topic pivot."""
+        cfg = _budget_config(injection_absolute_gate_enabled=True)
+        results = [{"score": 0.95}]
+        high_drift = {"topic_drift": 1.0}
+        suppressed = compute_adaptive_budget(
+            best_score=0.95,
+            results=results,
+            session_state=high_drift,
+            config=cfg,
+            best_raw_score=0.50,  # below floor 0.78
+        )
+        # Legacy comparison: same inputs with the gate OFF (drift amplifies).
+        cfg_off = _budget_config(injection_absolute_gate_enabled=False)
+        legacy = compute_adaptive_budget(
+            best_score=0.95,
+            results=results,
+            session_state=high_drift,
+            config=cfg_off,
+            best_raw_score=0.50,
+        )
+        assert suppressed < legacy
+
+    def test_above_floor_keeps_amplification(self):
+        cfg = _budget_config(injection_absolute_gate_enabled=True)
+        results = [{"score": 0.95}]
+        high_drift = {"topic_drift": 1.0}
+        gated = compute_adaptive_budget(
+            best_score=0.95,
+            results=results,
+            session_state=high_drift,
+            config=cfg,
+            best_raw_score=0.90,  # above floor → drift still amplifies
+        )
+        cfg_off = _budget_config(injection_absolute_gate_enabled=False)
+        legacy = compute_adaptive_budget(
+            best_score=0.95,
+            results=results,
+            session_state=high_drift,
+            config=cfg_off,
+            best_raw_score=0.90,
+        )
+        assert gated == legacy
+
+    def test_legacy_behavior_when_raw_score_absent(self):
+        cfg = _budget_config(injection_absolute_gate_enabled=True)
+        results = [{"score": 0.95}]
+        gated = compute_adaptive_budget(
+            best_score=0.95,
+            results=results,
+            session_state={"topic_drift": 1.0},
+            config=cfg,
+        )
+        cfg_off = _budget_config(injection_absolute_gate_enabled=False)
+        legacy = compute_adaptive_budget(
+            best_score=0.95,
+            results=results,
+            session_state={"topic_drift": 1.0},
+            config=cfg_off,
+        )
+        assert gated == legacy
+
+
+# ---------------------------------------------------------------------------
+# Production-size discrimination: banded ~0.95 vs absolute raw spread
+# ---------------------------------------------------------------------------
+
+
+class TestProductionSizeDiscrimination:
+    def _banded_band(self, n):
+        """Mimic search.py min-max: top→0.95, worst→0.5 across n results."""
+        if n == 1:
+            return [0.75]
+        return [round(0.95 - (0.45 * i / (n - 1)), 4) for i in range(n)]
+
+    def test_off_topic_set_all_banded_high_but_gate_skips(self):
+        cfg = _gate_config(floor=0.78, margin_min=0.05)
+        bands = self._banded_band(12)
+        # Single-domain off-topic neighborhood: raw cosines cluster ~0.72-0.75,
+        # all below the 0.78 store baseline floor.
+        raws = [
+            0.75,
+            0.745,
+            0.74,
+            0.738,
+            0.735,
+            0.73,
+            0.728,
+            0.725,
+            0.72,
+            0.71,
+            0.70,
+            0.69,
+        ]
+        results = [_result(b, r) for b, r in zip(bands, raws, strict=False)]
+        # The banded gate would inject (top banded 0.95 clears any threshold)...
+        assert results[0]["score"] == 0.95
+        # ...but the absolute gate skips: no candidate clears the floor.
+        sig = compute_relevance_signals(results, cfg, now=_now())
+        assert sig["floor_pass"] is False
+        assert sig["would_inject"] is False
+
+    def test_on_topic_present_in_large_set_injects(self):
+        cfg = _gate_config(floor=0.78, margin_min=0.05)
+        bands = self._banded_band(12)
+        # One genuinely on-topic item (0.87) above a same-domain tail (~0.72).
+        raws = [
+            0.87,
+            0.73,
+            0.728,
+            0.725,
+            0.72,
+            0.718,
+            0.715,
+            0.71,
+            0.705,
+            0.70,
+            0.69,
+            0.68,
+        ]
+        results = [_result(b, r) for b, r in zip(bands, raws, strict=False)]
+        sig = compute_relevance_signals(results, cfg, now=_now())
+        assert sig["best_raw"] == 0.87
+        assert sig["floor_pass"] is True
+        assert sig["margin"] >= 0.05
+        assert sig["would_inject"] is True
+
+
+# ---------------------------------------------------------------------------
+# F-5 (BUG-302): reject record carries reject-time remaining snapshot
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _silence_observability(monkeypatch):
+    monkeypatch.setattr("memory.injection.emit_trace_event", None, raising=False)
+    import memory.metrics_push as _mpush
+
+    monkeypatch.setattr(
+        _mpush, "push_retrieval_reject_metric_async", lambda *a, **k: None
+    )
+
+
+class TestBug302RejectTimeRemaining:
+    def test_remaining_is_reject_time_not_final(self):
+        """The case the post-loop formula gets wrong: a smaller item loads AFTER
+        the over-budget reject (greedy skip-and-continue), so the final remaining
+        is smaller than the remaining that actually triggered the reject. The
+        reject record must carry the reject-time snapshot."""
+        big_content = "word " * 60  # loads first
+        handoff_content = "word " * 40  # rejected (doesn't fit)
+        small_content = "word " * 8  # loads AFTER the reject
+
+        t_big = count_tokens(big_content)
+        t_handoff = count_tokens(handoff_content)
+        t_small = count_tokens(small_content)
+
+        # Budget fits big + small but NOT big + handoff. handoff > small ensures
+        # the handoff is rejected while the trailing small item still fits.
+        budget = t_big + t_small + 1
+        assert t_handoff > t_small  # precondition
+
+        results = [
+            {
+                "id": "big",
+                "content": big_content,
+                "score": 0.95,
+                "type": "session",
+                "collection": "discussions",
+            },
+            {
+                "id": "h",
+                "content": handoff_content,
+                "score": 0.90,
+                "type": "agent_handoff",
+                "collection": "discussions",
+            },
+            {
+                "id": "small",
+                "content": small_content,
+                "score": 0.85,
+                "type": "decision",
+                "collection": "discussions",
+            },
+        ]
+
+        _selected, tokens_used, meta = select_results_greedy(
+            results, budget=budget, return_meta=True, tier=2
+        )
+
+        rej = next(r for r in meta["rejects"] if r["reason"] == "budget_exceeded")
+        reject_time_remaining = budget - t_big  # free budget when handoff evaluated
+        final_remaining = budget - tokens_used
+
+        # The snapshot is the reject-time value, which differs from final remaining
+        # because the small item loaded afterwards.
+        assert rej["remaining"] == reject_time_remaining
+        assert final_remaining < reject_time_remaining
+        # Self-evident: the rejected candidate is larger than what was free.
+        assert rej["tokens"] > rej["remaining"]
+
+    def test_non_budget_rejects_have_no_remaining(self):
+        results = [
+            {
+                "id": "a",
+                "content": "dup",
+                "score": 0.9,
+                "type": "decision",
+                "collection": "discussions",
+            },
+            {
+                "id": "b",
+                "content": "dup",
+                "score": 0.9,
+                "type": "decision",
+                "collection": "discussions",
+            },
+        ]
+        _sel, _tok, meta = select_results_greedy(
+            results, budget=10_000, return_meta=True, tier=2
+        )
+        dedup = [r for r in meta["rejects"] if r["reason"] == "dedup"]
+        assert dedup
+        assert "remaining" not in dedup[0]

--- a/tests/test_pm343_relevance_gate.py
+++ b/tests/test_pm343_relevance_gate.py
@@ -193,6 +193,47 @@ class TestAttachRawCosine:
         )
         assert memories[0]["raw_score"] == 0.0
 
+    def test_hybrid_gate_calls_query_points_exactly_once(self):
+        """With attach_raw_cosine=True on a hybrid path the if-gate fires and
+        query_points is called exactly once for the raw-cosine side channel."""
+        from unittest.mock import MagicMock
+
+        s = self._search()
+        mock_client = MagicMock()
+        mock_client.query_points.return_value = SimpleNamespace(points=[])
+        s.client = mock_client
+
+        s._attach_raw_cosine(
+            [{"id": "a", "score": 0.95}],
+            search_mode="hybrid_rrf_decay",
+            collection="discussions",
+            query_embedding=[0.1] * 768,
+            query_filter=None,
+            search_params=None,
+        )
+        assert mock_client.query_points.call_count == 1
+
+    def test_dense_path_does_not_call_query_points(self):
+        """With attach_raw_cosine=False the gate does not fire; even if
+        _attach_raw_cosine were invoked on the dense path, query_points is
+        never called — the banded score is copied directly, no extra round-trip."""
+        from unittest.mock import MagicMock
+
+        s = self._search()
+        mock_client = MagicMock()
+        mock_client.query_points.return_value = SimpleNamespace(points=[])
+        s.client = mock_client
+
+        s._attach_raw_cosine(
+            [{"id": "a", "score": 0.95}],
+            search_mode="dense",
+            collection="discussions",
+            query_embedding=[0.1] * 768,
+            query_filter=None,
+            search_params=None,
+        )
+        assert mock_client.query_points.call_count == 0
+
 
 # ---------------------------------------------------------------------------
 # F-1 (Q2): compute_relevance_signals — floor + margin discrimination
@@ -538,6 +579,22 @@ class TestProductionSizeDiscrimination:
         assert sig["best_raw"] == 0.0
         assert sig["has_dense_signal"] is False
         assert sig["floor_pass"] is True  # deferred, not skipped
+        assert sig["would_inject"] is True
+
+    def test_defer_short_circuits_margin_and_freshness_with_nonzero_margin_min(self):
+        """Opus-F1 scenario: with injection_margin_min=0.05 AND a code-patterns
+        defer set (all raw_score==0.0 → has_dense_signal False), the short-circuit
+        forces margin_pass=True and freshness_pass=True so a non-zero margin
+        threshold cannot silently suppress every deferred injection."""
+        cfg = _gate_config(margin_min=0.05)
+        results = [
+            _result(b, 0.0, type_="implementation", collection="code-patterns")
+            for b in (0.95, 0.90, 0.85)
+        ]
+        sig = compute_relevance_signals(results, cfg, now=_now())
+        assert sig["has_dense_signal"] is False
+        assert sig["margin_pass"] is True
+        assert sig["freshness_pass"] is True
         assert sig["would_inject"] is True
 
 

--- a/tests/test_pm343_relevance_gate.py
+++ b/tests/test_pm343_relevance_gate.py
@@ -40,10 +40,16 @@ from memory.search import MemorySearch
 # ---------------------------------------------------------------------------
 
 
+# Calibrated production floor (DEC-PM343-D7, config.injection_absolute_floor).
+# The live read-only sweep put the off-topic raw-cosine ceiling at ~0.754 and the
+# on-topic cluster at >=0.760; 0.76 splits that gap.
+CALIBRATED_FLOOR = 0.76
+
+
 def _gate_config(
     *,
-    floor=0.78,
-    margin_min=0.05,
+    floor=CALIBRATED_FLOOR,
+    margin_min=0.0,
     max_age_days=0,
     enabled=True,
     drift_suppressor=0.5,
@@ -353,39 +359,72 @@ class TestProductionSizeDiscrimination:
             return [0.75]
         return [round(0.95 - (0.45 * i / (n - 1)), 4) for i in range(n)]
 
-    def test_off_topic_set_all_banded_high_but_gate_skips(self):
-        cfg = _gate_config(floor=0.78, margin_min=0.05)
+    def test_cross_domain_off_topic_banded_high_but_gate_skips(self):
+        """Calibrated floor on a production-size set. Cross-domain off-topic
+        ("NBA scores", "sourdough recipe") raw cosines from the live sweep cluster
+        ~0.667-0.747 — all below the 0.76 floor — while the banded top-1 is pinned
+        at 0.95. The absolute gate skips what the banded gate would inject."""
+        cfg = _gate_config()  # calibrated floor 0.76, margin off
         bands = self._banded_band(12)
-        # Single-domain off-topic neighborhood: raw cosines cluster ~0.72-0.75,
-        # all below the 0.78 store baseline floor.
+        # Live-swept cross-domain off-topic raw-cosine ceiling = 0.7467 (French).
         raws = [
-            0.75,
-            0.745,
-            0.74,
-            0.738,
-            0.735,
-            0.73,
-            0.728,
-            0.725,
-            0.72,
-            0.71,
-            0.70,
-            0.69,
+            0.7467,
+            0.7207,
+            0.7012,
+            0.6948,
+            0.6854,
+            0.6843,
+            0.6733,
+            0.6673,
+            0.665,
+            0.66,
+            0.655,
+            0.65,
         ]
         results = [_result(b, r) for b, r in zip(bands, raws, strict=False)]
-        # The banded gate would inject (top banded 0.95 clears any threshold)...
-        assert results[0]["score"] == 0.95
-        # ...but the absolute gate skips: no candidate clears the floor.
+        assert results[0]["score"] == 0.95  # banded gate would inject
         sig = compute_relevance_signals(results, cfg, now=_now())
+        assert sig["best_raw"] == 0.7467
+        assert sig["floor_pass"] is False
+        assert sig["would_inject"] is False
+
+    def test_same_domain_off_topic_banded_high_but_gate_skips(self):
+        """The F-1 case the gate exists for: software-adjacent-but-not-in-store
+        queries ("Kubernetes autoscaling", "Rust tokio") sit higher than cross-
+        domain noise but the live sweep still capped them at 0.7542 — below 0.76.
+        The banded top-1 is 0.95; the absolute gate still skips."""
+        cfg = _gate_config()
+        bands = self._banded_band(12)
+        # Live-swept same-domain off-topic raw-cosine ceiling = 0.7542 (Rust).
+        raws = [
+            0.7542,
+            0.7433,
+            0.7418,
+            0.7349,
+            0.7151,
+            0.7125,
+            0.71,
+            0.705,
+            0.70,
+            0.695,
+            0.69,
+            0.685,
+        ]
+        results = [_result(b, r) for b, r in zip(bands, raws, strict=False)]
+        assert results[0]["score"] == 0.95
+        sig = compute_relevance_signals(results, cfg, now=_now())
+        assert sig["best_raw"] == 0.7542
         assert sig["floor_pass"] is False
         assert sig["would_inject"] is False
 
     def test_on_topic_present_in_large_set_injects(self):
-        cfg = _gate_config(floor=0.78, margin_min=0.05)
+        """On-topic project content from the live sweep clusters at 0.76-0.84 over
+        a same-domain tail. The top-1 clears the calibrated 0.76 floor and injects."""
+        cfg = _gate_config()
         bands = self._banded_band(12)
-        # One genuinely on-topic item (0.87) above a same-domain tail (~0.72).
+        # Live-swept on-topic raw top-1 = 0.8419 (Langfuse) over a ~0.72 tail.
         raws = [
-            0.87,
+            0.8419,
             0.73,
             0.728,
             0.725,
@@ -400,9 +439,27 @@ class TestProductionSizeDiscrimination:
         ]
         results = [_result(b, r) for b, r in zip(bands, raws, strict=False)]
         sig = compute_relevance_signals(results, cfg, now=_now())
-        assert sig["best_raw"] == 0.87
+        assert sig["best_raw"] == 0.8419
         assert sig["floor_pass"] is True
-        assert sig["margin"] >= 0.05
+        assert sig["would_inject"] is True
+
+    def test_code_patterns_dense_miss_defers_to_banded(self):
+        """Calibration finding (DEC-PM343-D7): on the code-patterns route the
+        banded ranking is driven by sparse/colbert/decay, so no top result has a
+        dense neighbor and best_raw collapses to 0.0. The absolute floor cannot
+        judge relevance there, so the gate must DEFER (no skip) rather than
+        suppress every code-routed injection. A non-empty result set with all
+        raw_score == 0.0 must pass the floor."""
+        cfg = _gate_config()  # floor 0.76, gate enabled
+        bands = self._banded_band(10)
+        results = [
+            _result(b, 0.0, type_="implementation", collection="code-patterns")
+            for b in bands
+        ]
+        sig = compute_relevance_signals(results, cfg, now=_now())
+        assert sig["best_raw"] == 0.0
+        assert sig["has_dense_signal"] is False
+        assert sig["floor_pass"] is True  # deferred, not skipped
         assert sig["would_inject"] is True
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -796,10 +796,16 @@ class TestDecayPath:
         # build_decay_formula was called
         assert len(build_decay_called) == 1
 
-        # query_points was called with prefetch kwarg
-        call_kwargs = mock_qdrant_client.query_points.call_args.kwargs
-        assert "prefetch" in call_kwargs
-        assert call_kwargs["prefetch"] is not None
+        # query_points was called with prefetch kwarg. BUG-319: the decay path
+        # now also fires a trailing plain-dense raw-cosine query (no prefetch) to
+        # populate raw_score, so locate the decay call among all calls rather than
+        # assuming it is the last one.
+        prefetch_calls = [
+            c
+            for c in mock_qdrant_client.query_points.call_args_list
+            if c.kwargs.get("prefetch") is not None
+        ]
+        assert prefetch_calls, "decay path must issue a prefetch+FormulaQuery call"
 
 
 class TestMustNotTypesFilter:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -797,9 +797,10 @@ class TestDecayPath:
         assert len(build_decay_called) == 1
 
         # query_points was called with prefetch kwarg. BUG-319: the decay path
-        # now also fires a trailing plain-dense raw-cosine query (no prefetch) to
-        # populate raw_score, so locate the decay call among all calls rather than
-        # assuming it is the last one.
+        # fires a trailing plain-dense raw-cosine query (no prefetch) only when
+        # attach_raw_cosine=True (opt-in, Tier-2 gate). This call omits it, but
+        # locate the decay (prefetch) call among all calls rather than assuming it
+        # is the last one to stay robust either way.
         prefetch_calls = [
             c
             for c in mock_qdrant_client.query_points.call_args_list

--- a/tests/unit/test_injection.py
+++ b/tests/unit/test_injection.py
@@ -113,6 +113,11 @@ class TestComputeAdaptiveBudget:
         self.config.injection_quality_weight = 0.5
         self.config.injection_density_weight = 0.3
         self.config.injection_drift_weight = 0.2
+        # BUG-319 F-3: absolute gate disabled → drift-suppressor branch is inert,
+        # legacy additive-drift behavior preserved.
+        self.config.injection_absolute_gate_enabled = False
+        self.config.injection_absolute_floor = 0.5
+        self.config.injection_drift_suppressor_threshold = 0.5
 
     def test_floor_budget_when_signals_low(self):
         """Budget should be at floor when all signals are low."""

--- a/tests/unit/test_security_scanner.py
+++ b/tests/unit/test_security_scanner.py
@@ -1391,6 +1391,50 @@ class TestNameHandlePrecisionGate:
             is False
         )
 
+    def test_b1_crafted_git_index_prefix_masks_name(self):
+        """B1 (review2-l2-opus N-1): a line that shares a valid hex-sha git-index
+        prefix but carries trailing prose is NOT structural after the tail anchor
+        — PII context then governs, so 'contact John Smith' masks correctly.
+        A clean real git index line (no trailing prose) remains structural/exempt."""
+        from memory.security_scanner import (
+            _is_structural_line,
+            _should_mask_low_precision_pii,
+        )
+
+        # Crafted prefix with trailing prose: NOT structural → PII context masks.
+        crafted = "index deadbeef..feedface contact John Smith"
+        assert (
+            _should_mask_low_precision_pii(
+                crafted, _name_finding(crafted, "John Smith")
+            )
+            is True
+        ), "crafted index prefix + trailing PII prose must mask"
+
+        # Real git line "index <sha>..<sha> <mode>": still structural (exempt).
+        git_clean = "index abc1234..def5678 100644"
+        assert (
+            _is_structural_line(git_clean, 0, len(git_clean), for_name=True) is True
+        ), "real git index line with mode bits must remain structural"
+
+    def test_b2_new_framework_nouns_allowlisted(self):
+        """B2 (review2-l2-sonnet F-1 / review2-l2-opus F-2): newly-added framework
+        names (django, flask, celery, apache) are allow-listed so SpaCy PERSON
+        mis-tags next to a strong PII cue do not produce false positives."""
+        from memory.security_scanner import _should_mask_low_precision_pii
+
+        # "email" is a strong PII cue (_PII_CONTEXT_TRIGGERS); without the
+        # allow-list entry these single-token framework names would be masked.
+        for content, span in (
+            ("email Django about the config", "Django"),
+            ("email Flask about the config", "Flask"),
+            ("email Celery about the config", "Celery"),
+            ("email Apache about the config", "Apache"),
+        ):
+            assert (
+                _should_mask_low_precision_pii(content, _name_finding(content, span))
+                is False
+            ), f"allow-listed framework name must not be masked: {content!r}"
+
     def test_m_a_allcaps_name_with_context_is_masked(self):
         """M-A: an ALLCAPS name no longer vetoes masking when PII context present."""
         from memory.security_scanner import _should_mask_low_precision_pii

--- a/tests/unit/test_security_scanner.py
+++ b/tests/unit/test_security_scanner.py
@@ -1282,12 +1282,13 @@ class TestNameHandlePrecisionGate:
             ), f"{span!r} must not mask via dropped cue: {content!r}"
 
     def test_m_c_inflected_cues_mask(self):
-        """M-C: gerund/inflected forms of retained verb families mask a name."""
+        """M-C: gerund/inflected forms of retained verb families mask a multi-token
+        name. (The bare "meeting"/"call" forms were dropped — they collide with
+        common nouns in technical prose; see test_verb_cue_noun_collision_*.)"""
         from memory.security_scanner import _should_mask_low_precision_pii
 
         for content in (
             "contacting John Smith tomorrow",
-            "meeting Jordan Lee at noon",
             "reaching Jordan Lee by phone",
         ):
             span = "John Smith" if "John Smith" in content else "Jordan Lee"
@@ -1295,6 +1296,100 @@ class TestNameHandlePrecisionGate:
                 _should_mask_low_precision_pii(content, _name_finding(content, span))
                 is True
             ), f"inflected cue should mask: {content!r}"
+
+    def test_verb_cue_single_token_tech_not_masked(self):
+        """BUG-320 (cycle-2 F-1): a retained communication-verb cue next to a lone
+        technical token (non-allow-listed) must NOT mask — the multi-token
+        discriminator keeps single-token tech names unmasked."""
+        from memory.security_scanner import _should_mask_low_precision_pii
+
+        for content, span in (
+            ("contacting Watson for the model", "Watson"),
+            ("reaching Cassandra for the keyspace", "Cassandra"),
+            ("we call Kafka asynchronously", "Kafka"),
+            ("meet Jenkins at the build stage", "Jenkins"),
+        ):
+            assert (
+                _should_mask_low_precision_pii(content, _name_finding(content, span))
+                is False
+            ), f"verb cue + single-token tech must not mask: {content!r}"
+
+    def test_verb_cue_noun_collision_not_masked(self):
+        """BUG-320 (cycle-2): the dropped bare noun/verb cues
+        ("meeting"/"call"/"meet"/"reach") no longer mask an adjacent name in
+        attribution prose (standup notes, handoff logs)."""
+        from memory.security_scanner import _should_mask_low_precision_pii
+
+        for content, span in (
+            ("The standup meeting Jordan Lee attended", "Jordan Lee"),
+            ("weekly meeting John Smith scheduled", "John Smith"),
+            ("The function call John Smith registered", "John Smith"),
+            ("On the call John Smith made a point", "John Smith"),
+        ):
+            assert (
+                _should_mask_low_precision_pii(content, _name_finding(content, span))
+                is False
+            ), f"dropped noun cue must not mask: {content!r}"
+
+    def test_real_pii_still_masks_after_curation(self):
+        """The curation keeps genuine PII masked: "contact" + multi-token name."""
+        from memory.security_scanner import _should_mask_low_precision_pii
+
+        content = "Please contact John Smith about the issue"
+        assert (
+            _should_mask_low_precision_pii(
+                content, _name_finding(content, "John Smith")
+            )
+            is True
+        )
+
+    def test_allowlist_wins_over_pii_context(self):
+        """L-C (cycle-2 F-3): an allow-listed token is never masked even with an
+        adjacent PII cue."""
+        from memory.security_scanner import _should_mask_low_precision_pii
+
+        for content, span in (
+            ("contact Claude about the incident", "Claude"),
+            ("Dear Parzival, regards", "Parzival"),
+        ):
+            assert (
+                _should_mask_low_precision_pii(content, _name_finding(content, span))
+                is False
+            ), f"allow-listed token must win over PII context: {content!r}"
+
+    def test_from_reply_header_masks_name(self):
+        """cycle-2 F-4: "From:" reply headers (GitHub/Jira threads) mask a
+        multi-token name without firing on Python "from x import"."""
+        from memory.security_scanner import _should_mask_low_precision_pii
+
+        masks = "From: John Smith wrote the summary"
+        assert (
+            _should_mask_low_precision_pii(masks, _name_finding(masks, "John Smith"))
+            is True
+        )
+        no_mask = "from memory import SecurityScanner"
+        assert (
+            _should_mask_low_precision_pii(no_mask, _name_finding(no_mask, "memory"))
+            is False
+        )
+
+    def test_index_prose_line_masks_name(self):
+        """cycle-2 F-2: a non-git "index " prose line no longer exempts a name with
+        adjacent PII context, while a real git index line stays structural."""
+        from memory.security_scanner import _should_mask_low_precision_pii
+
+        prose = "index 42: contact John Smith about this"
+        assert (
+            _should_mask_low_precision_pii(prose, _name_finding(prose, "John Smith"))
+            is True
+        )
+        git_line = "index abc123..def456 100644 Jordan Lee"
+        assert (
+            _should_mask_low_precision_pii(
+                git_line, _name_finding(git_line, "Jordan Lee")
+            )
+            is False
+        )
 
     def test_m_a_allcaps_name_with_context_is_masked(self):
         """M-A: an ALLCAPS name no longer vetoes masking when PII context present."""
@@ -1488,6 +1583,33 @@ class TestNamePrecisionEndToEnd:
 
         assert result.action == ScanAction.BLOCKED
         assert result.content == ""
+
+    def test_verb_cue_over_masking_eliminated_end_to_end(self):
+        """cycle-2 F-1/F-4: verb-cue + tech-token and noun-collision attribution
+        prose stay UN-masked through the full scan() pipeline, while genuine PII
+        with a verb cue still masks."""
+        from memory.security_scanner import ScanAction, SecurityScanner
+
+        scanner = SecurityScanner(enable_ner=True)
+        for content in (
+            "we call Kafka asynchronously",
+            "contacting Watson for the model",
+            "meet Jenkins at the build stage",
+            "reaching Cassandra for the keyspace",
+            "The standup meeting Jordan Lee attended",
+            "weekly meeting John Smith scheduled",
+            "The function call John Smith registered",
+            "On the call John Smith made a point",
+        ):
+            result = scanner.scan(content)
+            assert "[NAME_REDACTED]" not in result.content, content
+            assert result.content == content, content
+            assert result.action == ScanAction.PASSED, content
+
+        masked = scanner.scan("Please contact John Smith about the issue")
+        assert masked.action == ScanAction.MASKED
+        assert "[NAME_REDACTED]" in masked.content
+        assert "John Smith" not in masked.content
 
 
 class TestHandleStructuralExclusion:

--- a/tests/unit/test_security_scanner.py
+++ b/tests/unit/test_security_scanner.py
@@ -1128,3 +1128,196 @@ class TestSecurityScannerInitLog:
         # requires the missing-model path not raise.
         result = scanner.scan("Plain text without PII.")
         assert result.action in (ScanAction.PASSED, ScanAction.MASKED)
+
+
+# ============================================================================
+# BUG-320 / BP-174 Q5: low-precision NAME/HANDLE redaction precision
+# ============================================================================
+# The SpaCy PERSON recognizer mis-tags technical proper nouns ("Docker"), diff
+# hunk headers, and filenames as PERSON and masked them DESTRUCTIVELY at storage
+# time, permanently corrupting stored content. The precision gate leaves
+# allow-listed tokens, structural/technical patterns, and context-free names
+# UNMASKED while keeping genuine PII (a name with PII context) and all secrets
+# strictly masked.
+
+
+def _name_finding(content, span):
+    """Build a PII_NAME ScanFinding for `span` within `content` (deterministic,
+    no SpaCy needed) so the precision gate can be unit-tested directly."""
+    from memory.security_scanner import FindingType, ScanFinding
+
+    start = content.index(span)
+    return ScanFinding(
+        finding_type=FindingType.PII_NAME,
+        layer=3,
+        original_text=span,
+        replacement="[NAME_REDACTED]",
+        confidence=0.80,
+        start=start,
+        end=start + len(span),
+    )
+
+
+class TestNameHandlePrecisionGate:
+    """BUG-320: precision gate predicate for NAME/HANDLE candidates."""
+
+    def test_allowlisted_technical_proper_nouns_not_masked(self):
+        from memory.security_scanner import _should_mask_low_precision_pii
+
+        content = "Phase 2 (Docker daemon restart) uses Qdrant and Claude Code"
+        for token in ("Docker", "Qdrant", "Claude Code"):
+            assert (
+                _should_mask_low_precision_pii(content, _name_finding(content, token))
+                is False
+            ), f"{token!r} should be allow-listed (never masked)"
+
+    def test_filename_tokens_not_masked(self):
+        from memory.security_scanner import _should_mask_low_precision_pii
+
+        content = "See CLAUDE.md and AGENTS.md plus config.py for details"
+        for token in ("CLAUDE.md", "AGENTS.md", "config.py"):
+            assert (
+                _should_mask_low_precision_pii(content, _name_finding(content, token))
+                is False
+            ), f"{token!r} (filename) should not be masked"
+
+    def test_diff_hunk_header_not_masked(self):
+        from memory.security_scanner import _should_mask_low_precision_pii
+
+        content = "@@ -205,7 +205,9 @@ Jordan Lee edited the function"
+        # Even a real-looking name on a diff hunk header line is structural.
+        assert (
+            _should_mask_low_precision_pii(
+                content, _name_finding(content, "Jordan Lee")
+            )
+            is False
+        )
+
+    def test_markdown_heading_not_masked(self):
+        from memory.security_scanner import _should_mask_low_precision_pii
+
+        content = "### 10. Release notes by Jordan Lee"
+        assert (
+            _should_mask_low_precision_pii(
+                content, _name_finding(content, "Jordan Lee")
+            )
+            is False
+        )
+
+    def test_name_without_pii_context_not_masked(self):
+        from memory.security_scanner import _should_mask_low_precision_pii
+
+        content = "Parzival dispatched the agent and Jordan Lee shipped it"
+        assert (
+            _should_mask_low_precision_pii(
+                content, _name_finding(content, "Jordan Lee")
+            )
+            is False
+        )
+
+    def test_name_with_pii_context_is_masked(self):
+        from memory.security_scanner import _should_mask_low_precision_pii
+
+        for content in (
+            "Please contact Jordan Lee about the account",
+            "Jordan Lee wrote a long letter",
+            "Dear Jordan Lee, regards",
+        ):
+            assert (
+                _should_mask_low_precision_pii(
+                    content, _name_finding(content, "Jordan Lee")
+                )
+                is True
+            ), f"name with PII context should mask: {content!r}"
+
+
+class TestNamePrecisionEndToEnd:
+    """BUG-320: NAME masking through the full scan() pipeline (Layer 3 NER)."""
+
+    @pytest.fixture(autouse=True)
+    def _require_spacy(self):
+        from memory.security_scanner import _load_spacy_model
+
+        if _load_spacy_model() is None:
+            pytest.skip("SpaCy model not available")
+
+    @pytest.fixture(autouse=True)
+    def _disable_detect_secrets(self, monkeypatch):
+        monkeypatch.setattr("memory.security_scanner._detect_secrets_available", False)
+
+    def test_sampled_false_positives_pass_unmasked(self):
+        from memory.security_scanner import ScanAction, SecurityScanner
+
+        scanner = SecurityScanner(enable_ner=True)
+        for content in (
+            "Phase 2 (Docker daemon restart)",
+            "@@ -205,7 +205,9 @@ def handler():",
+            "### 10. Release steps for Docker",
+            "Read CLAUDE.md and AGENTS.md before starting",
+        ):
+            result = scanner.scan(content)
+            assert "[NAME_REDACTED]" not in result.content, content
+            assert result.content == content
+            assert result.action == ScanAction.PASSED
+
+    def test_real_person_name_with_context_still_masked(self):
+        from memory.security_scanner import ScanAction, SecurityScanner
+
+        scanner = SecurityScanner(enable_ner=True)
+        result = scanner.scan("Please contact John Smith at the office.")
+
+        assert result.action == ScanAction.MASKED
+        assert "[NAME_REDACTED]" in result.content
+        assert "John Smith" not in result.content
+        # The candidate is still recorded for observability even when masked.
+        assert any(f.finding_type.value == "pii_name" for f in result.findings)
+
+    def test_false_positive_name_recorded_but_not_masked(self):
+        """A mis-tagged technical token is still surfaced as a finding (for
+        observability) but its replacement is cleared so content is preserved."""
+        from memory.security_scanner import SecurityScanner
+
+        scanner = SecurityScanner(enable_ner=True)
+        result = scanner.scan("Phase 2 (Docker daemon restart)")
+
+        name_findings = [
+            f for f in result.findings if f.finding_type.value == "pii_name"
+        ]
+        if name_findings:  # SpaCy tags "Docker" as PERSON
+            assert all(f.replacement is None for f in name_findings)
+
+    def test_secrets_still_blocked_with_ner(self):
+        from memory.security_scanner import ScanAction, SecurityScanner
+
+        scanner = SecurityScanner(enable_ner=True)
+        result = scanner.scan("Token ghp_" + "a" * 36 + " from John Smith")
+
+        assert result.action == ScanAction.BLOCKED
+        assert result.content == ""
+
+
+class TestHandleStructuralExclusion:
+    """BUG-320: handles on diff/heading/comment lines are not PII, while ordinary
+    @mention masking (intentional behavior) is preserved."""
+
+    @pytest.fixture(autouse=True)
+    def _disable_detect_secrets(self, monkeypatch):
+        monkeypatch.setattr("memory.security_scanner._detect_secrets_available", False)
+
+    def test_handle_on_markdown_heading_not_masked(self):
+        from memory.security_scanner import SecurityScanner
+
+        scanner = SecurityScanner(enable_ner=False)
+        result = scanner.scan("# Thanks to @octocat for the heading")
+
+        assert "[HANDLE_REDACTED]" not in result.content
+        assert "@octocat" in result.content
+
+    def test_handle_in_prose_still_masked(self):
+        from memory.security_scanner import ScanAction, SecurityScanner
+
+        scanner = SecurityScanner(enable_ner=False)
+        result = scanner.scan("Thanks to @octocat for the review")
+
+        assert result.action == ScanAction.MASKED
+        assert "[HANDLE_REDACTED]" in result.content

--- a/tests/unit/test_security_scanner.py
+++ b/tests/unit/test_security_scanner.py
@@ -614,6 +614,37 @@ class TestScanBatchNER:
         # Layer 3 should have been executed
         assert all(3 in r.layers_executed for r in results)
 
+    def test_batch_precision_gate_applied(self):
+        """M-E: the precision gate runs on the scan_batch() NER path — a
+        technical false positive is preserved while genuine PII is masked.
+        Guards the production bulk path (different offset computation)."""
+        from memory.security_scanner import (
+            ScanAction,
+            SecurityScanner,
+            _load_spacy_model,
+        )
+
+        if _load_spacy_model() is None:
+            pytest.skip("SpaCy not available")
+
+        scanner = SecurityScanner(enable_ner=False)
+        results = scanner.scan_batch(
+            [
+                "Refactored the Kafka client wrapper",  # technical FP
+                "Please contact John Smith urgently",  # genuine PII
+            ],
+            force_ner=True,
+        )
+
+        assert len(results) == 2
+        # FP path: preserved, never masked.
+        assert "[NAME_REDACTED]" not in results[0].content
+        assert results[0].content == "Refactored the Kafka client wrapper"
+        # PII path: masked.
+        assert results[1].action == ScanAction.MASKED
+        assert "[NAME_REDACTED]" in results[1].content
+        assert "John Smith" not in results[1].content
+
     def test_batch_blocked_texts_excluded_from_ner(self):
         """Test that BLOCKED texts skip NER processing."""
         from memory.security_scanner import (
@@ -1146,6 +1177,9 @@ def _name_finding(content, span):
     no SpaCy needed) so the precision gate can be unit-tested directly."""
     from memory.security_scanner import FindingType, ScanFinding
 
+    # L-B: guard against content.index() first-occurrence ambiguity — the span
+    # must appear exactly once so start/end unambiguously locate the candidate.
+    assert content.count(span) == 1, f"span {span!r} must occur exactly once"
     start = content.index(span)
     return ScanFinding(
         finding_type=FindingType.PII_NAME,
@@ -1230,6 +1264,152 @@ class TestNameHandlePrecisionGate:
                 is True
             ), f"name with PII context should mask: {content!r}"
 
+    def test_h_a_code_ubiquitous_cues_do_not_mask(self):
+        """H-A: dropped code-ubiquitous cues (client/manager/person/…) no longer
+        trigger masking of an adjacent technical proper noun."""
+        from memory.security_scanner import _should_mask_low_precision_pii
+
+        # spaCy can mis-tag "Kafka"/"Datadog" as PERSON; "client"/"manager" used
+        # to flip them to masked. They must now pass through.
+        for content, span in (
+            ("Refactored the Kafka client wrapper", "Kafka"),
+            ("Datadog manager dashboard config", "Datadog"),
+            ("The Splunk customer integration", "Splunk"),
+        ):
+            assert (
+                _should_mask_low_precision_pii(content, _name_finding(content, span))
+                is False
+            ), f"{span!r} must not mask via dropped cue: {content!r}"
+
+    def test_m_c_inflected_cues_mask(self):
+        """M-C: gerund/inflected forms of retained verb families mask a name."""
+        from memory.security_scanner import _should_mask_low_precision_pii
+
+        for content in (
+            "contacting John Smith tomorrow",
+            "meeting Jordan Lee at noon",
+            "reaching Jordan Lee by phone",
+        ):
+            span = "John Smith" if "John Smith" in content else "Jordan Lee"
+            assert (
+                _should_mask_low_precision_pii(content, _name_finding(content, span))
+                is True
+            ), f"inflected cue should mask: {content!r}"
+
+    def test_m_a_allcaps_name_with_context_is_masked(self):
+        """M-A: an ALLCAPS name no longer vetoes masking when PII context present."""
+        from memory.security_scanner import _should_mask_low_precision_pii
+
+        content = "Please contact JOHN SMITH urgently"
+        assert (
+            _should_mask_low_precision_pii(
+                content, _name_finding(content, "JOHN SMITH")
+            )
+            is True
+        )
+
+    def test_m_a_allcaps_token_without_context_not_masked(self):
+        """M-A: ALLCAPS doc-name tokens without PII context still pass through."""
+        from memory.security_scanner import _should_mask_low_precision_pii
+
+        content = "See AGENTS and README for setup"
+        assert (
+            _should_mask_low_precision_pii(content, _name_finding(content, "AGENTS"))
+            is False
+        )
+
+    def test_h_b_reply_header_dashes_not_structural(self):
+        """H-B: an email/Jira reply header ('--- John Smith wrote:') is NOT a git
+        diff header, so the name is decided by PII context (and masks here)."""
+        from memory.security_scanner import _should_mask_low_precision_pii
+
+        content = "--- John Smith wrote:"
+        assert (
+            _should_mask_low_precision_pii(
+                content, _name_finding(content, "John Smith")
+            )
+            is True
+        )
+
+    def test_h_b_git_diff_file_header_still_structural(self):
+        """H-B: a genuine git unified-diff file header stays structural (exempt)."""
+        from memory.security_scanner import _should_mask_low_precision_pii
+
+        content = "--- a/John Smith.py"
+        assert (
+            _should_mask_low_precision_pii(
+                content, _name_finding(content, "John Smith")
+            )
+            is False
+        )
+
+    def test_m_b_name_on_heading_with_context_is_masked(self):
+        """M-B: bare-'#' heading no longer exempts a NAME; PII context decides."""
+        from memory.security_scanner import _should_mask_low_precision_pii
+
+        content = "# Contact: Jane Doe, customer"
+        assert (
+            _should_mask_low_precision_pii(content, _name_finding(content, "Jane Doe"))
+            is True
+        )
+
+
+class TestPrecisionGateMaskApplication:
+    """BUG-320: deterministic, model-less coverage of the precision gate's
+    mask-application step (`_apply_masks_and_determine_action`) using hand-built
+    findings — no SpaCy required, so it runs on CI without the NER model."""
+
+    def _scanner(self):
+        from memory.security_scanner import SecurityScanner
+
+        return SecurityScanner(enable_ner=False)
+
+    def test_false_positive_name_recorded_but_not_masked(self):
+        """L-B: a mis-tagged technical token is surfaced as a finding (for
+        observability) but its replacement is cleared so content is preserved."""
+        content = "Phase 2 (Docker daemon restart)"
+        finding = _name_finding(content, "Docker")
+        masked, action = self._scanner()._apply_masks_and_determine_action(
+            content, [finding]
+        )
+
+        from memory.security_scanner import ScanAction
+
+        assert masked == content
+        assert action == ScanAction.PASSED
+        # Recorded for observability, but replacement cleared (not masked).
+        assert finding.replacement is None
+
+    def test_multi_segment_findings_realistic_offsets(self):
+        """L-A: feed multiple hand-built findings at realistic cumulative offsets
+        across a long multi-line body — the gate masks only the genuine-PII name
+        and preserves the technical false positive, applying right-to-left so the
+        offsets of earlier spans stay valid."""
+        from memory.security_scanner import ScanAction
+
+        # Two PERSON candidates far apart: a technical FP first, real PII later.
+        body = (
+            "Refactored the Kafka client wrapper for throughput.\n\n"
+            "Notes from the standup and the migration plan.\n\n"
+            "Please contact John Smith about the rollout."
+        )
+        fp = _name_finding(body, "Kafka")
+        pii = _name_finding(body, "John Smith")
+        # Realistic cumulative offsets (Kafka well before John Smith).
+        assert fp.start < pii.start
+
+        masked, action = self._scanner()._apply_masks_and_determine_action(
+            body, [fp, pii]
+        )
+
+        assert action == ScanAction.MASKED
+        assert "Kafka client wrapper" in masked  # FP preserved
+        assert fp.replacement is None
+        assert "[NAME_REDACTED]" in masked  # real PII masked
+        assert "John Smith" not in masked
+        # The earlier text is otherwise byte-identical up to the masked span.
+        assert masked.startswith("Refactored the Kafka client wrapper")
+
 
 class TestNamePrecisionEndToEnd:
     """BUG-320: NAME masking through the full scan() pipeline (Layer 3 NER)."""
@@ -1272,19 +1452,33 @@ class TestNamePrecisionEndToEnd:
         # The candidate is still recorded for observability even when masked.
         assert any(f.finding_type.value == "pii_name" for f in result.findings)
 
-    def test_false_positive_name_recorded_but_not_masked(self):
-        """A mis-tagged technical token is still surfaced as a finding (for
-        observability) but its replacement is cleared so content is preserved."""
+    def test_no_context_name_passes_unmasked(self):
+        """M-D: a PERSON name with no adjacent PII cue passes through scan()
+        UN-masked (precision-first); content is byte-identical."""
+        from memory.security_scanner import ScanAction, SecurityScanner
+
+        scanner = SecurityScanner(enable_ner=True)
+        content = "Jordan Lee shipped the release on Friday."
+        result = scanner.scan(content)
+
+        assert "[NAME_REDACTED]" not in result.content
+        assert result.content == content
+        assert result.action == ScanAction.PASSED
+
+    def test_over_masking_eliminated_for_technical_content(self):
+        """Must-verify (over-masking): technical proper nouns / tool names with
+        only code-ubiquitous neighbors are never masked through scan()."""
         from memory.security_scanner import SecurityScanner
 
         scanner = SecurityScanner(enable_ner=True)
-        result = scanner.scan("Phase 2 (Docker daemon restart)")
-
-        name_findings = [
-            f for f in result.findings if f.finding_type.value == "pii_name"
-        ]
-        if name_findings:  # SpaCy tags "Docker" as PERSON
-            assert all(f.replacement is None for f in name_findings)
+        for content in (
+            "Refactored the Kafka client wrapper",
+            "The Grafana manager dashboard",
+            "Docker daemon restart configuration",
+        ):
+            result = scanner.scan(content)
+            assert "[NAME_REDACTED]" not in result.content, content
+            assert result.content == content, content
 
     def test_secrets_still_blocked_with_ner(self):
         from memory.security_scanner import ScanAction, SecurityScanner
@@ -1321,3 +1515,15 @@ class TestHandleStructuralExclusion:
 
         assert result.action == ScanAction.MASKED
         assert "[HANDLE_REDACTED]" in result.content
+
+    def test_handle_with_incidental_at_at_in_prose_still_masked(self):
+        """M-B: '@@' anchored to start-of-line — an incidental '@@' mid-prose no
+        longer exempts a real @handle on that line (was under-masking)."""
+        from memory.security_scanner import ScanAction, SecurityScanner
+
+        scanner = SecurityScanner(enable_ner=False)
+        result = scanner.scan("Build failed @@ stage; ping @octocat to retry")
+
+        assert result.action == ScanAction.MASKED
+        assert "[HANDLE_REDACTED]" in result.content
+        assert "@octocat" not in result.content


### PR DESCRIPTION
Three correctness fixes to the tier-2 ambient memory-injection path.

## Relevance gating (BUG-319)
The tier-2 injection relevance gate keyed on a per-set min-max-normalized RRF score that pins the top result near 0.95 for *every* query, so the gate could never skip — off-topic, same-domain content was injected on every turn. This adds a separate **absolute raw-cosine** relevance signal (channel kept distinct from the banded ordering score) with a calibrated floor (0.76, derived from a read-only live sweep), a top-1/top-2 margin, an absolute freshness cap, and topic-drift suppression. The gate is **strictly additive** — it can only add a skip on top of the existing per-collection gate, never force an injection. Routes with no dense signal (e.g. code-patterns, whose dense neighborhood is near-orthogonal to NL queries) defer to the prior gate. `_attach_raw_cosine` is opt-in, so only the tier-2 path pays the extra query.

## Redaction precision (BUG-320)
Storage-time NAME/HANDLE recognizers over-masked technical proper nouns, filenames, and diff headers, permanently corrupting stored content at write time. Redaction is now precision-first: an allow-list of technical terms, a PII-context gate with a multi-token discriminator for high-ambiguity communication cues, and narrowed structural exclusions (git diff/index lines). Secret, key, password, email, and IP recognizers are unchanged and remain strict; HANDLE redaction stays structural-only.

## Reject observability (BUG-302)
The budget-reject marker surfaced `tokens` and `budget` without `remaining`, so a correct reject (where the candidate exceeds the *remaining* budget) read as a contradiction. The marker now renders `tokens=… remaining=… budget=…` per the BP-158 §3.5 field semantics (`budget` is total).

## Testing
New and existing unit coverage across both areas: relevance-gate defer paths, the additive-only invariant, marker render, and calibration floor; redaction over-masking regressions, structural narrowing, and allow-list behavior. Full suite green; black/ruff/isort clean.
