### PR TITLE
fix(TD-702): closeout cap-gate no longer blocks the secondary Qdrant save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- TD-702: closeout cap-gate (step-04) no longer hard-blocks the secondary Qdrant save (step-05 §1–§3); cap breaches are now surfaced as warnings with remedies and noted in the step-05 §4 checklist, honoring the workflow's "Qdrant save is secondary, never block closeout" contract.
+
 ## [2.8.0] - 2026-06-21
 
 ### Upgrade Instructions

--- a/_ai-memory/pov/workflows/session/close/steps-c/step-04-enforce-caps.md
+++ b/_ai-memory/pov/workflows/session/close/steps-c/step-04-enforce-caps.md
@@ -1,6 +1,6 @@
 ---
 name: 'step-04-enforce-caps'
-description: 'Enforce oversight-file caps before save; block closeout while any governed file is over cap'
+description: 'Enforce oversight-file caps before save; surface breaches as warnings with remedies; always advance to Step 5'
 nextStepFile: './step-05-save-and-confirm.md'
 ---
 
@@ -10,8 +10,9 @@ nextStepFile: './step-05-save-and-confirm.md'
 
 ## STEP GOAL:
 
-Run the cap-enforcement gate so closeout cannot declare complete — or push a
-bloated handoff to Qdrant — while any governed file is over its cap. The gate
+Run the cap-enforcement gate: it surfaces any over-cap governed file as a
+WARNING with its remedy and always advances to Step 5 — it never blocks the
+secondary Qdrant save. The gate
 spans BOTH domains: the **oversight** classes (`aim-tracking-rotate`) AND the
 **sanctum** identity classes (`aim-lore-hygiene` — CREED/PERSONA/LORE/BOND/
 MEMORY), so creep like the PERSONA `## Evolution Log` is caught automatically.
@@ -21,12 +22,12 @@ the Qdrant save (Step 5).
 **Scope:**
 - Available context: handoff from Step 3, tracking updated in Step 2
 - Focus: cap enforcement only — Qdrant save is the next step
-- Limits: a breach in EITHER gate BLOCKS closeout until fixed; do not skip, do not save over a breach
+- Limits: a breach in EITHER gate is surfaced as a WARNING with remedies; the Qdrant save (Step 5) always runs regardless
 - Dependencies: handoff written (Step 3) and tracking rotated (Step 2)
 
 **Behavioral Constraints:**
-- FORBIDDEN to proceed to Step 5 while EITHER `--check` reports a breach
-- Approach: run both gates, fix any over-cap file with the surfaced remedy, re-run until both clean
+- Run both gates; surface any breach as a WARNING with its remedy commands
+- Approach: fix any over-cap file with the surfaced remedy where possible; always advance to Step 5 after both gates run
 
 ## Sequence
 
@@ -46,7 +47,8 @@ absent. Caps are byte **and** line — either breach fails.
 
 - **Exit 0 (PASS)** → all governed oversight files within cap. Note it and proceed.
 - **Exit non-zero (FAIL)** → the gate prints a SYSTEM FAILURE block per
-  over-cap file (file, size, cap, remedy command). Closeout is BLOCKED.
+  over-cap file (file, size, cap, remedy command). Surface as **WARNING**: note
+  the breach and its remedy; apply the fix where possible; then continue.
 
 ### 1b. Run the Sanctum Enforcement Gate
 
@@ -68,9 +70,10 @@ closeout per A2: full files stay on disk and rotation is tag-driven), and PERSON
 - **Exit 0 (PASS)** → no blocking breach (any over-size LORE/MEMORY is a WARNING
   only). Note it and proceed.
 - **Exit non-zero (FAIL)** → a SYSTEM FAILURE block per over-cap file with its
-  remedy. Closeout is BLOCKED. **Identity files (CREED/PERSONA/LORE/BOND) are a
-  STOP-GATE**: a relocation that moves real identity content needs Will +
-  Parzival approval of the proposed diff before `--apply` (do not auto-apply).
+  remedy. Surface as **WARNING**: note the breach and its remedy; then continue.
+  **Identity files (CREED/PERSONA/LORE/BOND): do not auto-apply** — a relocation
+  needs Will + Parzival approval of the proposed diff; note as a pending WARNING
+  in the closeout checklist.
 
 ### 2. Rotate Any Over-Cap File
 
@@ -113,13 +116,13 @@ python ~/.ai-memory/_ai-memory/pov/skills/aim-tracking-rotate/scripts/tracking_r
 If `--fix` reports that a heartbeat body is still over cap after the front-matter
 refresh, trim the body by hand, then re-run.
 
-### 3. Re-Run Until Both Clean
+### 3. Confirm Fixes and Note Unresolvable Warnings
 
-Re-run the Step 1 (oversight) AND Step 1b (sanctum) `--check` commands. Repeat
-fix → re-check until BOTH report PASS. Only when both gates are clean may you
-advance to Step 5.
+After applying the §2 remedies, re-run the relevant `--check` to confirm each
+fix. If a breach cannot be resolved (e.g. identity STOP-GATE awaiting approval),
+note it as a pending WARNING in the closeout checklist and continue to Step 5.
 
 ## CRITICAL STEP COMPLETION NOTE
 
-ONLY when BOTH `--check` gates report PASS (all governed oversight AND sanctum
-files within cap), load and read fully {nextStepFile}
+After running both gates and noting any breach warnings (resolving where
+possible), always load and read fully {nextStepFile}

--- a/_ai-memory/pov/workflows/session/close/steps-c/step-05-save-and-confirm.md
+++ b/_ai-memory/pov/workflows/session/close/steps-c/step-05-save-and-confirm.md
@@ -15,11 +15,12 @@ Attempt to save the handoff and task state to Qdrant for cross-session AI-search
 - Available context: Handoff document from Step 3, session summary from Step 1
 - Focus: Qdrant save attempts and final closeout confirmation
 - Limits: Qdrant save is secondary — NEVER block closeout because Qdrant is unavailable
-- Dependencies: Handoff document from Step 3 is required
+- Dependencies: Handoff document from Step 3 is required; cap-enforcement warnings from Step 4 (if any) are surfaced in the §4 checklist only
 
 - Focus on Qdrant save attempts and final closeout confirmation
 **Behavioral Constraints:**
 - FORBIDDEN to block closeout because Qdrant is unavailable
+- Cap-breach warnings from Step 4 do NOT block the Qdrant save or closeout; surface them in the §4 checklist only
 - Approach: Attempt saves gracefully, present final checklist, handle user requests
 - File writes are the primary record — Qdrant is secondary and optional
 
@@ -121,6 +122,7 @@ via SHA-256 `content_hash` dedup.
 - [x] Task status updates: [Applied / Pending user approval]
 - [x] Decision log: [Updated / No new decisions]
 - [x] Blockers log: [Updated / No new blockers]
+- [x] Cap enforcement: [Clean / WARNING: over-cap files noted — remedies: {pending-items}]
 - [x] Qdrant handoff save: [Success / Skipped -- unavailable]
 - [x] Qdrant decision emit: [N saved / Skipped -- unavailable / No new decisions]
 


### PR DESCRIPTION
## Problem

The closeout workflow chains `step-03 (handoff) → step-04 (enforce-caps) → step-05 (Qdrant save)`. `step-04` hard-blocked advancing to `step-05` while **any** governed oversight/sanctum file was over its cap — *including files unrelated to what is being saved*. When the over-cap file was not auto-fixable (a sanctum identity file awaiting approval, or a register that refuses `--apply`), the secondary Qdrant save was skipped on every close — silently degrading cross-session memory. This directly contradicted `step-05`'s own contract: *"Qdrant save is secondary — NEVER block closeout."*

## Fix

Reconcile `step-04` with the never-block contract (warn-not-block):

- `step-04` still runs both enforcement gates and surfaces any breach as a **WARNING** with its remedy commands, but **always advances to `step-05`** — it never blocks the secondary Qdrant save. Identity-file relocations still require approval (surfaced as a pending warning, not a hard stop).
- `step-05` notes any cap warnings in its final checklist and states explicitly that they do not block the save or closeout.
- STEP-GOAL / behavioral-constraint / critical-step text updated for internal consistency.

## Scope

3 files — `step-04-enforce-caps.md`, `step-05-save-and-confirm.md`, `CHANGELOG.md`. Workflow-prose only; no code or behavior change beyond the block→warn reconciliation. Base: `main`.