### PR TITLE
embedding: bound effective in-flight work to keep transient peak under cap (BUG-326)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Embedding service `/health` aliased-fallback detection (TD-553 / BUG-289)** — the `health()` endpoint now returns HTTP 503 when the code model has fallen back to the English model alias (both registry entries point to the same object), not only when a model entry is `None`. The response body `status` field reflects `"degraded"` in this case. Compose `depends_on: condition: service_healthy` now correctly gates on genuine dual-model readiness; consumers no longer receive a false-healthy signal when the code model is degraded.
+
 ## [2.8.0] - 2026-06-21
 
 ### Upgrade Instructions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Embedding service CPU memory arena disabled (BUG-324)** — both `TextEmbedding` constructors now pass `enable_cpu_mem_arena=False`, disabling the onnxruntime BFC arena that retains mmap'd regions and never returns them to the OS. A controlled A/B measured a 3.8× reduction in retained memory (5289 → 1381 MiB) with no further accumulation under load. The 6 GiB container cap is retained as headroom for the transient inference peak (~4.3 GiB), which does return after the run.
 - **Embedding service `/health` aliased-fallback detection (TD-553 / BUG-289)** — the `health()` endpoint now returns HTTP 503 when the code model has fallen back to the English model alias (both registry entries point to the same object), not only when a model entry is `None`. The response body `status` field reflects `"degraded"` in this case. Compose `depends_on: condition: service_healthy` now correctly gates on genuine dual-model readiness; consumers no longer receive a false-healthy signal when the code model is degraded.
 
 ## [2.8.0] - 2026-06-21

--- a/docker/embedding/main.py
+++ b/docker/embedding/main.py
@@ -89,6 +89,36 @@ EMBEDDING_MEMORY_OK_RATIO = float(os.getenv("EMBEDDING_MEMORY_OK_RATIO", "0.75")
 EMBEDDING_MAX_BATCH_TEXTS = int(os.getenv("EMBEDDING_MAX_BATCH_TEXTS", "256"))
 EMBEDDING_MAX_INPUT_CHARS = int(os.getenv("EMBEDDING_MAX_INPUT_CHARS", "1000000"))
 
+# BUG-326: PROACTIVE pre-admission envelope on the worst-case concurrent transient
+# footprint. With the BUG-324 arena-off retention fix in place, the service still admits
+# loads whose *transient* allocation peak reaches the 6 GiB container cap with zero
+# headroom — measured (Round-2 S115): 4 concurrent batch-30 (~2KB/text) /embed requests
+# (= 4 x 30 = 120 concurrent in-flight texts) peaked at exactly 6.000 GiB == cap. It
+# survived only because the kernel held at cap and the #198 AIMD limiter fired AFTER the
+# peak; AIMD is REACTIVE. This bound is PROACTIVE: it caps the sum of batch sizes of all
+# requests concurrently holding an inference slot (the "effective in-flight work", in
+# units of texts) so the worst-case admitted transient cannot reach the cap. It is the
+# equivalent-effective-work realization of bounding (effective_concurrency x batch_size):
+# Sigma(in-flight batch sizes) <= effective_concurrency x max_batch, and is tighter +
+# correct for mixed batch sizes. It COMPLEMENTS — does not replace — the AIMD
+# _effective_limit controller (a second, pre-acquire admission gate; see run_inference_async).
+#
+# Default derivation (conservative; FINAL value set by live verification — see report):
+#   - Anchor: the cap-reproducing load is 4 x 30 = 120 concurrent in-flight texts ->
+#     6.000 GiB == cap (S115, ~2KB/text). Idle base ~1.5 GiB => ~4.5 GiB transient for
+#     120 texts ~= 38 MiB/text (linear-from-idle).
+#   - Bounding concurrent in-flight texts to 48 (= 40% of the 120 that hit the cap)
+#     projects a worst-case peak of ~1.5 + 48 x 0.038 ~= 3.3 GiB — ~2.7 GiB (~45%)
+#     headroom below the 6 GiB cap, and guarantees the exact bug load (120) is shed down
+#     to <= 48 in-flight texts.
+#   - 48 still fully admits the designed multi-client prose regime (<= 32 concurrent
+#     in-flight texts), so healthy load is never shed.
+#   - The 2-way batch-16 (32 texts -> ~5.25 GiB) datapoint is superlinear vs the 120
+#     anchor (text size unspecified, noisier); it is WHY the default sits well under that
+#     work level and why live verification governs the final value. Per-request total
+#     chars remain separately bounded by EMBEDDING_MAX_INPUT_CHARS.
+EMBEDDING_SAFE_INFLIGHT_TEXTS = int(os.getenv("EMBEDDING_SAFE_INFLIGHT_TEXTS", "48"))
+
 # Configure logging
 logging.basicConfig(
     level=getattr(logging, LOG_LEVEL.upper(), logging.INFO),
@@ -180,6 +210,12 @@ _inference_executor = ThreadPoolExecutor(
 # on the single-threaded event loop, so a plain int needs no lock.
 _waiting_count = 0
 
+# BUG-326: sum of batch sizes of requests CURRENTLY holding an inference slot (the
+# "effective in-flight work", in texts). Bounded by EMBEDDING_SAFE_INFLIGHT_TEXTS at
+# admission. Mutated only on the single-threaded event loop between a slot acquire and
+# its release (no await in that window), so a plain int needs no lock.
+_inflight_work = 0
+
 # BUG-324 Phase 2: the AIMD controller shrinks the EFFECTIVE limit below the static max
 # by *parking* permits on the semaphore (acquiring without releasing) — so a collapse to
 # 1 simply drains as in-flight requests finish. effective = max - parked.
@@ -193,7 +229,7 @@ _blind_hold_logged = False
 embedding_effective_concurrency_limit.set(_effective_limit)
 
 
-async def run_inference_async(operation):
+async def run_inference_async(operation, work_units=1):
     """Run a model inference under the service-global backpressure gate (BUG-324).
 
     Admission is BLOCK-not-drop: the caller waits up to ``EMBEDDING_ACQUIRE_TIMEOUT`` for
@@ -204,21 +240,38 @@ async def run_inference_async(operation):
     (``EMBEDDING_MAX_WAITERS``) or the wait exceeds the timeout — both ~never under
     correctly-sized load, and the client retries them (Phase 3).
 
+    BUG-326: after a slot is acquired, a PROACTIVE envelope gate checks whether admitting
+    this request's ``work_units`` (its batch size) would push the sum of batch sizes of
+    all requests concurrently holding a slot over ``EMBEDDING_SAFE_INFLIGHT_TEXTS``. If
+    so — and only if other work is already in flight — the slot is returned and the
+    request is shed via the SAME 503 + ``Retry-After`` path (detail
+    ``embedding_admission_over_envelope``) so the worst-case admitted concurrent transient
+    cannot reach the container cap. A request that finds the service idle
+    (``_inflight_work == 0``) is ALWAYS admitted regardless of size, so this gate never
+    starves a lone request (the per-request single-batch bound stays
+    ``EMBEDDING_MAX_BATCH_TEXTS`` / the 413 path). The gate is independent of the AIMD
+    ``_effective_limit`` controller — it neither parks nor reads semaphore permits — so
+    the two cannot deadlock or double-count: the semaphore bounds concurrency, this gate
+    bounds concurrent work.
+
     Python-level inference faults are isolated to a 503 so one bad request cannot crash
     the worker; this does NOT protect against an OS-level OOM SIGKILL, which the up-front
     payload limits and the memory budget exist to prevent.
 
     Args:
         operation: Zero-arg callable performing the (blocking) model inference.
+        work_units: This request's batch size (number of texts to embed); the unit the
+            envelope bounds. Defaults to 1.
 
     Returns:
         Whatever ``operation`` returns.
 
     Raises:
-        HTTPException: 503 (+ Retry-After) if no slot is admitted within the limits, or
-            if the inference call raises any non-HTTPException error.
+        HTTPException: 503 (+ Retry-After) if no slot is admitted within the limits, if
+            admitting would breach the in-flight-work envelope, or if the inference call
+            raises any non-HTTPException error.
     """
-    global _waiting_count
+    global _waiting_count, _inflight_work
 
     # Bounded wait-queue: shed (last resort) only when the queue itself is full, so total
     # memory = (in-flight + waiting) x per-request peak stays bounded (BP-175 §4).
@@ -261,6 +314,36 @@ async def run_inference_async(operation):
         embedding_queue_depth.set(_waiting_count)
 
     embedding_admission_wait_seconds.observe(time.monotonic() - start)
+
+    # BUG-326 proactive envelope gate. Runs after the slot acquire and before any model
+    # work, in a window with no ``await`` (so the read-and-increment of _inflight_work is
+    # atomic on the single event loop and cannot race other admissions). The semaphore
+    # already caps holders at the AIMD effective limit; this additionally caps the SUM of
+    # their batch sizes. Shed only when other work is already in flight — a lone request
+    # is always admitted so the gate never starves it (its size is bounded separately by
+    # EMBEDDING_MAX_BATCH_TEXTS). The shed gives the slot back, so it does not leak a
+    # permit or interfere with AIMD's parked permits.
+    if (
+        _inflight_work > 0
+        and _inflight_work + work_units > EMBEDDING_SAFE_INFLIGHT_TEXTS
+    ):
+        _inference_semaphore.release()
+        embedding_backpressure_total.labels(action="shed").inc()
+        logger.warning(
+            "embedding_admission_over_envelope",
+            extra={
+                "inflight_work": _inflight_work,
+                "work_units": work_units,
+                "envelope": EMBEDDING_SAFE_INFLIGHT_TEXTS,
+            },
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="embedding_admission_over_envelope",
+            headers={"Retry-After": str(EMBEDDING_RETRY_AFTER)},
+        )
+
+    _inflight_work += work_units
     embedding_inflight.inc()
     # M1 (BUG-324): release the slot EXACTLY ONCE and ONLY when the executor thread truly
     # completes. A client disconnect raises asyncio.CancelledError (a BaseException) out of
@@ -276,6 +359,8 @@ async def run_inference_async(operation):
     loop = asyncio.get_running_loop()
 
     def _release_slot():
+        global _inflight_work
+        _inflight_work -= work_units
         embedding_inflight.dec()
         _inference_semaphore.release()
 
@@ -807,7 +892,9 @@ async def embed_dense(request: EmbedDenseRequest) -> EmbedDenseResponse:
     _enforce_payload_limits(request.texts)
 
     model = MODEL_REGISTRY[request.model]
-    embeddings = await run_inference_async(lambda: list(model.embed(request.texts)))
+    embeddings = await run_inference_async(
+        lambda: list(model.embed(request.texts)), work_units=len(request.texts)
+    )
     return EmbedDenseResponse(
         embeddings=[e.tolist() for e in embeddings],
         model=MODEL_NAMES[request.model],
@@ -853,7 +940,9 @@ async def embed_chunked(request: EmbedWithOffsetsRequest):
 
     if not request.chunk_offsets:
         # No offsets — embed whole document as single vector
-        embeddings = await run_inference_async(lambda: list(model.embed([document])))
+        embeddings = await run_inference_async(
+            lambda: list(model.embed([document])), work_units=1
+        )
         return EmbedResponse(
             embeddings=[e.tolist() for e in embeddings],
             model=MODEL_NAMES["en"],
@@ -869,7 +958,9 @@ async def embed_chunked(request: EmbedWithOffsetsRequest):
         chunk_texts.append(document[start:end])
     _enforce_payload_limits(chunk_texts)
 
-    embeddings = await run_inference_async(lambda: list(model.embed(chunk_texts)))
+    embeddings = await run_inference_async(
+        lambda: list(model.embed(chunk_texts)), work_units=len(chunk_texts)
+    )
     return EmbedResponse(
         embeddings=[e.tolist() for e in embeddings],
         model=MODEL_NAMES["en"],
@@ -886,7 +977,9 @@ async def embed_sparse(request: EmbedSparseRequest):
         raise HTTPException(status_code=503, detail="BM25 model not loaded")
     _enforce_payload_limits(request.texts)
     model = SPARSE_REGISTRY["bm25"]
-    results = await run_inference_async(lambda: list(model.embed(request.texts)))
+    results = await run_inference_async(
+        lambda: list(model.embed(request.texts)), work_units=len(request.texts)
+    )
     return EmbedSparseResponse(
         embeddings=[
             SparseEmbeddingResult(indices=r.indices.tolist(), values=r.values.tolist())
@@ -908,7 +1001,9 @@ async def embed_late(request: EmbedLateRequest):
         )
     _enforce_payload_limits(request.texts)
     model = LATE_REGISTRY["colbert"]
-    results = await run_inference_async(lambda: list(model.embed(request.texts)))
+    results = await run_inference_async(
+        lambda: list(model.embed(request.texts)), work_units=len(request.texts)
+    )
     return EmbedLateResponse(
         embeddings=[LateEmbeddingResult(embeddings=r.tolist()) for r in results],
         model="colbert-ir/colbertv2.0",

--- a/docker/embedding/main.py
+++ b/docker/embedding/main.py
@@ -759,12 +759,14 @@ async def health():
     healthcheck. This handler does only trivial in-memory work, so running it on the
     loop is safe.
 
-    TD-553 (don't restart a draining service): readiness is tied to ``model_loaded``,
+    BUG-321 (don't restart a draining service): readiness is tied to ``model_loaded``,
     NOT to load or memory pressure. Under the AIMD drain mode (effective concurrency
     collapsed toward 1) the models stay loaded, so this returns 200 "healthy" — a
     pressured-but-functioning service is never marked unhealthy and is not restarted.
     Because the handler runs on the loop and does no inference, it stays responsive
     within the healthcheck timeout even when every inference slot is occupied.
+
+    TD-553: The 503-on-aliased-fallback gate below implements oversight TD-553.
     """
     model_loaded = all(m is not None for m in MODEL_REGISTRY.values())
     code_aliased_to_en = MODEL_REGISTRY.get("code") is MODEL_REGISTRY.get("en")

--- a/docker/embedding/main.py
+++ b/docker/embedding/main.py
@@ -586,7 +586,9 @@ def load_models():
     en_name = MODEL_NAMES["en"]
     logger.info("model_loading", extra={"model": en_name, "key": "en"})
     start_load = time.time()
-    MODEL_REGISTRY["en"] = TextEmbedding(en_name, threads=EMBEDDING_INFERENCE_THREADS)
+    MODEL_REGISTRY["en"] = TextEmbedding(
+        en_name, threads=EMBEDDING_INFERENCE_THREADS, enable_cpu_mem_arena=False
+    )
     load_duration = time.time() - start_load
     logger.info(
         "model_loaded",
@@ -603,7 +605,7 @@ def load_models():
         logger.info("model_loading", extra={"model": code_name, "key": "code"})
         start_load = time.time()
         MODEL_REGISTRY["code"] = TextEmbedding(
-            code_name, threads=EMBEDDING_INFERENCE_THREADS
+            code_name, threads=EMBEDDING_INFERENCE_THREADS, enable_cpu_mem_arena=False
         )
         load_duration = time.time() - start_load
         logger.info(

--- a/docker/embedding/main.py
+++ b/docker/embedding/main.py
@@ -765,8 +765,13 @@ async def health():
     within the healthcheck timeout even when every inference slot is occupied.
     """
     model_loaded = all(m is not None for m in MODEL_REGISTRY.values())
+    code_aliased_to_en = MODEL_REGISTRY.get("code") is MODEL_REGISTRY.get("en")
     response = HealthResponse(
-        status="healthy" if model_loaded else "loading",
+        status=(
+            "healthy"
+            if (model_loaded and not code_aliased_to_en)
+            else ("loading" if not model_loaded else "degraded")
+        ),
         model_loaded=model_loaded,
         model=MODEL_NAMES["en"],  # KEPT: backward compat for existing monitors
         models=list(MODEL_NAMES.values()),  # NEW: list both models
@@ -775,7 +780,7 @@ async def health():
         sparse_models=list(SPARSE_REGISTRY.keys()),
         late_models=list(LATE_REGISTRY.keys()),
     )
-    if not model_loaded:
+    if not model_loaded or code_aliased_to_en:
         from fastapi.responses import JSONResponse
 
         return JSONResponse(

--- a/tests/test_embedding_service.py
+++ b/tests/test_embedding_service.py
@@ -759,6 +759,49 @@ def test_blind_hold_at_one_logs_once_per_state_entry(caplog):
     assert len(blind_logs) == 1
 
 
+# --- BUG-324: enable_cpu_mem_arena=False on both TextEmbedding constructors ---
+
+
+def test_text_embedding_constructors_disable_cpu_mem_arena():
+    """Both TextEmbedding constructors pass enable_cpu_mem_arena=False (BUG-324).
+
+    Bypasses _load_service() so the spy TextEmbedding is not overwritten by
+    _install_fake_fastembed() during module load.
+    """
+    call_kwargs = []
+
+    class _SpyDenseModel(_StubDenseModel):
+        def __init__(self, *args, **kwargs):
+            call_kwargs.append(dict(kwargs))
+            super().__init__(*args, **kwargs)
+
+    spy_fastembed = ModuleType("fastembed")
+    spy_fastembed.TextEmbedding = _SpyDenseModel
+    spy_fastembed.SparseTextEmbedding = _StubSparseModel
+    spy_fastembed.LateInteractionTextEmbedding = _StubLateModel
+    sys.modules["fastembed"] = spy_fastembed
+
+    os.environ["EMBEDDING_MAX_CONCURRENCY"] = "4"
+    sys.modules.pop("embedding_main_under_test", None)
+    spec = importlib.util.spec_from_file_location(
+        "embedding_main_under_test", _MAIN_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    # load_models() must call TextEmbedding for both "en" and "code" at startup.
+    assert (
+        len(call_kwargs) >= 2
+    ), f"Expected ≥2 TextEmbedding calls, got {len(call_kwargs)}"
+    for i, kwargs in enumerate(call_kwargs):
+        assert (
+            kwargs.get("enable_cpu_mem_arena") is False
+        ), f"TextEmbedding call {i} must pass enable_cpu_mem_arena=False; got {kwargs}"
+    # Confirm the module loaded cleanly (both registry keys present)
+    assert "en" in module.MODEL_REGISTRY
+    assert "code" in module.MODEL_REGISTRY
+
+
 # --- TD-553: /health aliased-fallback detection ---
 
 

--- a/tests/test_embedding_service.py
+++ b/tests/test_embedding_service.py
@@ -141,6 +141,7 @@ def _restore_global_state():
         "EMBEDDING_MAX_WAITERS",
         "EMBEDDING_RETRY_AFTER",
         "EMBEDDING_INFERENCE_THREADS",
+        "EMBEDDING_SAFE_INFLIGHT_TEXTS",
     )
     saved_modules = {k: sys.modules.get(k) for k in module_keys}
     saved_env = {k: os.environ.get(k) for k in env_keys}
@@ -412,6 +413,117 @@ def test_backpressure_waits_without_shedding_under_designed_load():
     # Backpressure engaged (callers were made to wait) but NOTHING was shed.
     assert _backpressure_count(service, "shed") - before_shed == 0
     assert _backpressure_count(service, "waited") - before_waited > 0
+
+
+# --- BUG-326: proactive in-flight-work admission envelope ---
+
+
+def test_admission_envelope_sheds_over_envelope_concurrent_work():
+    """Once work is in flight, a request that would push the concurrent in-flight work
+    over EMBEDDING_SAFE_INFLIGHT_TEXTS is shed (503 + Retry-After); a request that fits is
+    admitted (BUG-326). The semaphore cap is not the binding constraint here — the
+    work-envelope is.
+    """
+    service = _load_service(4)
+    service.EMBEDDING_SAFE_INFLIGHT_TEXTS = 40
+
+    async def _drive():
+        gate = threading.Event()
+
+        def _blocking_op():
+            gate.wait(timeout=10)  # hold the slot so _inflight_work stays at 30
+            return ["held"]
+
+        # Hold one in-flight request of 30 work-units; wait until it is counted.
+        holder = asyncio.create_task(
+            service.run_inference_async(_blocking_op, work_units=30)
+        )
+        while service._inflight_work < 30:
+            await asyncio.sleep(0)
+
+        # Over-envelope: 30 + 20 = 50 > 40 -> shed.
+        before_shed = _backpressure_count(service, "shed")
+        with pytest.raises(HTTPException) as over:
+            await service.run_inference_async(lambda: ["x"], work_units=20)
+        shed_delta = _backpressure_count(service, "shed") - before_shed
+
+        # Under-envelope: 30 + 10 = 40, not over -> admitted.
+        fit = await service.run_inference_async(lambda: ["y"], work_units=10)
+
+        gate.set()
+        await holder
+        return over.value, shed_delta, fit
+
+    err, shed_delta, fit = asyncio.run(_drive())
+    assert err.status_code == 503
+    assert err.detail == "embedding_admission_over_envelope"
+    assert err.headers["Retry-After"] == str(service.EMBEDDING_RETRY_AFTER)
+    assert shed_delta == 1
+    assert fit == ["y"]
+
+
+def test_admission_envelope_never_starves_lone_request():
+    """A request larger than the envelope is still admitted when nothing else is in
+    flight, so the proactive gate never starves a lone caller — its size is bounded
+    separately by EMBEDDING_MAX_BATCH_TEXTS (BUG-326).
+    """
+    service = _load_service(4)
+    service.EMBEDDING_SAFE_INFLIGHT_TEXTS = 40
+
+    async def _drive():
+        # 100 > 40 envelope, but the service is idle (_inflight_work == 0) -> admitted.
+        return await service.run_inference_async(lambda: ["solo"], work_units=100)
+
+    assert asyncio.run(_drive()) == ["solo"]
+
+
+def test_admission_envelope_enforced_on_http_path_with_production_batches():
+    """End-to-end on the real /embed/dense path with production-shaped (~2KB/text)
+    batches: while a 30-text request is in flight, a concurrent 20-text request (30 + 20
+    = 50 > 40 envelope) is shed with the over-envelope 503. Proves work_units is wired
+    from the actual request batch size (BUG-326).
+    """
+    service = _load_service(4)
+    service.EMBEDDING_SAFE_INFLIGHT_TEXTS = 40
+
+    async def _drive():
+        gate = threading.Event()
+        entered = asyncio.Event()
+        loop = asyncio.get_running_loop()
+
+        class _GatedModel:
+            name = "gated-stub"
+
+            def embed(self, embed_texts):
+                loop.call_soon_threadsafe(entered.set)
+                gate.wait(timeout=10)  # hold the slot while the second request arrives
+                return [np.full(768, 0.1, dtype=np.float32) for _ in embed_texts]
+
+        service.MODEL_REGISTRY["en"] = _GatedModel()
+
+        transport = httpx.ASGITransport(app=service.app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://embedding.test"
+        ) as client:
+            held = _production_shaped_batch(count=30)  # 30 in-flight work-units
+            holder = asyncio.create_task(
+                client.post("/embed/dense", json={"texts": held, "model": "en"})
+            )
+            await entered.wait()  # the 30-text request is now in flight (counted)
+
+            over = await client.post(
+                "/embed/dense",
+                json={"texts": _production_shaped_batch(count=20), "model": "en"},
+            )
+
+            gate.set()
+            holder_resp = await holder
+            return over.status_code, over.json().get("detail"), holder_resp.status_code
+
+    status, detail, holder_status = asyncio.run(_drive())
+    assert status == 503
+    assert detail == "embedding_admission_over_envelope"
+    assert holder_status == 200
 
 
 # --- Phase 2: cgroup-v2 reader + memory-aware AIMD self-throttle ---

--- a/tests/test_embedding_service.py
+++ b/tests/test_embedding_service.py
@@ -757,3 +757,37 @@ def test_blind_hold_at_one_logs_once_per_state_entry(caplog):
 
     blind_logs = asyncio.run(_drive())
     assert len(blind_logs) == 1
+
+
+# --- TD-553: /health aliased-fallback detection ---
+
+
+def test_health_both_models_loaded_returns_200():
+    """Both models loaded and distinct → /health returns HTTP 200 (BUG-289 / TD-553)."""
+    service = _load_service(4)
+    client = TestClient(service.app)
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "healthy"
+    assert resp.json()["model_loaded"] is True
+
+
+def test_health_code_aliased_to_en_returns_503():
+    """Code model aliased to en model (fallback) → /health returns HTTP 503 (TD-553)."""
+    service = _load_service(4)
+    # Simulate aliased fallback: code model failed to load, registry entry aliased to en
+    service.MODEL_REGISTRY["code"] = service.MODEL_REGISTRY["en"]
+    client = TestClient(service.app)
+    resp = client.get("/health")
+    assert resp.status_code == 503
+    assert resp.json()["status"] == "degraded"
+
+
+def test_health_model_none_returns_503():
+    """Any model None → /health returns HTTP 503 (existing BUG-289 case)."""
+    service = _load_service(4)
+    service.MODEL_REGISTRY["code"] = None
+    client = TestClient(service.app)
+    resp = client.get("/health")
+    assert resp.status_code == 503
+    assert resp.json()["status"] == "loading"


### PR DESCRIPTION
## Problem
With BUG-324's arena-off retention fix in place, the embedding service still ADMITS concurrent load that transiently breaches the 6 GiB cap (round2 S115: 4×batch-30 ~2KB → 6.000 GiB, zero headroom; survived only via the reactive #198 AIMD limiter).

## Change
Proactive pre-admission envelope in run_inference_async: a new `_inflight_work` (sum of in-flight batch sizes) bounded by `EMBEDDING_SAFE_INFLIGHT_TEXTS` (default 48). Concurrent requests that would exceed the envelope are shed via the existing 503 + Retry-After path (`detail=embedding_admission_over_envelope`). A lone-request rule admits a request when nothing else is in flight (deadlock-free). Complements, does not replace, the #198 AIMD controller.

## Scope
Closes the LIVE concurrency cap-breach. The lone-large-single-batch vector (a single batch > envelope) is tracked separately in BUG-327 (client sub-batch reconciliation + a server 413 belt-and-suspenders) because internal callers legitimately batch >48 today.

## Tests
3 new tests (over-envelope shed, lone-request-never-starved, HTTP end-to-end work_units wiring with production-size batches); 29/29 pass. Dual-reviewed Opus+Sonnet APPROVE/APPROVE.

## Verification
Final envelope value governed by the BUG-324 live load-verification (maintainer round-trip).