### PR TITLE
fix(aim-tracking-freshness): render fallback title when extraction is empty

### DIFF
--- a/_ai-memory/pov/skills/aim-tracking-freshness/scripts/tracking_freshness.py
+++ b/_ai-memory/pov/skills/aim-tracking-freshness/scripts/tracking_freshness.py
@@ -100,7 +100,7 @@ _SEV_ALIASES: dict[str, str] = {
 _SEV_KNOWN: frozenset[str] = frozenset(["CRITICAL", "HIGH", "MEDIUM", "LOW"])
 
 # Title: explicit **Title**: field (used by records with generic headings, e.g. BUG-047 group).
-_TITLE_FIELD_RE = re.compile(r"^\*\*Title:?\*\*:?\s*(.+)$", re.MULTILINE)
+_TITLE_FIELD_RE = re.compile(r"^\*\*Title:?\*\*:?[^\S\n]*([^:\n][^\n]*)$", re.MULTILINE)
 
 # H1 or H2 headings; companion regex strips the ID prefix.
 # ID prefix formats confirmed in live tree:
@@ -292,8 +292,10 @@ def _de_slugify(filename: str) -> str:
     """Convert a slug filename to a readable title (last-resort fallback).
 
     Returns the slug portion of the filename as a title-cased phrase, or an
-    empty string when the filename has no slug (e.g. ``BUG-001.md``).  An
-    empty return signals that ``extract_title`` should not echo the bare ID.
+    empty string when the filename has no slug (e.g. ``BUG-001.md``).  May
+    also return a whitespace-only string for degenerate slugs (e.g.
+    ``BUG-001--.md``); callers should test ``slug.strip()`` to guard against
+    visually blank results.
 
     Examples:
         ``BUG-047-installer-fails-with-spaces-in-path.md``
@@ -318,8 +320,8 @@ def extract_title(text: str, filename: str) -> str:
        Headings that resolve to noise tokens (``Bug Report``,
        ``Root Cause Analysis``, ``Investigation Report``) are skipped.
     3. De-slugified filename (``BUG-047-installer-fails-…`` → readable words).
-       Returns empty string for slug-less files (``BUG-001.md``) to avoid
-       echoing the bare ID as a title.
+       Falls back to the bare stem (``BUG-001``) for slug-less files so the
+       return value is never empty.
     """
     # 1. Explicit **Title**: field
     m = _TITLE_FIELD_RE.search(text)
@@ -336,8 +338,13 @@ def extract_title(text: str, filename: str) -> str:
         if stripped and not _GENERIC_HEADING_RE.match(stripped):
             return stripped
 
-    # 3. De-slugify filename as last resort (returns "" for slug-less filenames)
-    return _de_slugify(filename)
+    # 3. De-slugify filename as last resort; for slug-less bare-ID files
+    #    (e.g. BUG-001.md) fall back to the stem (e.g. "BUG-001") so no
+    #    INDEX Title cell is ever blank.
+    slug = _de_slugify(filename)
+    if slug.strip():
+        return slug
+    return Path(filename).stem
 
 
 # ---------------------------------------------------------------------------

--- a/_ai-memory/pov/skills/aim-tracking-freshness/tests/test_tracking_freshness_integration.py
+++ b/_ai-memory/pov/skills/aim-tracking-freshness/tests/test_tracking_freshness_integration.py
@@ -561,3 +561,68 @@ class TestWriteRegeneration:
         second_text = (bugs_dir / "INDEX.md").read_text(encoding="utf-8")
 
         assert first_text == second_text
+
+    def test_write_bare_id_records_produce_non_blank_title_cells(
+        self, tmp_path: Path
+    ) -> None:
+        """Bare-ID records (BUG-001.md, TECH-DEBT-042.md) render non-blank Title cells.
+
+        Regression test for the blank-title bug (BUG-B6): when extract_title()
+        previously returned "" for slug-less files the INDEX Title cell was empty.
+        After the fix the stem (e.g. 'BUG-001') is used as fallback.
+
+        Both records are OPEN so they appear in the Open section which uses a
+        5-column format:  | ID | Sev | Title | Status | Link |
+        Title is cells[3].  The Closed section uses 4 columns (Title = cells[2]);
+        this test deliberately uses only OPEN records to stay in the 5-column format.
+        """
+        oversight, bugs_dir, td_dir = _make_oversight(tmp_path)
+        # Bare-ID bug with a generic heading — no usable title in content
+        (bugs_dir / "BUG-001.md").write_text(
+            "# Bug Report\n\n**Status**: OPEN\n**Severity**: HIGH\n",
+            encoding="utf-8",
+        )
+        # Bare-ID TD with no heading at all
+        (td_dir / "TECH-DEBT-042.md").write_text(
+            "**Status**: OPEN\n",
+            encoding="utf-8",
+        )
+
+        result = _run(oversight, "--write")
+        assert result.returncode == 0, (
+            f"--write should succeed.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+        bugs_index = (bugs_dir / "INDEX.md").read_text(encoding="utf-8")
+        assert "| BUG-001 |" in bugs_index, "BUG-001 row must appear in bugs INDEX"
+        for line in bugs_index.splitlines():
+            if "| BUG-001 |" in line:
+                cells = [c.strip() for c in line.split("|")]
+                # Open section: | ID | Sev | Title | Status | Link |
+                # cells: ['', ID, Sev, Title, Status, Link, ''] → Title at index 3
+                assert len(cells) >= 6, (
+                    f"Expected 5-column Open-section row, got {len(cells)-2} cols. "
+                    f"Row: {line!r}"
+                )
+                title_cell = cells[3]
+                assert title_cell == "BUG-001", (
+                    f"BUG-001 Title cell must equal 'BUG-001'. Got: {title_cell!r}. "
+                    f"Row: {line!r}"
+                )
+
+        td_index = (td_dir / "INDEX.md").read_text(encoding="utf-8")
+        assert "| TECH-DEBT-042 |" in td_index, "TECH-DEBT-042 row must appear in TD INDEX"
+        for line in td_index.splitlines():
+            if "| TECH-DEBT-042 |" in line:
+                cells = [c.strip() for c in line.split("|")]
+                # Open section: | ID | Sev | Title | Status | Link |
+                # cells: ['', ID, Sev, Title, Status, Link, ''] → Title at index 3
+                assert len(cells) >= 6, (
+                    f"Expected 5-column Open-section row, got {len(cells)-2} cols. "
+                    f"Row: {line!r}"
+                )
+                title_cell = cells[3]
+                assert title_cell == "TECH-DEBT-042", (
+                    f"TECH-DEBT-042 Title cell must equal 'TECH-DEBT-042'. "
+                    f"Got: {title_cell!r}. Row: {line!r}"
+                )

--- a/_ai-memory/pov/skills/aim-tracking-freshness/tests/test_verify_code_state.py
+++ b/_ai-memory/pov/skills/aim-tracking-freshness/tests/test_verify_code_state.py
@@ -811,3 +811,120 @@ class TestExtractEvidenceTokensVersions:
         tokens = tf.extract_evidence_tokens(text, "001", "bug")
         assert "versions" in tokens
         assert tokens["versions"] == set()
+
+
+# ---------------------------------------------------------------------------
+# extract_title — blank-title fix (BUG-B6)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTitle:
+    """Unit tests for extract_title() — verifies the blank-title fix (BUG-B6)."""
+
+    # --- stem fallback: bare-ID files ---
+
+    def test_bare_id_bug_file_returns_stem_not_empty(self) -> None:
+        """BUG-001.md with no extractable title returns 'BUG-001', never ''."""
+        result = tf.extract_title("**Status**: OPEN\n", "BUG-001.md")
+        assert result != "", "extract_title must never return empty string"
+        assert result == "BUG-001"
+
+    def test_bare_id_td_file_returns_stem_not_empty(self) -> None:
+        """TECH-DEBT-042.md with no extractable title returns 'TECH-DEBT-042', never ''."""
+        result = tf.extract_title("**Status**: OPEN\n", "TECH-DEBT-042.md")
+        assert result != "", "extract_title must never return empty string"
+        assert result == "TECH-DEBT-042"
+
+    def test_generic_h1_bug_report_bare_id_falls_back_to_stem(self) -> None:
+        """Generic H1 'Bug Report' on a bare-ID file → stem fallback."""
+        text = "# Bug Report\n\n**Status**: OPEN\n"
+        result = tf.extract_title(text, "BUG-007.md")
+        assert result == "BUG-007"
+
+    def test_generic_h1_rca_bare_id_falls_back_to_stem(self) -> None:
+        """Generic H1 'Root Cause Analysis' on a bare-ID TD file → stem fallback.
+
+        Distinct from the Bug Report case: exercises a different _GENERIC_HEADING_RE
+        token and a TECH-DEBT stem, confirming generic-heading suppression across
+        record kinds.
+        """
+        text = "# Root Cause Analysis\n\n**Status**: OPEN\n"
+        result = tf.extract_title(text, "TECH-DEBT-042.md")
+        assert result == "TECH-DEBT-042"
+
+    def test_whitespace_only_slug_falls_back_to_stem(self) -> None:
+        """Degenerate slug (BUG-001--.md → ' ') must not produce a blank cell.
+
+        _de_slugify('BUG-001--.md') → ' ' (truthy).  Before the slug.strip()
+        fix, extract_title returned that space and rendered a blank Title cell.
+        After the fix it falls through to the stem fallback.
+        """
+        result = tf.extract_title("**Status**: OPEN\n", "BUG-001--.md")
+        assert result.strip() != "", "whitespace-only slug must not render a blank cell"
+        assert result == "BUG-001--"
+
+    # --- higher-priority paths: heading and explicit Title field ---
+
+    def test_slug_ful_file_returns_slug_not_stem(self) -> None:
+        """Slug-ful filename still returns de-slugified words, not the stem."""
+        result = tf.extract_title("**Status**: OPEN\n", "BUG-047-installer-fails.md")
+        assert result == "Installer Fails"
+
+    def test_explicit_title_field_wins_over_fallback(self) -> None:
+        """A non-empty **Title**: field always wins, regardless of filename."""
+        text = "**Title**: Memory Leak In Cache\n\n**Status**: OPEN\n"
+        result = tf.extract_title(text, "BUG-001.md")
+        assert result == "Memory Leak In Cache"
+
+    def test_h1_heading_wins_over_fallback(self) -> None:
+        """A non-generic H1 always wins over the filename fallback."""
+        text = "# BUG-002: Crash On Startup\n\n**Status**: OPEN\n"
+        result = tf.extract_title(text, "BUG-002.md")
+        assert result == "Crash On Startup"
+
+    def test_h2_heading_wins_over_fallback(self) -> None:
+        """H2 non-generic heading is extracted correctly (ID prefix stripped)."""
+        text = "## BUG-003: Real Title\n\n**Status**: OPEN\n"
+        result = tf.extract_title(text, "BUG-003.md")
+        assert result == "Real Title"
+
+    # --- _TITLE_FIELD_RE newline-span fix ---
+
+    def test_empty_title_field_before_heading_does_not_capture_heading(self) -> None:
+        """**Title**: on its own line must NOT capture the next heading line.
+
+        Before the [^\\S\\n]* fix, \\s* spanned the newline and (.+) captured
+        '# Some Heading'.  After the fix the field is empty → falls through to
+        step 2 which returns 'Some Heading' (H1 prefix stripped).
+        """
+        text = "**Title**:\n# Some Heading\n\n**Status**: OPEN\n"
+        result = tf.extract_title(text, "BUG-047-some-heading.md")
+        # Must NOT start with '#' (the pre-fix symptom) and must equal step-2 result
+        assert not result.startswith("#"), (
+            f"Title must not include Markdown heading marker. Got: {result!r}"
+        )
+        assert result == "Some Heading"
+
+    def test_empty_title_field_before_status_does_not_capture_status(self) -> None:
+        """**Title**: on its own line must NOT capture the following **Status**: line.
+
+        Falls through to step 3 (slug/stem fallback).
+        """
+        text = "**Title**:\n**Status**: OPEN\n"
+        result = tf.extract_title(text, "BUG-001.md")
+        assert result != "**Status**: OPEN", (
+            "Empty **Title**: must not capture the following **Status** line"
+        )
+        assert result == "BUG-001"
+
+    def test_empty_title_field_at_eof_falls_through(self) -> None:
+        """**Title**: with nothing after it (EOF) falls through to stem fallback."""
+        text = "**Title**:\n"
+        result = tf.extract_title(text, "BUG-001.md")
+        assert result == "BUG-001"
+
+    def test_title_field_same_line_value_still_extracted(self) -> None:
+        """Regression guard: **Title**: Real Title (same line) still returns 'Real Title'."""
+        text = "**Title**: Real Title\n\n**Status**: OPEN\n"
+        result = tf.extract_title(text, "BUG-001.md")
+        assert result == "Real Title"

--- a/tests/unit/test_tracking_freshness_skill.py
+++ b/tests/unit/test_tracking_freshness_skill.py
@@ -626,15 +626,17 @@ class TestTitleExtraction:
         )
         assert result == "Architecture Doc Keyword Trigger Mismatch"
 
-    def test_slug_less_bug_file_desluggifies_to_empty(self) -> None:
-        """BUG-001.md with a generic heading and no **Title** field returns empty title.
+    def test_slug_less_bug_file_falls_back_to_stem(self) -> None:
+        """BUG-001.md with a generic heading and no **Title** field falls back to the stem.
 
-        A slug-less file has nothing to de-slugify; extract_title must return "" rather
-        than echoing "BUG-001" as a title.
+        A slug-less file has nothing to de-slugify; extract_title must return the bare
+        stem ("BUG-001") so the INDEX never renders a blank Title cell.
         """
         text = "# Bug Report\n\n**Status**: OPEN\n"
         result = extract_title(text, "BUG-001.md")
-        assert result == "", f"Expected empty title for slug-less file, got {result!r}"
+        assert (
+            result == "BUG-001"
+        ), f"Expected stem fallback for slug-less file, got {result!r}"
 
     def test_slug_less_bug_file_with_good_heading(self) -> None:
         """BUG-001.md with a descriptive heading extracts from the heading normally."""
@@ -642,11 +644,15 @@ class TestTitleExtraction:
         result = extract_title(text, "BUG-001.md")
         assert result == "Some Useful Title"
 
-    def test_slug_less_td_file_desluggifies_to_empty(self) -> None:
-        """TECH-DEBT-010.md with a generic heading returns empty title."""
+    def test_slug_less_td_file_falls_back_to_stem(self) -> None:
+        """TECH-DEBT-010.md with a generic heading falls back to the stem.
+
+        A slug-less file has nothing to de-slugify; extract_title must return the bare
+        stem ("TECH-DEBT-010") so the INDEX never renders a blank Title cell.
+        """
         text = "# Technical Debt Item\n\n**Status**: RESOLVED\n"
         result = extract_title(text, "TECH-DEBT-010.md")
-        assert result == ""
+        assert result == "TECH-DEBT-010"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The generated bug/TD INDEX tables could render **blank Title cells**. `extract_title()` returned an empty string for bare-ID record files (e.g. `BUG-001.md`) — `_de_slugify()` strips the ID prefix and leaves nothing to de-slugify — and the five INDEX render sites passed that empty string straight into the table cell.

## Fix

- **`extract_title()` fallback (single extraction contract).** When de-slugification yields nothing, fall back to the file stem (e.g. `BUG-001`) so a Title cell is never blank. The fix lives in `extract_title()` itself, so all five render sites — and any future one — are covered. Guarded with `slug.strip()` so a whitespace-only de-slug result (e.g. `BUG-001--.md`) also falls through to the stem rather than rendering a visually blank cell.
- **`_TITLE_FIELD_RE` hardening.** The previous `\s*` could span newlines, so an *empty* `**Title**:` field captured the following line (a heading, a `**Status**:` line, or a lone `:`). The pattern is now anchored to horizontal whitespace with a non-trivial capture, so an empty field correctly falls through to heading/stem extraction.

## Behavior preserved

Explicit `**Title**:` fields, H1/H2 headings, and slug-ful filenames all extract exactly as before — only the empty-extraction path changed. Mid-value colons, colon-inside-bold (`**Title:**`), no-colon, and no-space forms all continue to extract correctly.

## Tests

Added unit coverage (every empty-extraction path + the precedence/non-empty paths, including H1 and H2) and an end-to-end integration test asserting the rendered INDEX Title cell is non-blank with an exact value. Full suite green.
