### PR TITLE
Silence Grafana startup error for missing provisioning/plugins dir (TD-538)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ cd ~/.ai-memory/docker && docker compose \
 - **Embedding-service OOM-kill/restart loop under memory pressure (BUG-324)** — combined multi-repo load no longer drives the shared service past its cgroup cap; the memory-aware AIMD controller throttles *before* the kernel OOM-kills, turning the kill/restart loop into "slow down and survive".
 - **Dropped memory on embedding backpressure (TD-678)** — a server backpressure 503/429 is now retried by the client instead of raising and losing the memory; the zero-vector rejection (TD-354) remains intact end to end.
 - **`metrics_import_failed` startup warning (TD-694)** — the embedding service no longer imports the unused client-side `memory.metrics` module (which triggered the heavy `memory` package init absent from the slim image), eliminating the spurious startup WARNING.
+- **Grafana no longer logs a startup `level=error` for a missing `provisioning/plugins` directory** — an empty `plugins/.gitkeep` is now shipped so the provisioning path exists (TD-538).
 
 ## [2.7.0] - 2026-06-16
 


### PR DESCRIPTION
## What
Ship an empty `docker/grafana/provisioning/plugins/.gitkeep` so the Grafana plugin-provisioning directory exists at container start.

## Why
On a fresh install `ai-memory-grafana` logs `level=error msg="Failed to read plugin provisioning files from directory" path=/etc/grafana/provisioning/plugins`. The container is fully healthy, but the error adds false-alarm noise to startup log scans. The provisioning directory is bind-mounted into the container (`docker-compose.yml`: `./grafana/provisioning:/etc/grafana/provisioning:ro`), so shipping an empty `plugins/` subdirectory removes the error. This mirrors the existing `alerting/`, `dashboards/`, and `datasources/` provisioning subdirs.

## Scope
- Adds `docker/grafana/provisioning/plugins/.gitkeep` and a CHANGELOG `Fixed` entry. No plugin-install configuration is introduced.
- Out of scope: the separate `plugin table is already registered` startup noise is upstream Grafana core behavior with no change-site in this tree.