### PR TITLE
Governance and bootstrap hygiene: ledger cap-gate, bootstrap insight display, BR Phase-4 group_id

### DIFF
--- a/_ai-memory/pov/skills/aim-parzival-bootstrap/bootstrap.py
+++ b/_ai-memory/pov/skills/aim-parzival-bootstrap/bootstrap.py
@@ -241,7 +241,7 @@ def main() -> int:
                 print("### Insights\n")
                 for i in insights:
                     score_pct = int(i.get("score", 0) * 100)
-                    print(f"- **[{score_pct}%]** {i.get('content', '').strip()[:200]}")
+                    print(f"- **[{score_pct}%]** {i.get('content', '').strip()}")
                 print()
 
             if other:

--- a/_ai-memory/pov/skills/aim-tracking-rotate/scripts/tracking_rotate.py
+++ b/_ai-memory/pov/skills/aim-tracking-rotate/scripts/tracking_rotate.py
@@ -115,6 +115,13 @@ FALLBACK_REGISTRY: dict[str, Contract] = {
         archive_target="tracking/archive/decision-log-ARCHIVE-{YYYY-MM}.md",
         index_file="tracking/decision-log-INDEX.md",
     ),
+    "tracking/technical-debt.md": Contract(
+        150,
+        15,
+        "register",
+        True,
+        archive_target="tracking/technical-debt-archive-{YYYY}.md",
+    ),
     "session-index/INDEX.md": Contract(
         120,
         10,
@@ -156,6 +163,7 @@ MANUAL_ROTATION_FILES: frozenset[str] = frozenset(
     {
         "tracking/blockers-log.md",
         "tracking/risk-register.md",
+        "tracking/technical-debt.md",
         "SESSION_WORK_INDEX.md",
         "session-index/INDEX.md",
     }
@@ -1356,10 +1364,7 @@ def _is_memory_pointer(line: str) -> bool:
 
 def _has_log_shape_violation(text: str) -> bool:
     """True if ``text`` contains at least one block that needs relocation."""
-    for block in _split_into_blocks(text):
-        if _entry_needs_relocation(block):
-            return True
-    return False
+    return any(_entry_needs_relocation(block) for block in _split_into_blocks(text))
 
 
 def _entry_needs_relocation(block: str) -> bool:

--- a/_ai-memory/pov/skills/aim-tracking-rotate/scripts/tracking_rotate.py
+++ b/_ai-memory/pov/skills/aim-tracking-rotate/scripts/tracking_rotate.py
@@ -147,6 +147,9 @@ FRESHNESS_OWNED: frozenset[str] = frozenset({"bugs/INDEX.md", "tech-debt/INDEX.m
 #   - risk-register.md : TABLE rows under "### Critical/High/Medium/Low" severity
 #                        headers — the H3 boundary matches a severity header, not
 #                        a record.
+#   - technical-debt.md : "### TD-NNN:" detail H3 entries + "### <Category>"
+#                        summary tables in "Debt by Category" — H3-boundary
+#                        rotation would orphan table rows referencing those TDs.
 #   - SESSION_WORK_INDEX.md : FOUR distinct tables (Active Task / Last 5 Sessions
 #                        / Active Blockers / High Priority Risks); a bare '^\\| '
 #                        match sheds rows from the wrong table, and the
@@ -1364,7 +1367,10 @@ def _is_memory_pointer(line: str) -> bool:
 
 def _has_log_shape_violation(text: str) -> bool:
     """True if ``text`` contains at least one block that needs relocation."""
-    return any(_entry_needs_relocation(block) for block in _split_into_blocks(text))
+    for block in _split_into_blocks(text):  # noqa: SIM110  # pre-existing loop; unrelated to Lane C
+        if _entry_needs_relocation(block):
+            return True
+    return False
 
 
 def _entry_needs_relocation(block: str) -> bool:

--- a/_ai-memory/skills/aim-best-practices-researcher/RESEARCH-METHODOLOGY.md
+++ b/_ai-memory/skills/aim-best-practices-researcher/RESEARCH-METHODOLOGY.md
@@ -90,9 +90,8 @@ scripts/memory/run-with-env.sh store_best_practice.py \
     --domain "topic-domain" \
     --tags topic keywords \
     --source "https://source-url.com" \
-    --source-date "2026-01-29"
-# Optionally pin scope explicitly: --group-id <project-id>
-# (resolved automatically via full-precedence chain if omitted)
+    --source-date "2026-01-29" \
+    --group-id "$AI_MEMORY_PROJECT_ID"
 ```
 
 Output: `Stored: <memory_id>` on success, `Duplicate skipped` if already present.

--- a/_ai-memory/skills/aim-best-practices-researcher/SKILL.md
+++ b/_ai-memory/skills/aim-best-practices-researcher/SKILL.md
@@ -44,7 +44,8 @@ scripts/memory/run-with-env.sh store_best_practice.py \
     --domain "python" \
     --tags topic \
     --source "https://source-url.com" \
-    --source-date "2026-01-29"
+    --source-date "2026-01-29" \
+    --group-id "$AI_MEMORY_PROJECT_ID"
 ```
 
 ## 5-Phase Workflow
@@ -92,8 +93,8 @@ scripts/memory/run-with-env.sh store_best_practice.py \
     --domain "YOUR_DOMAIN" \
     --tags YOUR TAGS \
     --source "SOURCE_URL" \
-    --source-date "2026-05-30"
-# Optionally pin scope: --group-id <project-id>  (resolved automatically if omitted)
+    --source-date "2026-05-30" \
+    --group-id "$AI_MEMORY_PROJECT_ID"
 ```
 
 **Checklist before moving to Phase 5**:

--- a/templates/oversight/tracking/technical-debt.md
+++ b/templates/oversight/tracking/technical-debt.md
@@ -1,3 +1,14 @@
+---
+class: register
+read_path: section-anchored
+owns: "technical debt records (TD-*)"
+cap_lines: 150
+cap_kb: 15
+rotation_trigger: on-close-over-cap  # auto-rotation deferred to TD-655; rotate manually until then
+archive_target: tracking/technical-debt-archive-{YYYY}.md
+index_file: N/A
+reconciliation: "live = OPEN/Active only + banner; on Resolved MOVE to archive"
+---
 # Technical Debt Ledger
 
 **Purpose**: Track technical debt incurred and plans for resolution.

--- a/tests/unit/test_parzival_bootstrap_script.py
+++ b/tests/unit/test_parzival_bootstrap_script.py
@@ -122,6 +122,41 @@ def test_main_respects_parzival_disabled(monkeypatch, capsys, tmp_path, enabled)
     assert "Parzival is not enabled" in out
 
 
+def test_insights_not_truncated_at_200_chars(monkeypatch, capsys, tmp_path):
+    """TD-682: insight content longer than 200 chars must not be truncated.
+
+    Decisions and other-context keep their [:200] cap; only insights are
+    untruncated (dense cross-session 'what to do next' context loses its
+    actionable tail at 200 chars).
+    """
+    monkeypatch.chdir(tmp_path)
+    resolve_spy = MagicMock(return_value="resolved-project")
+    _inject_fake_memory(monkeypatch, resolve_spy)
+
+    long_insight = "A" * 300  # 300 chars — well past the former 200-char cut
+    fake_results = [
+        {"id": "i1", "type": "agent_insight", "content": long_insight, "score": 0.8},
+    ]
+    sys.modules["memory.injection"].retrieve_bootstrap_context.return_value = (
+        fake_results,
+        {},
+    )
+    sys.modules["memory.injection"].select_results_greedy.return_value = (
+        fake_results,
+        50,
+        {},
+    )
+
+    module = _load_bootstrap_module()
+    rc = module.main()
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "### Insights" in out
+    # Full 300-char content must appear verbatim — no truncation at 200.
+    assert long_insight in out
+
+
 def test_output_has_no_github_or_sanctum_sections(monkeypatch, capsys, tmp_path):
     """A1 contract: bootstrap output never contains GitHub Activity or sanctum LORE/BOND.
 

--- a/tests/unit/test_tracking_rotate_skill.py
+++ b/tests/unit/test_tracking_rotate_skill.py
@@ -831,10 +831,11 @@ def test_apply_refuses_session_index_non_destructive(tmp_path: Path) -> None:
 def test_all_manual_files_refuse_apply(tmp_path: Path) -> None:
     """Every rel-path in MANUAL_ROTATION_FILES refuses --apply non-destructively
     (guards against a future registry edit silently re-enabling one)."""
-    assert len(MANUAL_ROTATION_FILES) == 4
+    assert len(MANUAL_ROTATION_FILES) == 5
     for expected in (
         "tracking/blockers-log.md",
         "tracking/risk-register.md",
+        "tracking/technical-debt.md",
         "SESSION_WORK_INDEX.md",
         "session-index/INDEX.md",
     ):
@@ -869,6 +870,54 @@ def test_check_still_enforces_cap_on_manual_files(tmp_path: Path) -> None:
     assert "TD-655" in result.stderr
     assert "by hand" in result.stderr
     assert "--apply" not in result.stderr  # do not loop the operator back
+
+
+# ---------------------------------------------------------------------------
+# TD-681: technical-debt.md now governed by the cap gate (parity with other
+#          manual-rotation registers; --check enforces, --apply refuses)
+# ---------------------------------------------------------------------------
+
+
+def test_technical_debt_in_fallback_registry_and_manual_rotation() -> None:
+    """technical-debt.md must be in both FALLBACK_REGISTRY and MANUAL_ROTATION_FILES
+    so --check enforces its cap and --apply refuses non-destructively (TD-681).
+    """
+    assert "tracking/technical-debt.md" in FALLBACK_REGISTRY
+    assert "tracking/technical-debt.md" in MANUAL_ROTATION_FILES
+    contract = FALLBACK_REGISTRY["tracking/technical-debt.md"]
+    assert contract.cap_lines == 150
+    assert contract.cap_kb == 15
+
+
+def test_check_enforces_technical_debt_cap(tmp_path: Path) -> None:
+    """--check on an over-cap technical-debt.md emits SYSTEM FAILURE and exits
+    non-zero (TD-681: parity with blockers-log / risk-register governance).
+    The remedy must NOT point to --apply (manual-rotation guard).
+    """
+    root = _make_oversight(tmp_path)
+    td = root / "tracking" / "technical-debt.md"
+    # 180 lines > cap of 150.
+    td.write_text("\n".join(f"line {i}" for i in range(180)) + "\n", encoding="utf-8")
+    result = _run("--check", "--oversight-root", str(root))
+    assert result.returncode == 1
+    assert "SYSTEM FAILURE" in result.stderr
+    assert "technical-debt.md" in result.stderr
+    assert "by hand" in result.stderr
+    assert "--apply" not in result.stderr
+
+
+def test_check_passes_technical_debt_within_cap(tmp_path: Path) -> None:
+    """--check on a within-cap technical-debt.md passes cleanly (TD-681)."""
+    root = _make_oversight(tmp_path)
+    td = root / "tracking" / "technical-debt.md"
+    # 50 lines < cap of 150.
+    td.write_text(
+        "\n".join(f"### TD-{i:03d}: some debt item {i}" for i in range(50)) + "\n",
+        encoding="utf-8",
+    )
+    result = _run("--check", "--oversight-root", str(root))
+    assert result.returncode == 0, result.stderr
+    assert "PASS" in result.stdout
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Three governance/bootstrap hygiene fixes.

- The `technical-debt.md` ledger is now governed by the tracking cap gate (parity with `blockers-log.md`/`risk-register.md`): a register-class contract is registered and `--check` enforces the cap; auto-rotation is intentionally manual-only (deferred), and `--apply` refuses non-destructively before any read/write.
- The session-start bootstrap no longer truncates insight display to 200 characters, so the cross-session 'what to do next' context is fully visible (decisions and other context keep their caps).
- The best-practices-researcher Phase-4 store snippet now passes `--group-id "$AI_MEMORY_PROJECT_ID"` explicitly in both the SKILL and methodology docs, so the documented sample runs correctly (the forked-subprocess wrapper does not propagate the project env).

Two related items were assessed and routed out of scope rather than coded here: bmad persona degradation without `_bmad/` config is an installer/workspace-layer concern, and the startup token-cost overcount lives in `src/memory` (its own follow-on).