### PR TITLE
stack: rebuild python-source baked images on restart (TD-723)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`stack.sh start`/`restart` now rebuilds all source-baked services on the cached path (TD-723)** — `stack.sh` previously brought the `build:`+`image:` hybrid services up with no build, so they reused their cached image when baked content changed and a release could deploy stale silently. A cached (NOT `--no-cache`) build now runs before each `up -d`, redeploying baked src for the baked-src services (`embedding`, `monitoring-api`, `github-sync` core; `trace-flush-worker` langfuse) and baked pip dependencies (`requirements.txt`) for the volume-mounted-src services (`classifier-worker` core; `evaluator-scheduler` langfuse — the PM-#353 `No module named 'openai'` class). `monitoring-api` (genuinely baked-src, runs under `--profile monitoring` which defaults on) is now included; the `github-sync` rebuild is gated behind the same `GITHUB_SYNC_ENABLED` + `GITHUB_TOKEN` condition the startup uses. Cached builds keep no-op restarts cheap (embedding ONNX models and the github-sync spaCy download are not re-fetched) and are non-fatal on failure.
+
 ## [2.8.0] - 2026-06-21
 
 ### Upgrade Instructions

--- a/scripts/stack.sh
+++ b/scripts/stack.sh
@@ -242,15 +242,15 @@ cmd_start() {
     fi
 
     # ── Step 1b: Rebuild python-source baked services (core) ─────────────────
-    # TD-723: these core services cache their built image under the build:+image:
-    # hybrid pattern, so `compose up -d` reuses the cached image and a changed
-    # release deploys stale silently. A CACHED `build` (NOT --no-cache)
-    # invalidates only the changed layers, so it's cheap on a no-op restart and
-    # does NOT re-bake embedding ONNX models or re-run the github-sync spacy
-    # download every time. The rebuild redeploys baked changes — baked src for
-    # the baked-src services, and baked pip dependencies (requirements.txt) for
-    # all of them, since `up -d` reuses the cached image. Two source-delivery
-    # classes are present, both needing this rebuild:
+    # TD-723: compose caches each service's built image — built once, reused by
+    # `up -d` even when COPY'd source changed — so a release deploys stale
+    # silently. (embedding uses the build:+image: hybrid pattern; the others are
+    # plain build: services.) A CACHED `build` (NOT --no-cache) invalidates only
+    # the changed layers, so it's cheap on a no-op restart and does NOT re-bake
+    # embedding ONNX models or re-run the github-sync spacy download every time.
+    # The rebuild redeploys baked changes — baked src for the baked-src services,
+    # and baked pip dependencies (requirements.txt) for all of them.
+    # Two source-delivery classes are present, both needing this rebuild:
     #   • baked-src — embedding, monitoring-api (+ github-sync): COPY their python
     #     source into the image with NO src volume mount, so a source change
     #     deploys ONLY via a rebuild.
@@ -258,11 +258,16 @@ cmd_start() {
     #     requirements.txt + pip-installs but volume-mounts ../src:/app/src:ro, so
     #     src changes deploy via the mount, but a requirements.txt change (the
     #     PM #353 'No module named openai' class) still needs a rebuild.
-    # monitoring-api is behind --profile monitoring (default ON) and built
-    # unconditionally; github-sync is behind --profile github and built only when
-    # github sync is enabled (mirrors the `up` gating below). Each profiled
-    # service needs its --profile flag to be visible to `build`.
-    local -a SOURCE_BAKE_SERVICES=(embedding classifier-worker monitoring-api)
+    # monitoring-api is behind --profile monitoring and gated on MONITORING_ENABLED
+    # (default ON, mirrors the `up` gating); github-sync is behind --profile github
+    # and built only when github sync is enabled (mirrors the `up` gating below).
+    # Each profiled service needs its --profile flag to be visible to `build`.
+    local -a SOURCE_BAKE_SERVICES=(embedding classifier-worker)
+    local -a _monitoring_source_profile=()
+    if [[ "${MONITORING_ENABLED}" != "false" ]]; then
+        SOURCE_BAKE_SERVICES+=(monitoring-api)
+        _monitoring_source_profile=(--profile monitoring)
+    fi
     local -a _github_source_profile=()
     if [[ "${GITHUB_SYNC_ENABLED}" == "true" && -n "${GITHUB_TOKEN:-}" ]]; then
         SOURCE_BAKE_SERVICES+=(github-sync)
@@ -271,11 +276,11 @@ cmd_start() {
     step "Step 1b/2 — Rebuilding python-source baked services (${SOURCE_BAKE_SERVICES[*]})"
     if ! _compose \
             -f "${COMPOSE_CORE}" \
-            --profile monitoring \
+            "${_monitoring_source_profile[@]}" \
             "${_github_source_profile[@]}" \
             build "${SOURCE_BAKE_SERVICES[@]}"; then
         log_warning "Python-source rebuild failed — continuing with cached images. Inspect:"
-        log_warning "  docker compose -f ${COMPOSE_CORE} --profile monitoring ${_github_source_profile[*]} build ${SOURCE_BAKE_SERVICES[*]}"
+        log_warning "  docker compose -f ${COMPOSE_CORE} ${_monitoring_source_profile[*]} ${_github_source_profile[*]} build ${SOURCE_BAKE_SERVICES[*]}"
     fi
 
     # ── Step 1: Core stack ────────────────────────────────────────────────────

--- a/scripts/stack.sh
+++ b/scripts/stack.sh
@@ -241,6 +241,25 @@ cmd_start() {
         log_warning "  docker compose -f ${COMPOSE_CORE} build ${IMAGE_BAKE_SERVICES[*]}"
     fi
 
+    # ── Step 1b: Rebuild python-source baked services (core) ─────────────────
+    # TD-723: services using the build:+image: hybrid pattern with COPY'd python
+    # source (embedding, classifier-worker, github-sync) cache their built image.
+    # `compose up` reuses the cached image even when the COPY'd source changed —
+    # a baked-source release deploys stale silently. A CACHED `build` (NOT
+    # --no-cache) invalidates only the changed COPY layers, so it's cheap on a
+    # no-op restart and does NOT re-bake embedding ONNX models or re-run the
+    # github-sync spacy download every time. --profile github is required to make
+    # github-sync visible; embedding/classifier-worker are always visible.
+    local -a SOURCE_BAKE_SERVICES=(embedding classifier-worker github-sync)
+    step "Step 1b/2 — Rebuilding python-source baked services (${SOURCE_BAKE_SERVICES[*]})"
+    if ! _compose \
+            -f "${COMPOSE_CORE}" \
+            --profile github \
+            build "${SOURCE_BAKE_SERVICES[@]}"; then
+        log_warning "Python-source rebuild failed — continuing with cached images. Inspect:"
+        log_warning "  docker compose -f ${COMPOSE_CORE} --profile github build ${SOURCE_BAKE_SERVICES[*]}"
+    fi
+
     # ── Step 1: Core stack ────────────────────────────────────────────────────
     # Creates the ai-memory_default network that langfuse will join.
     local _profiles_short="${_profiles_display//--profile /}"
@@ -274,6 +293,20 @@ cmd_start() {
                     -f "${COMPOSE_LANGFUSE}" \
                     build --no-cache "${IMAGE_BAKE_SERVICES_LANGFUSE[@]}"; then
                 log_warning "Langfuse image-bake rebuild failed — continuing with cached images."
+            fi
+
+            # TD-723: evaluator-scheduler and trace-flush-worker use the
+            # build:+image: hybrid with COPY'd python source. CACHED build (NOT
+            # --no-cache) invalidates only changed COPY layers so a baked-source
+            # release deploys instead of the stale cached image. --profile
+            # langfuse is required to make these services visible.
+            local -a SOURCE_BAKE_SERVICES_LANGFUSE=(evaluator-scheduler trace-flush-worker)
+            if ! _compose \
+                    -f "${COMPOSE_CORE}" \
+                    -f "${COMPOSE_LANGFUSE}" \
+                    --profile langfuse \
+                    build "${SOURCE_BAKE_SERVICES_LANGFUSE[@]}"; then
+                log_warning "Langfuse python-source rebuild failed — continuing with cached images."
             fi
 
             # NOTE: Both compose files are passed intentionally. Docker Compose merges

--- a/scripts/stack.sh
+++ b/scripts/stack.sh
@@ -242,22 +242,40 @@ cmd_start() {
     fi
 
     # ── Step 1b: Rebuild python-source baked services (core) ─────────────────
-    # TD-723: services using the build:+image: hybrid pattern with COPY'd python
-    # source (embedding, classifier-worker, github-sync) cache their built image.
-    # `compose up` reuses the cached image even when the COPY'd source changed —
-    # a baked-source release deploys stale silently. A CACHED `build` (NOT
-    # --no-cache) invalidates only the changed COPY layers, so it's cheap on a
-    # no-op restart and does NOT re-bake embedding ONNX models or re-run the
-    # github-sync spacy download every time. --profile github is required to make
-    # github-sync visible; embedding/classifier-worker are always visible.
-    local -a SOURCE_BAKE_SERVICES=(embedding classifier-worker github-sync)
+    # TD-723: these core services cache their built image under the build:+image:
+    # hybrid pattern, so `compose up -d` reuses the cached image and a changed
+    # release deploys stale silently. A CACHED `build` (NOT --no-cache)
+    # invalidates only the changed layers, so it's cheap on a no-op restart and
+    # does NOT re-bake embedding ONNX models or re-run the github-sync spacy
+    # download every time. The rebuild redeploys baked changes — baked src for
+    # the baked-src services, and baked pip dependencies (requirements.txt) for
+    # all of them, since `up -d` reuses the cached image. Two source-delivery
+    # classes are present, both needing this rebuild:
+    #   • baked-src — embedding, monitoring-api (+ github-sync): COPY their python
+    #     source into the image with NO src volume mount, so a source change
+    #     deploys ONLY via a rebuild.
+    #   • baked-deps, src volume-mounted — classifier-worker: COPYs
+    #     requirements.txt + pip-installs but volume-mounts ../src:/app/src:ro, so
+    #     src changes deploy via the mount, but a requirements.txt change (the
+    #     PM #353 'No module named openai' class) still needs a rebuild.
+    # monitoring-api is behind --profile monitoring (default ON) and built
+    # unconditionally; github-sync is behind --profile github and built only when
+    # github sync is enabled (mirrors the `up` gating below). Each profiled
+    # service needs its --profile flag to be visible to `build`.
+    local -a SOURCE_BAKE_SERVICES=(embedding classifier-worker monitoring-api)
+    local -a _github_source_profile=()
+    if [[ "${GITHUB_SYNC_ENABLED}" == "true" && -n "${GITHUB_TOKEN:-}" ]]; then
+        SOURCE_BAKE_SERVICES+=(github-sync)
+        _github_source_profile=(--profile github)
+    fi
     step "Step 1b/2 — Rebuilding python-source baked services (${SOURCE_BAKE_SERVICES[*]})"
     if ! _compose \
             -f "${COMPOSE_CORE}" \
-            --profile github \
+            --profile monitoring \
+            "${_github_source_profile[@]}" \
             build "${SOURCE_BAKE_SERVICES[@]}"; then
         log_warning "Python-source rebuild failed — continuing with cached images. Inspect:"
-        log_warning "  docker compose -f ${COMPOSE_CORE} --profile github build ${SOURCE_BAKE_SERVICES[*]}"
+        log_warning "  docker compose -f ${COMPOSE_CORE} --profile monitoring ${_github_source_profile[*]} build ${SOURCE_BAKE_SERVICES[*]}"
     fi
 
     # ── Step 1: Core stack ────────────────────────────────────────────────────
@@ -295,18 +313,30 @@ cmd_start() {
                 log_warning "Langfuse image-bake rebuild failed — continuing with cached images."
             fi
 
-            # TD-723: evaluator-scheduler and trace-flush-worker use the
-            # build:+image: hybrid with COPY'd python source. CACHED build (NOT
-            # --no-cache) invalidates only changed COPY layers so a baked-source
-            # release deploys instead of the stale cached image. --profile
-            # langfuse is required to make these services visible.
+            # TD-723: trace-flush-worker and evaluator-scheduler cache their built
+            # image under the build:+image: hybrid pattern. A CACHED build (NOT
+            # --no-cache) invalidates only changed layers so a baked change
+            # deploys instead of the stale cached image. The rebuild redeploys
+            # baked changes — baked src for the baked-src services, and baked pip
+            # dependencies (requirements.txt) for all of them, since `up -d`
+            # reuses the cached image. Two source-delivery classes are present:
+            #   • baked-src — trace-flush-worker: COPYs its python source into the
+            #     image with NO src volume mount; a source change deploys ONLY via
+            #     a rebuild.
+            #   • baked-deps, src volume-mounted — evaluator-scheduler: COPYs
+            #     requirements.txt + pip-installs but volume-mounts
+            #     ../src:/app/src:ro, so src changes deploy via the mount but a
+            #     requirements.txt change still needs a rebuild.
+            # --profile langfuse is required to make these services visible to
+            # `build`.
             local -a SOURCE_BAKE_SERVICES_LANGFUSE=(evaluator-scheduler trace-flush-worker)
             if ! _compose \
                     -f "${COMPOSE_CORE}" \
                     -f "${COMPOSE_LANGFUSE}" \
                     --profile langfuse \
                     build "${SOURCE_BAKE_SERVICES_LANGFUSE[@]}"; then
-                log_warning "Langfuse python-source rebuild failed — continuing with cached images."
+                log_warning "Langfuse python-source rebuild failed — continuing with cached images. Inspect:"
+                log_warning "  docker compose -f ${COMPOSE_CORE} -f ${COMPOSE_LANGFUSE} --profile langfuse build ${SOURCE_BAKE_SERVICES_LANGFUSE[*]}"
             fi
 
             # NOTE: Both compose files are passed intentionally. Docker Compose merges

--- a/tests/test_compose_bare_up_topology.py
+++ b/tests/test_compose_bare_up_topology.py
@@ -604,21 +604,53 @@ class TestStackShImageBakeRebuild:
 # TD-723 — stack.sh cmd_start python-source CACHED rebuild assertions
 # ---------------------------------------------------------------------------
 
-# Python-source baked services (build:+image: hybrid with COPY'd python source).
-TD723_CORE_SOURCE_SERVICES = ["embedding", "classifier-worker", "github-sync"]
+# Python-source baked services rebuilt by stack.sh cmd_start (TD-723).
+#
+# Two source-delivery classes both require the CACHED rebuild:
+#   • baked-src — COPY python source into the image with NO src volume mount, so
+#     a source change deploys ONLY via a rebuild: embedding, monitoring-api,
+#     github-sync (core); trace-flush-worker (langfuse).
+#   • baked-deps, src volume-mounted — COPY requirements.txt + pip-install but
+#     volume-mount ../src:/app/src:ro, so src changes deploy via the mount but a
+#     requirements.txt change (the PM #353 'No module named openai' class) still
+#     needs a rebuild: classifier-worker (core); evaluator-scheduler (langfuse).
+#
+# Unconditional core members (always built). github-sync is built ONLY when
+# github sync is enabled, so it is asserted separately by the gating test.
+TD723_CORE_SOURCE_SERVICES = ["embedding", "classifier-worker", "monitoring-api"]
 TD723_LANGFUSE_SOURCE_SERVICES = ["evaluator-scheduler", "trace-flush-worker"]
+
+
+def _source_bake_build_block(text, build_array):
+    """Return the `if ! _compose ... build "${build_array[@]}"` invocation text.
+
+    Spans from the nearest `if ! _compose` preceding the build call down to and
+    including the `build "${build_array[@]}"` line. Lets tests assert that a
+    --profile flag and its build call co-occur in the SAME invocation without
+    requiring them on adjacent lines (LOW-5: decoupled from the brittle
+    exact-adjacency regex that broke if any flag was inserted between them).
+    """
+    m = re.search(r'build\s+"\$\{' + re.escape(build_array) + r'\[@\]\}"', text)
+    if not m:
+        return None
+    starts = list(re.finditer(r"if ! _compose", text[: m.start()]))
+    if not starts:
+        return None
+    return text[starts[-1].start() : m.end()]
 
 
 class TestStackShSourceBakeRebuild:
     """Verify stack.sh cmd_start contains a CACHED compose build for the
     python-source baked services.
 
-    TD-723: embedding, classifier-worker, github-sync (core) and
-    evaluator-scheduler, trace-flush-worker (langfuse) use the build:+image:
-    hybrid with COPY'd python source. `compose up -d` reuses the cached image
-    even when the COPY'd source changed, so a baked-source release deploys
-    stale silently. The fix adds a CACHED `build` (NOT --no-cache, so only
-    changed COPY layers are invalidated) before each `up -d --wait`.
+    TD-723: embedding, classifier-worker, monitoring-api, github-sync (core) and
+    evaluator-scheduler, trace-flush-worker (langfuse) cache their built image
+    under the build:+image: hybrid pattern. `compose up -d` reuses the cached
+    image even when a baked change shipped, so a release deploys stale silently.
+    The fix adds a CACHED `build` (NOT --no-cache, so only changed layers are
+    invalidated) before each `up -d --wait`. The rebuild redeploys baked changes
+    — baked src for the baked-src services, and baked pip dependencies
+    (requirements.txt) for all of them.
 
     These must be CACHED builds — adding them to the --no-cache IMAGE_BAKE
     arrays would re-bake embedding ONNX models / re-run github-sync's spacy
@@ -654,11 +686,21 @@ class TestStackShSourceBakeRebuild:
 
     @pytest.mark.parametrize("service", TD723_CORE_SOURCE_SERVICES)
     def test_core_service_in_source_bake_array(self, stack_sh_text, service):
-        """Each core python-source service must appear in the core array."""
+        """Each unconditional core python-source service must appear in the core
+        array initializer (github-sync is gated — see the gating test)."""
         assert re.search(
             r"SOURCE_BAKE_SERVICES=\([^)]*\b" + re.escape(service) + r"\b[^)]*\)",
             stack_sh_text,
         ), f"'{service}' must be in the core SOURCE_BAKE_SERVICES array (TD-723)"
+
+    def test_monitoring_api_in_core_source_bake(self, stack_sh_text):
+        """monitoring-api is genuinely baked-src (monitoring/Dockerfile COPYs
+        src with NO src volume mount) and runs under --profile monitoring
+        (default ON), so it must be in the unconditional core source-bake set."""
+        assert re.search(
+            r"SOURCE_BAKE_SERVICES=\([^)]*\bmonitoring-api\b[^)]*\)",
+            stack_sh_text,
+        ), "monitoring-api must be in the core SOURCE_BAKE_SERVICES array (TD-723)"
 
     @pytest.mark.parametrize("service", TD723_LANGFUSE_SOURCE_SERVICES)
     def test_langfuse_service_in_source_bake_array(self, stack_sh_text, service):
@@ -670,19 +712,56 @@ class TestStackShSourceBakeRebuild:
             stack_sh_text,
         ), f"'{service}' must be in the SOURCE_BAKE_SERVICES_LANGFUSE array (TD-723)"
 
-    def test_core_build_is_profile_github_aware(self, stack_sh_text):
-        """github-sync is behind --profile github, so the core source build must
-        pass --profile github to make it visible."""
-        assert re.search(
-            r"--profile github \\\s*\n\s*build\s+\"\$\{SOURCE_BAKE_SERVICES\[@\]\}\"",
-            stack_sh_text,
-        ), "core source build must pass --profile github so github-sync is visible (TD-723)"
+    def test_core_build_is_profile_monitoring_aware(self, stack_sh_text):
+        """monitoring-api is behind --profile monitoring, so the core source
+        build invocation must carry --profile monitoring. Asserts co-occurrence
+        within the same `if ! _compose` block, NOT line-adjacency (LOW-5)."""
+        block = _source_bake_build_block(stack_sh_text, "SOURCE_BAKE_SERVICES")
+        assert block is not None, "core source-bake build invocation not found (TD-723)"
+        assert "--profile monitoring" in block, (
+            "core source build must pass --profile monitoring so monitoring-api "
+            "is visible (TD-723)"
+        )
+
+    def test_github_sync_build_conditionally_gated(self, stack_sh_text):
+        """github-sync is behind --profile github and is only started when
+        GITHUB_SYNC_ENABLED=true AND GITHUB_TOKEN is set, so the core source
+        build must append github-sync (and --profile github) under that SAME
+        condition — not build it unconditionally (TD-723)."""
+        gates = [
+            m.group(1)
+            for m in re.finditer(
+                r'if \[\[ "\$\{GITHUB_SYNC_ENABLED\}" == "true" '
+                r'&& -n "\$\{GITHUB_TOKEN:-\}" \]\]; then(.*?)\n    fi',
+                stack_sh_text,
+                re.DOTALL,
+            )
+            if "SOURCE_BAKE_SERVICES+=" in m.group(1)
+        ]
+        assert gates, (
+            "github-sync must be appended to SOURCE_BAKE_SERVICES inside the "
+            "GITHUB_SYNC_ENABLED + GITHUB_TOKEN gate (TD-723)"
+        )
+        gate = gates[0]
+        assert "SOURCE_BAKE_SERVICES+=(github-sync)" in gate, (
+            "github-sync must be appended to the core source-bake set inside the "
+            "github gate (TD-723)"
+        )
+        assert "--profile github" in gate, (
+            "the github gate must also enable --profile github for the source "
+            "build so github-sync is visible (TD-723)"
+        )
 
     def test_langfuse_build_is_profile_langfuse_aware(self, stack_sh_text):
-        """langfuse services are behind --profile langfuse; the build must pass it."""
-        assert re.search(
-            r"--profile langfuse \\\s*\n\s*build\s+\"\$\{SOURCE_BAKE_SERVICES_LANGFUSE\[@\]\}\"",
-            stack_sh_text,
+        """langfuse services are behind --profile langfuse; the build invocation
+        must carry --profile langfuse. Asserts co-occurrence within the same
+        `if ! _compose` block, NOT line-adjacency (LOW-5)."""
+        block = _source_bake_build_block(stack_sh_text, "SOURCE_BAKE_SERVICES_LANGFUSE")
+        assert (
+            block is not None
+        ), "langfuse source-bake build invocation not found (TD-723)"
+        assert (
+            "--profile langfuse" in block
         ), "langfuse source build must pass --profile langfuse (TD-723)"
 
 

--- a/tests/test_compose_bare_up_topology.py
+++ b/tests/test_compose_bare_up_topology.py
@@ -615,9 +615,10 @@ class TestStackShImageBakeRebuild:
 #     requirements.txt change (the PM #353 'No module named openai' class) still
 #     needs a rebuild: classifier-worker (core); evaluator-scheduler (langfuse).
 #
-# Unconditional core members (always built). github-sync is built ONLY when
-# github sync is enabled, so it is asserted separately by the gating test.
-TD723_CORE_SOURCE_SERVICES = ["embedding", "classifier-worker", "monitoring-api"]
+# Unconditional core members (always built). monitoring-api is gated on
+# MONITORING_ENABLED and github-sync on GITHUB_SYNC_ENABLED+GITHUB_TOKEN;
+# both are asserted separately by their respective gating tests.
+TD723_CORE_SOURCE_SERVICES = ["embedding", "classifier-worker"]
 TD723_LANGFUSE_SOURCE_SERVICES = ["evaluator-scheduler", "trace-flush-worker"]
 
 
@@ -643,9 +644,10 @@ class TestStackShSourceBakeRebuild:
     """Verify stack.sh cmd_start contains a CACHED compose build for the
     python-source baked services.
 
-    TD-723: embedding, classifier-worker, monitoring-api, github-sync (core) and
-    evaluator-scheduler, trace-flush-worker (langfuse) cache their built image
-    under the build:+image: hybrid pattern. `compose up -d` reuses the cached
+    TD-723: embedding, classifier-worker, monitoring-api (conditional on
+    MONITORING_ENABLED), and github-sync (conditional on GITHUB_SYNC_ENABLED +
+    GITHUB_TOKEN) in core; evaluator-scheduler and trace-flush-worker in langfuse.
+    compose caches each service's built image; `compose up -d` reuses the cached
     image even when a baked change shipped, so a release deploys stale silently.
     The fix adds a CACHED `build` (NOT --no-cache, so only changed layers are
     invalidated) before each `up -d --wait`. The rebuild redeploys baked changes
@@ -693,15 +695,6 @@ class TestStackShSourceBakeRebuild:
             stack_sh_text,
         ), f"'{service}' must be in the core SOURCE_BAKE_SERVICES array (TD-723)"
 
-    def test_monitoring_api_in_core_source_bake(self, stack_sh_text):
-        """monitoring-api is genuinely baked-src (monitoring/Dockerfile COPYs
-        src with NO src volume mount) and runs under --profile monitoring
-        (default ON), so it must be in the unconditional core source-bake set."""
-        assert re.search(
-            r"SOURCE_BAKE_SERVICES=\([^)]*\bmonitoring-api\b[^)]*\)",
-            stack_sh_text,
-        ), "monitoring-api must be in the core SOURCE_BAKE_SERVICES array (TD-723)"
-
     @pytest.mark.parametrize("service", TD723_LANGFUSE_SOURCE_SERVICES)
     def test_langfuse_service_in_source_bake_array(self, stack_sh_text, service):
         """Each langfuse python-source service must appear in the langfuse array."""
@@ -713,14 +706,54 @@ class TestStackShSourceBakeRebuild:
         ), f"'{service}' must be in the SOURCE_BAKE_SERVICES_LANGFUSE array (TD-723)"
 
     def test_core_build_is_profile_monitoring_aware(self, stack_sh_text):
-        """monitoring-api is behind --profile monitoring, so the core source
-        build invocation must carry --profile monitoring. Asserts co-occurrence
-        within the same `if ! _compose` block, NOT line-adjacency (LOW-5)."""
+        """monitoring-api is behind --profile monitoring; the core source build
+        must expand _monitoring_source_profile so the flag reaches the build
+        when monitoring is enabled. Asserts co-occurrence within the same
+        `if ! _compose` block, NOT line-adjacency (LOW-5)."""
         block = _source_bake_build_block(stack_sh_text, "SOURCE_BAKE_SERVICES")
         assert block is not None, "core source-bake build invocation not found (TD-723)"
-        assert "--profile monitoring" in block, (
-            "core source build must pass --profile monitoring so monitoring-api "
-            "is visible (TD-723)"
+        assert '"${_monitoring_source_profile[@]}"' in block, (
+            'core source build must expand "${_monitoring_source_profile[@]}" so '
+            "--profile monitoring reaches the build invocation when monitoring is "
+            "enabled (TD-723)"
+        )
+
+    def test_monitoring_api_build_conditionally_gated(self, stack_sh_text):
+        """monitoring-api is behind --profile monitoring and only started when
+        MONITORING_ENABLED != 'false' (default ON, mirrors the `up` gating),
+        so the core source build must append monitoring-api (and set
+        _monitoring_source_profile) under that SAME condition — not build it
+        unconditionally (TD-723)."""
+        gates = [
+            m.group(1)
+            for m in re.finditer(
+                r'if \[\[ "\$\{MONITORING_ENABLED\}" != "false" \]\]; then(.*?)\n    fi',
+                stack_sh_text,
+                re.DOTALL,
+            )
+            if "SOURCE_BAKE_SERVICES+=" in m.group(1)
+        ]
+        assert gates, (
+            "monitoring-api must be appended to SOURCE_BAKE_SERVICES inside the "
+            "MONITORING_ENABLED gate (TD-723)"
+        )
+        gate = gates[0]
+        assert "SOURCE_BAKE_SERVICES+=(monitoring-api)" in gate, (
+            "monitoring-api must be appended to the core source-bake set inside "
+            "the monitoring gate (TD-723)"
+        )
+        assert "_monitoring_source_profile=(--profile monitoring)" in gate, (
+            "the monitoring gate must set _monitoring_source_profile to "
+            "--profile monitoring so monitoring-api is visible to the build (TD-723)"
+        )
+        # Assert the profile variable is wired into the build invocation
+        build_block = _source_bake_build_block(stack_sh_text, "SOURCE_BAKE_SERVICES")
+        assert (
+            build_block is not None
+        ), "core source-bake build invocation not found (TD-723)"
+        assert '"${_monitoring_source_profile[@]}"' in build_block, (
+            '"${_monitoring_source_profile[@]}" must appear in the core source '
+            "build invocation so --profile monitoring is wired in (TD-723)"
         )
 
     def test_github_sync_build_conditionally_gated(self, stack_sh_text):
@@ -750,6 +783,15 @@ class TestStackShSourceBakeRebuild:
         assert "--profile github" in gate, (
             "the github gate must also enable --profile github for the source "
             "build so github-sync is visible (TD-723)"
+        )
+        # Assert the profile variable expansion is wired into the build invocation
+        build_block = _source_bake_build_block(stack_sh_text, "SOURCE_BAKE_SERVICES")
+        assert (
+            build_block is not None
+        ), "core source-bake build invocation not found (TD-723)"
+        assert '"${_github_source_profile[@]}"' in build_block, (
+            '"${_github_source_profile[@]}" must appear in the core source build '
+            "invocation so --profile github is wired in, not just set (TD-723)"
         )
 
     def test_langfuse_build_is_profile_langfuse_aware(self, stack_sh_text):

--- a/tests/test_compose_bare_up_topology.py
+++ b/tests/test_compose_bare_up_topology.py
@@ -601,6 +601,92 @@ class TestStackShImageBakeRebuild:
 
 
 # ---------------------------------------------------------------------------
+# TD-723 — stack.sh cmd_start python-source CACHED rebuild assertions
+# ---------------------------------------------------------------------------
+
+# Python-source baked services (build:+image: hybrid with COPY'd python source).
+TD723_CORE_SOURCE_SERVICES = ["embedding", "classifier-worker", "github-sync"]
+TD723_LANGFUSE_SOURCE_SERVICES = ["evaluator-scheduler", "trace-flush-worker"]
+
+
+class TestStackShSourceBakeRebuild:
+    """Verify stack.sh cmd_start contains a CACHED compose build for the
+    python-source baked services.
+
+    TD-723: embedding, classifier-worker, github-sync (core) and
+    evaluator-scheduler, trace-flush-worker (langfuse) use the build:+image:
+    hybrid with COPY'd python source. `compose up -d` reuses the cached image
+    even when the COPY'd source changed, so a baked-source release deploys
+    stale silently. The fix adds a CACHED `build` (NOT --no-cache, so only
+    changed COPY layers are invalidated) before each `up -d --wait`.
+
+    These must be CACHED builds — adding them to the --no-cache IMAGE_BAKE
+    arrays would re-bake embedding ONNX models / re-run github-sync's spacy
+    download on every restart.
+    """
+
+    @pytest.fixture(scope="class")
+    def stack_sh_text(self):
+        return STACK_SH_PATH.read_text(encoding="utf-8")
+
+    def test_core_source_bake_cached_build_present(self, stack_sh_text):
+        """Core python-source services must be built via a CACHED build
+        (the build call must NOT carry --no-cache)."""
+        assert re.search(
+            r'build\s+"\$\{SOURCE_BAKE_SERVICES\[@\]\}"',
+            stack_sh_text,
+        ), "stack.sh must build SOURCE_BAKE_SERVICES (cached) before core up (TD-723)"
+        assert not re.search(
+            r'--no-cache\s+"\$\{SOURCE_BAKE_SERVICES\[@\]\}"',
+            stack_sh_text,
+        ), "core python-source build must be CACHED, not --no-cache (TD-723)"
+
+    def test_langfuse_source_bake_cached_build_present(self, stack_sh_text):
+        """Langfuse python-source services must be built via a CACHED build."""
+        assert re.search(
+            r'build\s+"\$\{SOURCE_BAKE_SERVICES_LANGFUSE\[@\]\}"',
+            stack_sh_text,
+        ), "stack.sh must build SOURCE_BAKE_SERVICES_LANGFUSE (cached) before langfuse up (TD-723)"
+        assert not re.search(
+            r'--no-cache\s+"\$\{SOURCE_BAKE_SERVICES_LANGFUSE\[@\]\}"',
+            stack_sh_text,
+        ), "langfuse python-source build must be CACHED, not --no-cache (TD-723)"
+
+    @pytest.mark.parametrize("service", TD723_CORE_SOURCE_SERVICES)
+    def test_core_service_in_source_bake_array(self, stack_sh_text, service):
+        """Each core python-source service must appear in the core array."""
+        assert re.search(
+            r"SOURCE_BAKE_SERVICES=\([^)]*\b" + re.escape(service) + r"\b[^)]*\)",
+            stack_sh_text,
+        ), f"'{service}' must be in the core SOURCE_BAKE_SERVICES array (TD-723)"
+
+    @pytest.mark.parametrize("service", TD723_LANGFUSE_SOURCE_SERVICES)
+    def test_langfuse_service_in_source_bake_array(self, stack_sh_text, service):
+        """Each langfuse python-source service must appear in the langfuse array."""
+        assert re.search(
+            r"SOURCE_BAKE_SERVICES_LANGFUSE=\([^)]*\b"
+            + re.escape(service)
+            + r"\b[^)]*\)",
+            stack_sh_text,
+        ), f"'{service}' must be in the SOURCE_BAKE_SERVICES_LANGFUSE array (TD-723)"
+
+    def test_core_build_is_profile_github_aware(self, stack_sh_text):
+        """github-sync is behind --profile github, so the core source build must
+        pass --profile github to make it visible."""
+        assert re.search(
+            r"--profile github \\\s*\n\s*build\s+\"\$\{SOURCE_BAKE_SERVICES\[@\]\}\"",
+            stack_sh_text,
+        ), "core source build must pass --profile github so github-sync is visible (TD-723)"
+
+    def test_langfuse_build_is_profile_langfuse_aware(self, stack_sh_text):
+        """langfuse services are behind --profile langfuse; the build must pass it."""
+        assert re.search(
+            r"--profile langfuse \\\s*\n\s*build\s+\"\$\{SOURCE_BAKE_SERVICES_LANGFUSE\[@\]\}\"",
+            stack_sh_text,
+        ), "langfuse source build must pass --profile langfuse (TD-723)"
+
+
+# ---------------------------------------------------------------------------
 # BP-162 Layer 2 — built-image parent-dir mode assertions
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem
`stack.sh` restart/start rebuilt only the `--no-cache` image-bake services (qdrant, grafana, prometheus-init, langfuse-clickhouse) and brought every other service up with `up -d` and no build. The python-source images (embedding, classifier-worker, github-sync, evaluator-scheduler, trace-flush-worker) use the build:+image: hybrid, so `up -d` reused the cached image even when their COPY'd source changed — a baked-source release deployed stale silently (the embedding arena-off fix sat on disk while the running container kept the old image until a manual rebuild).

## Change
Add a cached, profile-aware rebuild step for the python-source baked services in both the core and langfuse sections of `cmd_start` (which `cmd_restart` delegates to):
- core: `build embedding classifier-worker github-sync` with `--profile github`
- langfuse: `build evaluator-scheduler trace-flush-worker` with `--profile langfuse`

Cached (not `--no-cache`): a cached build re-COPYs only changed layers, so embedding ONNX models are not re-baked and github-sync's spacy download does not re-run when source is unchanged. Non-fatal on failure (log_warning + continue), matching the existing image-bake step. The existing `--no-cache` IMAGE_BAKE arrays are unchanged.

## Tests
`tests/test_compose_bare_up_topology.py::TestStackShSourceBakeRebuild` asserts each service is rebuilt via a cached build (not `--no-cache`) with the correct profile.

## Verification
Two-phase live verification (change a baked source file → `stack.sh restart` → assert the running container reflects it; then daemon restart → confirm no spurious rebuild loop / layers report CACHED) to be run by the maintainer.