### PR TITLE
Route agent_* memory types to discussions on the async/retry store paths (BUG-322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Agent memory types now route to the discussions collection on the async/retry store paths (BUG-322)** — the four agent memory types (`agent_handoff`, `agent_insight`, `agent_memory`, `agent_task`) were omitted from the type-to-collection selection in both `process_retry_queue.py` (`get_collection_for_type`) and `post_work_store_async.py` (`store_memory_async`), so they fell through to the code-patterns collection instead of discussions. This diverged from the authoritative `MemoryStorage.store_agent_memory` path and could store an agent record into the wrong collection (and miss the discussions original during dedup). Both selection sites now map all four types to the discussions collection, matching the store path.
+
 ## [2.7.0] - 2026-06-16
 
 ### Upgrade Instructions

--- a/scripts/memory/post_work_store_async.py
+++ b/scripts/memory/post_work_store_async.py
@@ -193,6 +193,10 @@ async def store_memory_async(payload: dict[str, Any]) -> None:
             "session_summary",
             "chat_memory",
             "agent_decision",
+            "agent_handoff",
+            "agent_memory",
+            "agent_task",
+            "agent_insight",
         ]:
             collection = COLLECTION_DISCUSSIONS
         # code-patterns: implementation, error_pattern, refactor, file_pattern

--- a/scripts/memory/process_retry_queue.py
+++ b/scripts/memory/process_retry_queue.py
@@ -76,6 +76,10 @@ def get_collection_for_type(memory_type: str) -> str:
         "agent_decision",
         "user_message",
         "agent_response",
+        "agent_handoff",
+        "agent_memory",
+        "agent_task",
+        "agent_insight",
     ]:
         return COLLECTION_DISCUSSIONS
     else:

--- a/tests/unit/test_bug322_collection_routing.py
+++ b/tests/unit/test_bug322_collection_routing.py
@@ -1,0 +1,118 @@
+"""BUG-322: agent_* memory types must route to the discussions collection.
+
+The authoritative store path (``MemoryStorage.store_agent_memory``) stores the
+four agent memory types — ``agent_handoff``, ``agent_insight``,
+``agent_memory``, ``agent_task`` — plus ``decision`` into
+``COLLECTION_DISCUSSIONS``. Two downstream selection sites independently mapped
+memory types to collections and omitted the four ``agent_*`` types, so on the
+async/retry paths those records were routed to ``COLLECTION_CODE_PATTERNS``
+instead. These tests pin both sites to the authoritative collection.
+
+No live Qdrant: the retry site is a pure function; the post-work site is driven
+with a mocked ``MemoryStorage``.
+"""
+
+import asyncio
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from memory.config import (
+    COLLECTION_CODE_PATTERNS,
+    COLLECTION_CONVENTIONS,
+    COLLECTION_DISCUSSIONS,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_RETRY_SCRIPT = _REPO_ROOT / "scripts" / "memory" / "process_retry_queue.py"
+_POST_WORK_SCRIPT = _REPO_ROOT / "scripts" / "memory" / "post_work_store_async.py"
+
+AGENT_TYPES = ["agent_handoff", "agent_insight", "agent_memory", "agent_task"]
+
+
+def _load_script(name: str, path: Path):
+    """Import a scripts/memory/*.py file as a standalone module."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestRetryQueueCollectionRouting:
+    """scripts/memory/process_retry_queue.py :: get_collection_for_type."""
+
+    @pytest.fixture(autouse=True)
+    def _load(self, monkeypatch):
+        if not _RETRY_SCRIPT.exists():
+            pytest.skip(f"Script not found: {_RETRY_SCRIPT}")
+        # The script resolves src/ from AI_MEMORY_INSTALL_DIR; point it at the repo.
+        monkeypatch.setenv("AI_MEMORY_INSTALL_DIR", str(_REPO_ROOT))
+        self.mod = _load_script("process_retry_queue", _RETRY_SCRIPT)
+
+    @pytest.mark.parametrize("memory_type", AGENT_TYPES)
+    def test_agent_types_route_to_discussions(self, memory_type):
+        assert self.mod.get_collection_for_type(memory_type) == COLLECTION_DISCUSSIONS
+
+    def test_decision_routes_to_discussions(self):
+        assert self.mod.get_collection_for_type("decision") == COLLECTION_DISCUSSIONS
+
+    def test_conventions_type_routes_to_conventions(self):
+        assert self.mod.get_collection_for_type("guideline") == COLLECTION_CONVENTIONS
+
+    def test_unmapped_type_falls_through_to_code_patterns(self):
+        assert (
+            self.mod.get_collection_for_type("implementation")
+            == COLLECTION_CODE_PATTERNS
+        )
+
+
+class TestPostWorkCollectionRouting:
+    """scripts/memory/post_work_store_async.py :: store_memory_async."""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        if not _POST_WORK_SCRIPT.exists():
+            pytest.skip(f"Script not found: {_POST_WORK_SCRIPT}")
+        self.mod = _load_script("post_work_store_async", _POST_WORK_SCRIPT)
+
+    def _run_store(self, memory_type):
+        """Drive store_memory_async with a mocked storage; return store kwargs."""
+        mock_storage = MagicMock()
+        mock_storage.store_memory.return_value = {
+            "status": "stored",
+            "memory_id": "test-id",
+            "embedding_status": "complete",
+        }
+        payload = {
+            "content": "x" * 50,
+            "metadata": {
+                "type": memory_type,
+                "group_id": "test-project",
+                "cwd": "/tmp",
+            },
+        }
+        with (
+            patch.object(self.mod, "MemoryStorage", return_value=mock_storage),
+            patch("memory.project.resolve_project_id", return_value="test-project"),
+            patch.object(self.mod, "_log_to_activity"),
+            patch.object(self.mod, "memory_captures_total", None),
+            patch.object(self.mod, "deduplication_events_total", None),
+        ):
+            asyncio.run(self.mod.store_memory_async(payload))
+
+        mock_storage.store_memory.assert_called_once()
+        return mock_storage.store_memory.call_args[1]
+
+    @pytest.mark.parametrize("memory_type", AGENT_TYPES)
+    def test_agent_types_route_to_discussions(self, memory_type):
+        assert self._run_store(memory_type)["collection"] == COLLECTION_DISCUSSIONS
+
+    def test_decision_routes_to_discussions(self):
+        assert self._run_store("decision")["collection"] == COLLECTION_DISCUSSIONS
+
+    def test_unmapped_type_falls_through_to_code_patterns(self):
+        assert (
+            self._run_store("implementation")["collection"] == COLLECTION_CODE_PATTERNS
+        )


### PR DESCRIPTION
## Summary

The four agent memory types (`agent_handoff`, `agent_insight`, `agent_memory`, `agent_task`) were omitted from the type-to-collection selection on two downstream store paths, so they fell through to the **code-patterns** collection instead of **discussions**. This diverged from the authoritative `MemoryStorage.store_agent_memory` path (which stores those types to discussions), so a retried or async-stored agent record could land in the wrong collection — and, because dedup then searches the wrong collection, produce a duplicate while the discussions original goes unhealed.

## Changes

- `scripts/memory/process_retry_queue.py` (`get_collection_for_type`) — add the four `agent_*` types to the discussions branch. This is the reachable path: agent records whose initial store fails are drained here and re-routed.
- `scripts/memory/post_work_store_async.py` (`store_memory_async`) — same four types added to the inline discussions selection. Currently latent (no caller feeds `agent_*` to this path today), fixed as defense-in-depth so it cannot drift into a live defect.
- `tests/unit/test_bug322_collection_routing.py` — new deterministic regression test (no live Qdrant) covering both sites: all four `agent_*` types → discussions, plus regression guards for `decision`, conventions, and the code-patterns fallthrough.
- `CHANGELOG.md` — Fixed entry under `[Unreleased]`.

## Verification

- New test: fails on pre-fix code (8 failures — the four `agent_*` assertions across both sites), passes after the fix (13 passed).
- Full unit suite green aside from pre-existing, environment-dependent `TestGitHubConfig` defaults checks (the GitHub connector is unchanged by this PR).

## Notes / follow-ups (out of scope, tracked)

- A shared source-of-truth constant for the agent-type → collection mapping (the lists are currently hand-maintained in 3+ places and have drifted) — tracked as TD-691.
- One-time backfill of any agent records already misrouted to code-patterns before this fix — tracked as TD-692 (investigation-gated).