### PR TITLE
Standalone fixes: aim-purge datetime filter, qdrant version warning, backup size reporting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,6 +205,7 @@ ignore = ["E501"]  # Line length handled by black
 "tests/integration/test_sdk_integration.py" = ["E402"]  # E402: sys.modules mock before imports
 "tests/unit/connectors/**/*.py" = ["E402"]  # E402: conftest logger setup before imports
 "scripts/memory/post_work_store_async.py" = ["E402"]  # E402: sys.path.insert before imports
+"scripts/memory/purge_collections.py" = ["E402"]  # E402: sys.path.insert before imports
 "scripts/memory/store-chat-memory.py" = ["E402"]  # E402: sys.path.insert before imports
 
 # Black configuration

--- a/scripts/backup_qdrant.py
+++ b/scripts/backup_qdrant.py
@@ -631,7 +631,8 @@ def main() -> int:
             collection_backups.append(backup)
 
             print(
-                f"    {GREEN}✓{RESET} {records} records, snapshot created ({format_size(size_bytes)})"
+                f"    {GREEN}✓{RESET} {records} records, "
+                f"snapshot file: {format_size(size_bytes)} on disk"
             )
 
         except Exception as e:
@@ -684,7 +685,7 @@ def main() -> int:
     print(f"\n{'='*60}")
     print(f"  {GREEN}✓ Backup complete: {backup_dir}{RESET}")
     print()
-    print(f"  Total size: {format_size(total_size)}")
+    print(f"  Total snapshot size: {format_size(total_size)}")
     print(f"  Collections: {len(collection_backups)}")
     print(f"  Records: {total_records}")
     print(f"{'='*60}\n")

--- a/scripts/memory/purge_collections.py
+++ b/scripts/memory/purge_collections.py
@@ -27,10 +27,10 @@ _install_dir = os.environ.get(
 sys.path.insert(0, os.path.join(_install_dir, "src"))
 
 from qdrant_client.models import (
+    DatetimeRange,
     FieldCondition,
     Filter,
     MatchValue,
-    Range,
 )
 
 from memory.config import (
@@ -100,7 +100,7 @@ def scan_purgeable(client, collections, group_id, cutoff_iso):
         must_conditions = [
             FieldCondition(
                 key="timestamp",
-                range=Range(lt=cutoff_iso),
+                range=DatetimeRange(lt=cutoff_iso),
             ),
         ]
         if group_id:

--- a/src/memory/qdrant_client.py
+++ b/src/memory/qdrant_client.py
@@ -113,6 +113,7 @@ def get_qdrant_client(
             timeout=config.qdrant_timeout,
             prefer_grpc=True,
             grpc_port=grpc_port,
+            check_compatibility=False,
         )
         # Probe to verify gRPC is reachable (construction alone does not connect)
         client.get_collections()
@@ -128,6 +129,7 @@ def get_qdrant_client(
             api_key=api_key_value,
             https=config.qdrant_use_https,
             timeout=config.qdrant_timeout,
+            check_compatibility=False,
         )
 
     _client_cache[cache_key] = client

--- a/tests/test_purge_collections.py
+++ b/tests/test_purge_collections.py
@@ -357,11 +357,20 @@ class TestBug317DatetimeRange:
     """
 
     def test_dry_run_no_crash_with_iso_cutoff(self, monkeypatch, capsys):
-        """(a) Dry-run returns exit 0 with a real ISO cutoff string — no ValidationError."""
+        """(a) Dry-run returns exit 0 with a real ISO cutoff string — no ValidationError.
+
+        Uses the REAL DatetimeRange so the filter construction is genuine and would
+        raise a ValidationError if the old buggy Range was still in place.
+        """
+        from qdrant_client.models import DatetimeRange as RealDatetimeRange
+
         mock_client = MagicMock()
         mock_client.scroll.return_value = ([], None)
 
         mod = _load_module(monkeypatch, mock_client)
+        # Replace the fake no-op DatetimeRange with the real one so the dry-run
+        # path genuinely constructs the real filter (proves BUG-317 is fixed).
+        mod.DatetimeRange = RealDatetimeRange
         monkeypatch.setattr(
             sys, "argv", ["purge_collections.py", "--older-than", "30d"]
         )

--- a/tests/test_purge_collections.py
+++ b/tests/test_purge_collections.py
@@ -73,14 +73,14 @@ def _inject_mocks(monkeypatch, mock_client):
         def __init__(self, **kw):
             pass
 
-    class _Range:
+    class _DatetimeRange:
         def __init__(self, **kw):
             pass
 
     qc_models.FieldCondition = _FC
     qc_models.Filter = _Filter
     qc_models.MatchValue = _MV
-    qc_models.Range = _Range
+    qc_models.DatetimeRange = _DatetimeRange
 
     for name, mod in [
         ("memory", mem_pkg),
@@ -347,3 +347,52 @@ class TestConfirmPath:
 
         assert rc == 0
         assert mock_client.delete.call_count == 2
+
+
+class TestBug317DatetimeRange:
+    """BUG-317 regression guard: Range(lt=ISO_string) crashes; DatetimeRange is the fix.
+
+    (a) dry-run path completes without crash.
+    (b) DatetimeRange(lt=cutoff_iso) selects records BEFORE cutoff — delete scope unchanged.
+    """
+
+    def test_dry_run_no_crash_with_iso_cutoff(self, monkeypatch, capsys):
+        """(a) Dry-run returns exit 0 with a real ISO cutoff string — no ValidationError."""
+        mock_client = MagicMock()
+        mock_client.scroll.return_value = ([], None)
+
+        mod = _load_module(monkeypatch, mock_client)
+        monkeypatch.setattr(
+            sys, "argv", ["purge_collections.py", "--older-than", "30d"]
+        )
+
+        rc = mod.main()
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "No memories found" in out
+
+    def test_datetime_range_lt_boundary(self):
+        """(b) Real DatetimeRange(lt=cutoff_iso) selects records before cutoff only.
+
+        Proves delete-scope is unchanged: records older than the cutoff satisfy
+        the lt condition; records at or after the cutoff do not.
+        """
+        from datetime import datetime, timezone
+
+        from qdrant_client.models import DatetimeRange as RealDatetimeRange
+
+        cutoff_dt = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+        dr = RealDatetimeRange(lt=cutoff_dt.isoformat())
+        cutoff_parsed = dr.lt  # DatetimeRange parses the ISO string to a datetime
+
+        # Record 1 second before cutoff → older, must satisfy lt
+        before = datetime(2024, 6, 1, 11, 59, 59, tzinfo=timezone.utc)
+        # Record 1 second after cutoff → newer, must NOT satisfy lt
+        after = datetime(2024, 6, 1, 12, 0, 1, tzinfo=timezone.utc)
+
+        assert before < cutoff_parsed, "Record before cutoff must satisfy lt condition"
+        assert (
+            after > cutoff_parsed
+        ), "Record after cutoff must NOT satisfy lt condition"
+        assert cutoff_parsed == cutoff_dt  # round-trip fidelity

--- a/tests/test_qdrant_client.py
+++ b/tests/test_qdrant_client.py
@@ -330,6 +330,27 @@ class TestQdrantClient:
             call_kwargs = MockQdrantClient.call_args.kwargs
             assert call_kwargs.get("check_compatibility") is False
 
+    def test_check_compatibility_disabled_on_http_fallback(self):
+        """TD-683: check_compatibility=False is set on the HTTP fallback client too."""
+        calls_kwargs = []
+        grpc_client = Mock()
+        grpc_client.get_collections.side_effect = RuntimeError(
+            "gRPC connection refused"
+        )
+
+        def side_effect(**kwargs):
+            calls_kwargs.append(dict(kwargs))
+            return grpc_client if kwargs.get("prefer_grpc") else Mock()
+
+        with patch("src.memory.qdrant_client.QdrantClient", side_effect=side_effect):
+            config = MemoryConfig()
+            get_qdrant_client(config)
+
+        assert len(calls_kwargs) == 2
+        # Both the gRPC attempt and the HTTP fallback must suppress the compat warning
+        assert calls_kwargs[0].get("check_compatibility") is False  # gRPC path
+        assert calls_kwargs[1].get("check_compatibility") is False  # HTTP fallback
+
     def test_module_has_all_exports(self):
         """AC 1.4.3: Module exports required functions."""
         from src.memory import qdrant_client as qc_module

--- a/tests/test_qdrant_client.py
+++ b/tests/test_qdrant_client.py
@@ -318,6 +318,18 @@ class TestQdrantClient:
             call_kwargs = MockQdrantClient.call_args.kwargs
             assert call_kwargs["api_key"] == rw_key
 
+    def test_check_compatibility_disabled(self):
+        """TD-683: check_compatibility=False suppresses the server-version UserWarning."""
+        with patch("src.memory.qdrant_client.QdrantClient") as MockQdrantClient:
+            mock_instance = Mock()
+            MockQdrantClient.return_value = mock_instance
+
+            config = MemoryConfig()
+            get_qdrant_client(config)
+
+            call_kwargs = MockQdrantClient.call_args.kwargs
+            assert call_kwargs.get("check_compatibility") is False
+
     def test_module_has_all_exports(self):
         """AC 1.4.3: Module exports required functions."""
         from src.memory import qdrant_client as qc_module

--- a/tests/unit/test_backup_size_reporting.py
+++ b/tests/unit/test_backup_size_reporting.py
@@ -64,30 +64,56 @@ class TestFormatSize:
 class TestSizeReportingLabel:
     """TD-688: per-collection line and summary use unambiguous snapshot-size labels."""
 
-    def test_per_collection_line_says_snapshot_file(self, capsys):
-        """Output line for each collection must include 'snapshot file' label."""
-        mod = _load_backup_module()
-        # Simulate the per-collection print used in main()
-        records = 18
-        size_bytes = 1_433_600_000  # ~1367 MB — the inflated figure from TD-688
-
-        GREEN = mod.GREEN
-        RESET = mod.RESET
-        print(
-            f"    {GREEN}✓{RESET} {records} records, "
-            f"snapshot file: {mod.format_size(size_bytes)} on disk"
+    def _mock_main(self, mod, monkeypatch, tmp_path, size_bytes):
+        """Patch all I/O helpers in *mod* and run main(), returning captured stdout."""
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "backup_qdrant.py",
+                "--output",
+                str(tmp_path),
+                "--collection",
+                "discussions",
+            ],
         )
+        mock_httpx = MagicMock()
+        mock_httpx.get.return_value.status_code = 200
+        monkeypatch.setattr(mod, "httpx", mock_httpx)
+        monkeypatch.setattr(
+            mod, "get_collection_info", lambda c: {"points_count": 18, "schema": None}
+        )
+        monkeypatch.setattr(
+            mod, "check_disk_space", lambda bd, es: (True, 10 * 1024 * 1024 * 1024)
+        )
+        monkeypatch.setattr(mod, "create_snapshot", lambda c: f"{c}_snap")
+        monkeypatch.setattr(
+            mod, "download_snapshot", lambda c, s, o, retries=0: size_bytes
+        )
+        monkeypatch.setattr(mod, "delete_server_snapshot", lambda c, s: True)
+        monkeypatch.setattr(mod, "backup_config_files", lambda bd: [])
+        monkeypatch.setattr(mod, "create_manifest", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            mod, "write_checksums", lambda bd: tmp_path / "CHECKSUMS.sha256"
+        )
+        return mod.main()
+
+    def test_per_collection_line_says_snapshot_file(
+        self, monkeypatch, capsys, tmp_path
+    ):
+        """main() per-collection output must include 'snapshot file' and 'on disk' labels."""
+        mod = _load_backup_module()
+        rc = self._mock_main(mod, monkeypatch, tmp_path, size_bytes=1_433_600_000)
+        assert rc == 0
         out = capsys.readouterr().out
         assert "snapshot file" in out
         assert "on disk" in out
-        # Must not use ambiguous bare size label
         assert "snapshot created" not in out
 
-    def test_summary_line_says_total_snapshot_size(self, capsys):
-        """Summary total must say 'Total snapshot size', not bare 'Total size'."""
+    def test_summary_line_says_total_snapshot_size(self, monkeypatch, capsys, tmp_path):
+        """main() summary line must say 'Total snapshot size'."""
         mod = _load_backup_module()
-        total_size = 2_867_200_000  # ~2734 MB
-
-        print(f"  Total snapshot size: {mod.format_size(total_size)}")
+        rc = self._mock_main(mod, monkeypatch, tmp_path, size_bytes=2_867_200_000)
+        assert rc == 0
         out = capsys.readouterr().out
         assert "Total snapshot size" in out

--- a/tests/unit/test_backup_size_reporting.py
+++ b/tests/unit/test_backup_size_reporting.py
@@ -1,0 +1,93 @@
+"""TD-688: per-collection snapshot size reporting sanity tests.
+
+The backup script reports the physical snapshot file size, which can be inflated
+due to HNSW shared-segment data included per-collection snapshot. This is
+REPORTING ONLY — backup/restore behavior and checksums are unaffected.
+
+These tests verify:
+- format_size produces sane human-readable labels at common byte magnitudes
+- The per-collection output line includes the "snapshot file" label, so
+  operators know the figure is physical-on-disk, not logical collection size
+- The summary line uses "Total snapshot size" to avoid ambiguity
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_REPO = Path(__file__).resolve().parents[2]
+_BACKUP_SCRIPT = _REPO / "scripts" / "backup_qdrant.py"
+
+
+def _load_backup_module():
+    """Load backup_qdrant.py, stubbing out the env-loader side-effect."""
+    env_loader = MagicMock()
+    env_loader.load_install_env = MagicMock()
+
+    # Stub _env_loader before the script imports it at module level
+    sys.modules.pop("_env_loader", None)
+    sys.modules["_env_loader"] = env_loader
+
+    spec = importlib.util.spec_from_file_location("backup_qdrant", _BACKUP_SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestFormatSize:
+    """TD-688: format_size returns sensible labels at each magnitude."""
+
+    def test_bytes(self):
+        mod = _load_backup_module()
+        assert mod.format_size(512) == "512 B"
+
+    def test_kilobytes(self):
+        mod = _load_backup_module()
+        result = mod.format_size(2048)
+        assert "KB" in result
+        assert "2.0" in result
+
+    def test_megabytes(self):
+        mod = _load_backup_module()
+        result = mod.format_size(5 * 1024 * 1024)
+        assert "MB" in result
+        assert "5.0" in result
+
+    def test_zero(self):
+        mod = _load_backup_module()
+        assert mod.format_size(0) == "0 B"
+
+
+class TestSizeReportingLabel:
+    """TD-688: per-collection line and summary use unambiguous snapshot-size labels."""
+
+    def test_per_collection_line_says_snapshot_file(self, capsys):
+        """Output line for each collection must include 'snapshot file' label."""
+        mod = _load_backup_module()
+        # Simulate the per-collection print used in main()
+        records = 18
+        size_bytes = 1_433_600_000  # ~1367 MB — the inflated figure from TD-688
+
+        GREEN = mod.GREEN
+        RESET = mod.RESET
+        print(
+            f"    {GREEN}✓{RESET} {records} records, "
+            f"snapshot file: {mod.format_size(size_bytes)} on disk"
+        )
+        out = capsys.readouterr().out
+        assert "snapshot file" in out
+        assert "on disk" in out
+        # Must not use ambiguous bare size label
+        assert "snapshot created" not in out
+
+    def test_summary_line_says_total_snapshot_size(self, capsys):
+        """Summary total must say 'Total snapshot size', not bare 'Total size'."""
+        mod = _load_backup_module()
+        total_size = 2_867_200_000  # ~2734 MB
+
+        print(f"  Total snapshot size: {mod.format_size(total_size)}")
+        out = capsys.readouterr().out
+        assert "Total snapshot size" in out


### PR DESCRIPTION
Three independent fixes.

- `aim-purge` no longer crashes on the real-purge path: the age cutoff filter now uses `DatetimeRange` (which accepts the RFC-3339 timestamp the collections store) instead of the numeric `Range`, which raised a validation error before any scan or delete. The set of records selected for deletion is unchanged.
- The Qdrant client no longer emits a client/server version-compatibility `UserWarning` on every bootstrap, via the client's own `check_compatibility=False` on both init paths (no unrelated warnings are masked).
- The backup script's per-collection size reporting is relabelled to reflect on-disk snapshot size (HNSW shared-segment physical size) rather than implying logical collection size; backup and restore behaviour and checksums are unchanged.