### PR TITLE
Bound Jira connector at-exit Langfuse drain to prevent teardown wedge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Jira connector at-exit Langfuse drain no longer wedges process teardown** — the `atexit`-registered shutdown hook in the Jira sync connector now bounds its `flush()`/`shutdown()` with an external watchdog (the V4 SDK's `flush()`/`shutdown()` take no timeout and block on the worker queue join when a backend is reachable but slow to drain), and skips the drain and its registration entirely when Langfuse is disabled at the app level. Local unit suites with a reachable Langfuse no longer appear to hang after the final test.
+- **Jira connector at-exit Langfuse drain no longer wedges process teardown** — the `atexit`-registered shutdown hook in the Jira sync connector now bounds its `flush()`/`shutdown()` with an external watchdog (the V4 SDK's `flush()`/`shutdown()` take no timeout and block on the worker queue join when a backend is reachable but slow to drain), and skips the drain and its registration entirely when Langfuse is disabled at the app level. Scoped to the Jira connector's at-exit hook only: local unit suites that import the Jira sync connector no longer appear to hang after the final test on account of that hook (the sibling at-exit sites in other modules are addressed separately).
 
 ## [2.7.0] - 2026-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Jira connector at-exit Langfuse drain no longer wedges process teardown** — the `atexit`-registered shutdown hook in the Jira sync connector now bounds its `flush()`/`shutdown()` with an external watchdog (the V4 SDK's `flush()`/`shutdown()` take no timeout and block on the worker queue join when a backend is reachable but slow to drain), and skips the drain and its registration entirely when Langfuse is disabled at the app level. Local unit suites with a reachable Langfuse no longer appear to hang after the final test.
+
 ## [2.7.0] - 2026-06-16
 
 ### Upgrade Instructions

--- a/src/memory/connectors/jira/sync.py
+++ b/src/memory/connectors/jira/sync.py
@@ -19,7 +19,8 @@ Error Handling:
 """
 
 # LANGFUSE: Uses trace buffer (Path A). See LANGFUSE-INTEGRATION-SPEC.md §3.1, §4, §7.7
-# SDK VERSION: V4. Path A files use emit_trace_event() only — no direct langfuse import.
+# SDK VERSION: V4. Tracing uses emit_trace_event() only (Path A); get_client() is
+# imported solely for the atexit drain lifecycle (TD-625), not for tracing.
 # CONSTANT: TRACE_CONTENT_MAX = 10000 (no other value permitted)
 
 import asyncio
@@ -63,6 +64,8 @@ except ImportError:
 # drain therefore runs in a daemon thread bounded EXTERNALLY by a watchdog join
 # (langfuse-guard §5 / BP-168 addendum); flush(timeout=…)/shutdown(timeout=…)
 # do not exist in V4.
+# 5s: best-effort at-exit local drain bound — deliberately short and distinct from
+# the stop-hook's longer in-flow LANGFUSE_FLUSH_TIMEOUT_SECONDS (default 15s).
 _LANGFUSE_SHUTDOWN_TIMEOUT_SECONDS = 5.0
 
 

--- a/src/memory/connectors/jira/sync.py
+++ b/src/memory/connectors/jira/sync.py
@@ -28,6 +28,7 @@ import contextlib
 import json
 import logging
 import os
+import threading
 from datetime import datetime, timezone
 from typing import Any
 from urllib.parse import urlparse
@@ -50,10 +51,35 @@ try:
 except ImportError:
     _langfuse_get_client = None  # type: ignore[assignment]
 
+try:
+    from ...langfuse_config import is_langfuse_enabled as _langfuse_enabled
+except ImportError:
+    _langfuse_enabled = None  # type: ignore[assignment]
+
+# External bound for the at-exit Langfuse drain. langfuse 4.7.1 flush() and
+# shutdown() take no timeout and block on the SDK worker's queue.join(), which
+# never returns when a reachable-but-slow backend keeps the queue non-empty
+# (TD-625) — the surrounding try/except catches exceptions, not a hang. The
+# drain therefore runs in a daemon thread bounded EXTERNALLY by a watchdog join
+# (langfuse-guard §5 / BP-168 addendum); flush(timeout=…)/shutdown(timeout=…)
+# do not exist in V4.
+_LANGFUSE_SHUTDOWN_TIMEOUT_SECONDS = 5.0
+
 
 def _langfuse_shutdown():
-    """Flush and shutdown Langfuse client on process exit (TD-248)."""
-    if _langfuse_get_client is not None:
+    """Flush and shutdown the Langfuse client on process exit (TD-248, TD-625).
+
+    Skipped entirely when Langfuse is disabled at the app level. The blocking
+    flush/shutdown runs in a daemon thread that is abandoned after
+    ``_LANGFUSE_SHUTDOWN_TIMEOUT_SECONDS`` so a reachable-but-slow backend can
+    never wedge process teardown.
+    """
+    if _langfuse_get_client is None:
+        return
+    if _langfuse_enabled is not None and not _langfuse_enabled():
+        return
+
+    def _drain():
         try:
             client = _langfuse_get_client()
             if client:
@@ -62,8 +88,14 @@ def _langfuse_shutdown():
         except Exception:
             pass
 
+    worker = threading.Thread(target=_drain, name="langfuse-atexit-drain", daemon=True)
+    worker.start()
+    worker.join(_LANGFUSE_SHUTDOWN_TIMEOUT_SECONDS)
 
-if _langfuse_get_client is not None:
+
+if _langfuse_get_client is not None and (
+    _langfuse_enabled is None or _langfuse_enabled()
+):
     atexit.register(_langfuse_shutdown)
 
 from .client import JiraClient

--- a/tests/unit/connectors/jira/test_sync_langfuse_shutdown.py
+++ b/tests/unit/connectors/jira/test_sync_langfuse_shutdown.py
@@ -1,0 +1,90 @@
+"""Tests for the at-exit Langfuse drain in the Jira sync connector (TD-625).
+
+Covers:
+- The drain cannot block past its external watchdog bound even when the
+  Langfuse SDK ``flush()`` hangs (reachable-but-slow backend).
+- The drain is skipped entirely when Langfuse is disabled at the app level.
+- ``atexit`` registration honors the app-level enabled flag.
+"""
+
+import atexit as _atexit
+import importlib
+import threading
+import time
+from unittest.mock import Mock
+
+from src.memory.connectors.jira import sync
+
+
+class _HangingClient:
+    """Fake Langfuse client whose flush() blocks until explicitly released."""
+
+    def __init__(self, release: threading.Event):
+        self._release = release
+        self.flush_started = threading.Event()
+
+    def flush(self):
+        self.flush_started.set()
+        self._release.wait()
+
+    def shutdown(self):
+        pass
+
+
+def test_shutdown_does_not_block_when_flush_hangs(monkeypatch):
+    """The watchdog bound must abandon a hanging flush instead of wedging."""
+    release = threading.Event()
+    client = _HangingClient(release)
+    monkeypatch.setattr(sync, "_langfuse_get_client", lambda: client)
+    monkeypatch.setattr(sync, "_langfuse_enabled", lambda: True)
+    monkeypatch.setattr(sync, "_LANGFUSE_SHUTDOWN_TIMEOUT_SECONDS", 0.3)
+
+    try:
+        start = time.monotonic()
+        sync._langfuse_shutdown()
+        elapsed = time.monotonic() - start
+
+        # The drain actually ran (flush was entered) ...
+        assert client.flush_started.wait(1.0)
+        # ... but returned bounded by the watchdog, not on the infinite flush.
+        assert elapsed < 5.0
+        # ... and it honored the external bound rather than returning instantly.
+        assert elapsed >= 0.25
+    finally:
+        # Release the abandoned daemon thread so it can finish cleanly.
+        release.set()
+
+
+def test_shutdown_skips_drain_when_disabled(monkeypatch):
+    """With the app-level flag off, the client is never even retrieved."""
+    get_client = Mock()
+    monkeypatch.setattr(sync, "_langfuse_get_client", get_client)
+    monkeypatch.setattr(sync, "_langfuse_enabled", lambda: False)
+
+    sync._langfuse_shutdown()
+
+    get_client.assert_not_called()
+
+
+def test_registration_honors_enabled_flag(monkeypatch):
+    """atexit registration is skipped when disabled, performed when enabled."""
+    registered: list[str] = []
+    monkeypatch.setattr(
+        _atexit,
+        "register",
+        lambda fn, *a, **k: (registered.append(getattr(fn, "__name__", "")), fn)[1],
+    )
+
+    try:
+        monkeypatch.setenv("LANGFUSE_ENABLED", "false")
+        importlib.reload(sync)
+        assert "_langfuse_shutdown" not in registered
+
+        registered.clear()
+        monkeypatch.setenv("LANGFUSE_ENABLED", "true")
+        importlib.reload(sync)
+        if sync._langfuse_get_client is not None:
+            assert "_langfuse_shutdown" in registered
+    finally:
+        # Restore a consistently initialized module for any later importers.
+        importlib.reload(sync)

--- a/tests/unit/connectors/jira/test_sync_langfuse_shutdown.py
+++ b/tests/unit/connectors/jira/test_sync_langfuse_shutdown.py
@@ -46,13 +46,28 @@ def test_shutdown_does_not_block_when_flush_hangs(monkeypatch):
 
         # The drain actually ran (flush was entered) ...
         assert client.flush_started.wait(1.0)
-        # ... but returned bounded by the watchdog, not on the infinite flush.
-        assert elapsed < 5.0
+        # ... but returned bounded by the watchdog (~2x the patched 0.3s bound),
+        # not on the infinite flush.
+        assert elapsed < 0.6
         # ... and it honored the external bound rather than returning instantly.
         assert elapsed >= 0.25
     finally:
         # Release the abandoned daemon thread so it can finish cleanly.
         release.set()
+
+
+def test_shutdown_flushes_and_shuts_down_on_normal_path(monkeypatch):
+    """On the normal path (enabled + healthy client) the drain must call BOTH
+    flush() and shutdown() exactly once — a no-op'd flush would otherwise pass
+    every other test in this module."""
+    client = Mock()
+    monkeypatch.setattr(sync, "_langfuse_get_client", lambda: client)
+    monkeypatch.setattr(sync, "_langfuse_enabled", lambda: True)
+
+    sync._langfuse_shutdown()
+
+    client.flush.assert_called_once()
+    client.shutdown.assert_called_once()
 
 
 def test_shutdown_skips_drain_when_disabled(monkeypatch):
@@ -83,8 +98,9 @@ def test_registration_honors_enabled_flag(monkeypatch):
         registered.clear()
         monkeypatch.setenv("LANGFUSE_ENABLED", "true")
         importlib.reload(sync)
-        if sync._langfuse_get_client is not None:
-            assert "_langfuse_shutdown" in registered
+        # langfuse is a hard project dependency, so _langfuse_get_client is always
+        # importable and the registration must occur unconditionally.
+        assert "_langfuse_shutdown" in registered
     finally:
         # Restore a consistently initialized module for any later importers.
         importlib.reload(sync)


### PR DESCRIPTION
## Summary

The `atexit`-registered `_langfuse_shutdown` hook in the Jira sync connector called `client.flush()` then `client.shutdown()` with no bound. Under the Langfuse V4 SDK both methods are zero-arg (no `timeout=`) and block on the worker's queue join, which never returns when a Langfuse backend is reachable but slow to drain. The surrounding `try/except` catches exceptions, not a hang, so local unit suites with a reachable Langfuse appeared to wedge after the final test completed.

## Changes

- Run `flush()`/`shutdown()` in a daemon thread bounded by an external watchdog `join(timeout)`, so teardown can never block past the bound regardless of drain state. (`flush(timeout=…)`/`shutdown(timeout=…)` do not exist in V4 — the bound must be external.)
- Skip the drain and its `atexit` registration entirely when Langfuse is disabled at the app level (`LANGFUSE_ENABLED`), via the shared `is_langfuse_enabled()` helper.
- Add tests asserting the drain cannot block past its watchdog bound when `flush()` hangs, that the drain is skipped when disabled, and that registration honors the enabled flag.

## Testing

- New + existing Jira sync unit tests pass (23 passed).
- `black` / `ruff` / `isort` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)