### PR TITLE
Refresh evaluation-dataset golden fixtures to Langfuse V4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Evaluation-dataset golden fixtures (`create_datasets.py`)** — refreshed the Langfuse seed fixtures and the file's governance header from stale V3-only guidance to the current V4 (OTel-based) SDK. The dataset previously seeded V3-era answers (a decision fixture, an insight fixture, a retrieval expectation, and a spec-excerpt chunking fixture) that could score outdated responses as correct; their content and `key_terms_required` now reflect V4, and the spec-excerpt fixture's token estimate is re-derived from its rewritten text. The coupled `test_create_datasets.py` assertions are updated to match.
+
 ## [2.7.0] - 2026-06-16
 
 ### Upgrade Instructions

--- a/scripts/create_datasets.py
+++ b/scripts/create_datasets.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # LANGFUSE: V4 SDK ONLY. See LANGFUSE-INTEGRATION-SPEC.md
-# FORBIDDEN: Langfuse(host=...) with explicit creds, start_span(), start_generation(), langfuse_context
+# FORBIDDEN (removed in V4): start_span(), start_generation(), V3 decorator context helpers
 # REQUIRED: get_client(), create_dataset(), create_dataset_item(), flush()
 """Create 5 Langfuse golden datasets for regression testing.
 
@@ -184,7 +184,7 @@ DS_01_ITEMS = [
             "type_filter": "decision",
         },
         "expected_output": {
-            "should_match": "DEC-068 mandates Langfuse V3 SDK only; V2 patterns forbidden; get_client() singleton",
+            "should_match": "The project standardized on the Langfuse V4 (OTel-based) SDK; get_client() is preferred for call sites and the bare Langfuse() constructor is also valid",
             "min_relevance": 0.85,
         },
     },
@@ -539,14 +539,14 @@ DS_03_ITEMS = [
         "input": {
             "agent_id": "parzival",
             "content_type": "decision",
-            "content": "DEC-068: Langfuse V3 SDK only in this project. Use get_client() singleton pattern. Never use the constructor with explicit creds. Rationale: V2/V3 divergence caused 13+ integration failures across 10 sessions.",
+            "content": "Decision: standardize on the Langfuse V4 (OTel-based) SDK in this project. Use get_client() as the singleton accessor for ordinary call sites; the bare Langfuse() constructor is also valid and returns the same singleton (only the explicit-credentials constructor form is discouraged). Rationale: V4 is the current generation; earlier V2/V3 SDK divergence caused repeated integration failures.",
             "skill": "parzival-save-handoff",
         },
         "expected_output": {
             "agent_id": "parzival",
             "retrieved_by_skill": "aim-parzival-bootstrap",
             "content_present": True,
-            "key_terms_required": ["DEC-068", "Langfuse", "V3", "get_client"],
+            "key_terms_required": ["Langfuse", "V4", "get_client", "OTel"],
             "min_relevance": 0.80,
         },
     },
@@ -554,7 +554,7 @@ DS_03_ITEMS = [
         "input": {
             "agent_id": "parzival",
             "content_type": "insight",
-            "content": "Insight from PM #145: When migrating Langfuse V2 to V3, the critical change is replacing Langfuse(public_key=..., secret_key=..., host=...) with get_client() which reads env vars automatically. The V3 SDK is OTel-based and not fully backward compatible.",
+            "content": "Insight: on the Langfuse V4 (OTel-based) SDK, get_client() returns a singleton that reads env vars automatically, and the bare Langfuse() constructor is equivalent. V4 removed several V3 methods (start_span, start_generation) and is not fully backward compatible with V2 or V3; the explicit-credentials constructor form is discouraged.",
             "skill": "parzival-save-handoff",
         },
         "expected_output": {
@@ -562,10 +562,8 @@ DS_03_ITEMS = [
             "retrieved_by_skill": "aim-parzival-bootstrap",
             "content_present": True,
             "key_terms_required": [
-                "PM #145",
                 "Langfuse",
-                "V2",
-                "V3",
+                "V4",
                 "get_client",
                 "OTel",
             ],
@@ -1400,14 +1398,14 @@ DS_05_ITEMS = [
     },
     {
         "input": {
-            "content": "## LANGFUSE-INTEGRATION-SPEC.md\n\n**Version**: 1.2  \n**Status**: AUTHORITATIVE\n\n### 2. CRITICAL: V3 SDK Only\n\nThe Langfuse Python SDK V3 (released May 2025) is OTel-based and NOT backward compatible with V2.\n\n```python\n# CORRECT — V3 singleton\nfrom langfuse import get_client\nlangfuse = get_client()\n\n# WRONG — V2 pattern: bypasses env config, do not use\n# Langfuse(host=...) with explicit creds is DISCOURAGED\n```\n\n### 3. Architecture: Dual Integration\n\nPath A (hooks): emit_trace_event() → JSON buffer → trace_flush_worker  \nPath B (services): get_client() → direct SDK calls",
+            "content": "## LANGFUSE-INTEGRATION-SPEC.md\n\n**Version**: 2.0  \n**Status**: AUTHORITATIVE\n\n### 2. CRITICAL: V4 SDK (OTel-Based)\n\nThe Langfuse Python SDK V4 is OTel-based and removed several V3 methods (start_span, start_generation, and the legacy decorator context helper). It is NOT backward compatible with V2 or V3.\n\n```python\n# CORRECT — V4 singleton accessor\nfrom langfuse import get_client\nlangfuse = get_client()\n\n# VALID — bare constructor returns the same singleton, reads env vars\nfrom langfuse import Langfuse\nlangfuse = Langfuse()\n```\n\n### 3. Architecture: Dual Integration\n\nPath A (hooks): emit_trace_event writes a JSON buffer drained by trace_flush_worker  \nPath B (services): get_client() makes direct SDK calls",
             "content_type": "markdown_with_code_blocks",
-            "estimated_tokens": 130,
+            "estimated_tokens": 178,
         },
         "expected_output": {
             "expected_chunk_count": 3,
             "chunk_strategy": "markdown_heading_with_code_preservation",
-            "avg_tokens_per_chunk": 43,
+            "avg_tokens_per_chunk": 59,
             "boundary_quality": "high",
             "chunker_type": "markdown",
         },

--- a/scripts/create_datasets.py
+++ b/scripts/create_datasets.py
@@ -554,7 +554,7 @@ DS_03_ITEMS = [
         "input": {
             "agent_id": "parzival",
             "content_type": "insight",
-            "content": "Insight: on the Langfuse V4 (OTel-based) SDK, get_client() returns a singleton that reads env vars automatically, and the bare Langfuse() constructor is equivalent. V4 removed several V3 methods (start_span, start_generation) and is not fully backward compatible with V2 or V3; the explicit-credentials constructor form is discouraged.",
+            "content": "Insight: migrating to the Langfuse V4 (OTel-based) SDK means replacing the span methods removed in V4. V4 removed start_span and start_generation; use the unified start_observation (as_type='span') instead. V4 is not fully backward compatible with V2 or V3, so any code still calling the old span methods breaks at runtime.",
             "skill": "parzival-save-handoff",
         },
         "expected_output": {
@@ -564,8 +564,8 @@ DS_03_ITEMS = [
             "key_terms_required": [
                 "Langfuse",
                 "V4",
-                "get_client",
-                "OTel",
+                "start_observation",
+                "start_span",
             ],
             "min_relevance": 0.80,
         },
@@ -1398,7 +1398,7 @@ DS_05_ITEMS = [
     },
     {
         "input": {
-            "content": "## LANGFUSE-INTEGRATION-SPEC.md\n\n**Version**: 2.0  \n**Status**: AUTHORITATIVE\n\n### 2. CRITICAL: V4 SDK (OTel-Based)\n\nThe Langfuse Python SDK V4 is OTel-based and removed several V3 methods (start_span, start_generation, and the legacy decorator context helper). It is NOT backward compatible with V2 or V3.\n\n```python\n# CORRECT — V4 singleton accessor\nfrom langfuse import get_client\nlangfuse = get_client()\n\n# VALID — bare constructor returns the same singleton, reads env vars\nfrom langfuse import Langfuse\nlangfuse = Langfuse()\n```\n\n### 3. Architecture: Dual Integration\n\nPath A (hooks): emit_trace_event writes a JSON buffer drained by trace_flush_worker  \nPath B (services): get_client() makes direct SDK calls",
+            "content": "## LANGFUSE-INTEGRATION-SPEC.md\n\n**Version**: 1.4  \n**Status**: AUTHORITATIVE\n\n### 2. CRITICAL: V4 SDK (OTel-Based)\n\nThe Langfuse Python SDK V4 is OTel-based and removed several V3 methods (start_span, start_generation, and the legacy decorator context helper). It is NOT backward compatible with V2 or V3.\n\n```python\n# CORRECT — V4 singleton accessor\nfrom langfuse import get_client\nlangfuse = get_client()\n\n# VALID — bare constructor returns the same singleton, reads env vars\nfrom langfuse import Langfuse\nlangfuse = Langfuse()\n```\n\n### 3. Architecture: Dual Integration\n\nPath A (hooks): emit_trace_event writes a JSON buffer drained by trace_flush_worker  \nPath B (services): get_client() makes direct SDK calls",
             "content_type": "markdown_with_code_blocks",
             "estimated_tokens": 178,
         },

--- a/tests/test_create_datasets.py
+++ b/tests/test_create_datasets.py
@@ -554,7 +554,7 @@ class TestIdempotencyAndDryRun:
 
 
 class TestV4SDKCompliance:
-    def test_script_has_v3_header_comment(self):
+    def test_script_has_v4_header_comment(self):
         """create_datasets.py must have the V4 SDK header comment."""
         script_path = os.path.join(
             os.path.dirname(__file__), "..", "scripts", "create_datasets.py"
@@ -601,7 +601,7 @@ class TestV4SDKCompliance:
                 )
 
     def test_uses_get_client(self):
-        """create_datasets.py must use get_client() (V3 singleton pattern)."""
+        """create_datasets.py must use get_client() (V4 singleton accessor)."""
         script_path = os.path.join(
             os.path.dirname(__file__), "..", "scripts", "create_datasets.py"
         )


### PR DESCRIPTION
## What

Refreshes the Langfuse golden seed fixtures and the governance header in `scripts/create_datasets.py` from stale V3-only guidance to the current V4 (OTel-based) SDK, and updates the coupled assertions in `tests/test_create_datasets.py`.

## Why

The evaluation dataset seeds these fixtures as *correct* answers. Several taught Langfuse V3-only guidance (a decision fixture, an insight fixture, a retrieval `should_match`, and a spec-excerpt chunking fixture), so the LLM-as-judge could score outdated V3-era responses as correct for "which SDK version should I use?" This is eval-correctness debt, distinct from code-comment headers.

## Changes

- **Governance header** updated to the V4 form (drops the stale `Langfuse(host=...)` forbidden clause).
- **Decision and insight fixtures** rewritten to current V4 guidance and made **generic** (no decision/session-id attribution), so the dataset teaches current guidance without restating real historical records with altered content. `key_terms_required` updated V3→V4.
- **Retrieval `should_match`** updated to V4.
- **Spec-excerpt fixture** rewritten to a V4 spec excerpt; `estimated_tokens` re-derived from the rewritten text. `expected_chunk_count` is retained as a design-target (logical-section) value, consistent with the other fixtures in the dataset — no code consumes this field and the chunker does not produce per-fixture counts.
- **Coupled test** docstring/name updated (`test_script_has_v4_header_comment`).

## Verification

- `langfuse-guard/lint_langfuse_v4.sh scripts/create_datasets.py` → clean
- `black` / `ruff` / `isort` → clean
- `pytest tests/test_create_datasets.py` → 35 passed
- Dataset loads (`--dry-run`): 5 datasets, 123 items