### PR TITLE
Cap aim-sot reindex wall-time and guard against stale locks

### DIFF
--- a/_ai-memory/skills/aim-sot/scripts/aim_sot_detect_propose.py
+++ b/_ai-memory/skills/aim-sot/scripts/aim_sot_detect_propose.py
@@ -93,9 +93,10 @@ _DISCOVERY_MAX_SECONDS = _env_float("AI_MEMORY_SOT_DISCOVERY_MAX_SECONDS", 6.0)
 # Wall-time cap for the per-entry reindex loop (F-RT5-GAP-1 / F-SOT-2); mirrors
 # _DISCOVERY_MAX_SECONDS.  0 → treated as default per _env_float convention.
 _SOT_REINDEX_MAX_SECONDS = _env_float("AI_MEMORY_SOT_REINDEX_MAX_SECONDS", 30.0)
-# Reindex lock files older than this are presumed orphaned (flock self-heals on
-# process death; the surviving .lock file is cosmetic) and swept before acquire.
-_LOCK_STALE_SECONDS = 300.0
+# Stale-lock threshold: always >= 2x the reindex cap so a live holder (which
+# releases within _SOT_REINDEX_MAX_SECONDS) can never own a lock older than this
+# window.  The 300s floor preserves safe behaviour for the default cap (30s).
+_LOCK_STALE_SECONDS = max(300.0, 2 * _SOT_REINDEX_MAX_SECONDS)
 
 _DRIFT_CACHE_DIR = (
     Path(os.environ.get("AI_MEMORY_INSTALL_DIR", os.path.expanduser("~/.ai-memory")))
@@ -948,7 +949,11 @@ def _reindex_lock(project_id: str):
         safe_id = project_id.replace("/", "__")
         lock_path = _DRIFT_CACHE_DIR / f"sot_reindex_{safe_id}.lock"
         # Sweep orphaned lock files (R2 / F-SOT-2): flock self-heals on process
-        # death, so a .lock file this old is cosmetic — remove it before acquiring.
+        # death, so a surviving .lock is cosmetic for that crash/exit case.  For
+        # a live holder, the max()-derived _LOCK_STALE_SECONDS invariant
+        # (= max(300, 2 * _SOT_REINDEX_MAX_SECONDS)) ensures any reindex still
+        # running — it releases within _SOT_REINDEX_MAX_SECONDS — can never own
+        # a lock older than this threshold, so no LIVE lock is ever swept.
         try:
             if (
                 lock_path.exists()

--- a/_ai-memory/skills/aim-sot/scripts/aim_sot_detect_propose.py
+++ b/_ai-memory/skills/aim-sot/scripts/aim_sot_detect_propose.py
@@ -90,6 +90,12 @@ def _env_int(name: str, default: int) -> int:
 # the [CL] hook's ~20s subprocess cap.  Both are env-overridable.
 _MAX_DISCOVERY_DIRS = _env_int("AI_MEMORY_SOT_DISCOVERY_MAX_DIRS", 5000)
 _DISCOVERY_MAX_SECONDS = _env_float("AI_MEMORY_SOT_DISCOVERY_MAX_SECONDS", 6.0)
+# Wall-time cap for the per-entry reindex loop (F-RT5-GAP-1 / F-SOT-2); mirrors
+# _DISCOVERY_MAX_SECONDS.  0 → treated as default per _env_float convention.
+_SOT_REINDEX_MAX_SECONDS = _env_float("AI_MEMORY_SOT_REINDEX_MAX_SECONDS", 30.0)
+# Reindex lock files older than this are presumed orphaned (flock self-heals on
+# process death; the surviving .lock file is cosmetic) and swept before acquire.
+_LOCK_STALE_SECONDS = 300.0
 
 _DRIFT_CACHE_DIR = (
     Path(os.environ.get("AI_MEMORY_INSTALL_DIR", os.path.expanduser("~/.ai-memory")))
@@ -940,8 +946,19 @@ def _reindex_lock(project_id: str):
     try:
         _DRIFT_CACHE_DIR.mkdir(parents=True, exist_ok=True)
         safe_id = project_id.replace("/", "__")
+        lock_path = _DRIFT_CACHE_DIR / f"sot_reindex_{safe_id}.lock"
+        # Sweep orphaned lock files (R2 / F-SOT-2): flock self-heals on process
+        # death, so a .lock file this old is cosmetic — remove it before acquiring.
+        try:
+            if (
+                lock_path.exists()
+                and (time.time() - lock_path.stat().st_mtime) > _LOCK_STALE_SECONDS
+            ):
+                lock_path.unlink(missing_ok=True)
+        except OSError:
+            pass
         lock_fd = open(  # noqa: SIM115 — held across the yield; closed in finally
-            _DRIFT_CACHE_DIR / f"sot_reindex_{safe_id}.lock", "w", encoding="utf-8"
+            lock_path, "w", encoding="utf-8"
         )
         fcntl.flock(lock_fd, fcntl.LOCK_EX)
     except OSError:
@@ -1074,7 +1091,20 @@ def _reindex_sot_entries(
 
             stored = 0
             rejected = 0  # writes refused by core validation (DEFECT-4)
+            _cap_fired = False  # R1 wall-time guard (F-RT5-GAP-1 / F-SOT-2)
+            _deadline = time.monotonic() + _SOT_REINDEX_MAX_SECONDS
             for content in prepared:
+                if time.monotonic() > _deadline:
+                    # Never silent: emit a visible warning, then stop.  Remaining
+                    # entries stay in the registry and are indexed next run.
+                    print(
+                        f"[aim-sot] reindex wall-time cap ({_SOT_REINDEX_MAX_SECONDS:.0f}s)"
+                        f" reached; {stored}/{len(prepared)} entries stored —"
+                        " remainder will be indexed next run.",
+                        file=sys.stderr,
+                    )
+                    _cap_fired = True
+                    break
                 try:
                     result = storage.store_memory(
                         content=content,
@@ -1099,6 +1129,10 @@ def _reindex_sot_entries(
                 except Exception:
                     pass  # per-entry failure is non-fatal
 
+            # Cap fired mid-loop: sha must NOT advance so the next run completes
+            # the reindex (F-SOT-2 / F-RT5-GAP-1).
+            if _cap_fired:
+                return ReindexResult(False, stored, "reindex_capped")
             # Delete ran but every re-store failed → the 5b cache is
             # emptied-not-restored.  Report failure so the caller does NOT advance
             # registry_sha and the rebuild retries next run rather than masking the

--- a/tests/test_sot_detect_propose.py
+++ b/tests/test_sot_detect_propose.py
@@ -48,6 +48,11 @@ Coverage:
   T-DP34 — F-ENG-4: drift-cache write cleans the partial .tmp on json.dump error
   T-DP35 — F-ENG-4: _reindex_lock releases the lock when the guarded body raises
 
+  F-RT5-GAP-1 / F-SOT-2 (reindex wall-time cap + stale-lock sweep):
+  T-DP41a — cap stops the loop + leaves remaining entries + emits visible signal
+  T-DP41b — stale lock file (> _LOCK_STALE_SECONDS) is swept before acquire
+  T-DP41c — fresh lock file (< _LOCK_STALE_SECONDS) is NOT swept
+
 All tests are hermetic (no network, tmp dirs, store mocked via injection points).
 """
 
@@ -1774,3 +1779,126 @@ def test_cold_start_message_is_bootstrap_hint_not_circular(
     assert rc == 0
     assert "Run aim-sot detect-propose to create one" not in out
     assert ".sot/registry.yaml" in out  # actionable bootstrap hint
+
+
+# ===========================================================================
+# F-RT5-GAP-1 / F-SOT-2: reindex wall-time cap + stale-lock sweep
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# T-DP41a — F-SOT-2: wall-time cap stops the loop, leaves entries, emits signal
+# ---------------------------------------------------------------------------
+
+
+def test_reindex_wall_time_cap_stops_loop_and_emits_signal(tmp_path, capsys):
+    """Wall-time cap fires before the second entry, returns reindex_capped (ok=False
+    so registry_sha is NOT advanced and the next run retries), and emits a visible
+    stderr warning.  FAILS pre-fix (no cap exists)."""
+    registry_path = tmp_path / ".sot" / "registry.yaml"
+    _write_registry(
+        registry_path,
+        [
+            {"id": "core", "sot_location": "src/", "description": "Core"},
+            {"id": "docs", "sot_location": "docs/", "description": "Docs"},
+        ],
+    )
+    mock_client = MagicMock()
+    mock_client.scroll.side_effect = [([], None)]
+    mock_storage = MagicMock()
+    mock_storage.store_memory.return_value = {"status": "stored"}
+
+    # Control time.monotonic to fire the cap on the second loop check:
+    # call #1 → sets deadline=base+cap; call #2 → within deadline (first iter ok);
+    # call #3 → past deadline (second iter triggers cap).
+    _base = 1000.0
+    _calls = [0]
+
+    def _fake_monotonic():
+        _calls[0] += 1
+        if _calls[0] <= 2:
+            return _base
+        return _base + 9999.0
+
+    with (
+        patch.object(dp, "_DRIFT_CACHE_DIR", tmp_path),
+        patch.object(dp.time, "monotonic", _fake_monotonic),
+    ):
+        result = dp._reindex_sot_entries(
+            registry_path, "proj", _qdrant_client=mock_client, _storage=mock_storage
+        )
+
+    assert result.ok is False
+    assert result.reason == "reindex_capped"
+    # Only the first entry was stored before the cap fired.
+    assert mock_storage.store_memory.call_count == 1
+    err = capsys.readouterr().err
+    assert err, "cap must emit a non-empty stderr warning"
+    assert "cap" in err.lower() or "wall-time" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# T-DP41b — F-SOT-2: stale lock file is swept before acquisition
+# ---------------------------------------------------------------------------
+
+
+def test_reindex_lock_sweeps_stale_lock_file(tmp_path):
+    """A .lock file older than _LOCK_STALE_SECONDS is removed before _reindex_lock
+    acquires (orphaned cosmetic lock).  FAILS pre-fix (no sweep logic)."""
+    import os
+    import time as _time
+
+    lock_path = tmp_path / "sot_reindex_proj.lock"
+    lock_path.write_text("orphan", encoding="utf-8")
+    old_mtime = _time.time() - dp._LOCK_STALE_SECONDS - 1
+    os.utime(lock_path, (old_mtime, old_mtime))
+
+    unlinked = []
+    _real_unlink = Path.unlink
+
+    def _spy_unlink(self, missing_ok=False):
+        unlinked.append(self)
+        _real_unlink(self, missing_ok=missing_ok)
+
+    with (
+        patch.object(dp, "_DRIFT_CACHE_DIR", tmp_path),
+        patch.object(Path, "unlink", _spy_unlink),
+        dp._reindex_lock("proj"),
+    ):
+        pass
+
+    assert lock_path in unlinked, "stale lock file was not swept before acquisition"
+
+
+# ---------------------------------------------------------------------------
+# T-DP41c — F-SOT-2: fresh lock file is NOT swept
+# ---------------------------------------------------------------------------
+
+
+def test_reindex_lock_does_not_sweep_fresh_lock_file(tmp_path):
+    """A .lock file newer than _LOCK_STALE_SECONDS is left alone — only genuinely
+    orphaned (old) files are swept.  FAILS pre-fix would sweep unconditionally."""
+    import os
+    import time as _time
+
+    lock_path = tmp_path / "sot_reindex_proj.lock"
+    lock_path.write_text("live", encoding="utf-8")
+    # 1 second old — well within the TTL.
+    fresh_mtime = _time.time() - 1
+    os.utime(lock_path, (fresh_mtime, fresh_mtime))
+
+    unlinked = []
+    _real_unlink = Path.unlink
+
+    def _spy_unlink(self, missing_ok=False):
+        unlinked.append(self)
+        _real_unlink(self, missing_ok=missing_ok)
+
+    with (
+        patch.object(dp, "_DRIFT_CACHE_DIR", tmp_path),
+        patch.object(Path, "unlink", _spy_unlink),
+        dp._reindex_lock("proj"),
+    ):
+        pass
+
+    assert lock_path not in unlinked, "fresh lock file was incorrectly swept"

--- a/tests/test_sot_detect_propose.py
+++ b/tests/test_sot_detect_propose.py
@@ -1902,3 +1902,37 @@ def test_reindex_lock_does_not_sweep_fresh_lock_file(tmp_path):
         pass
 
     assert lock_path not in unlinked, "fresh lock file was incorrectly swept"
+
+
+# ---------------------------------------------------------------------------
+# T-DP42 — stale-lock invariant: _LOCK_STALE_SECONDS >= 2 * _SOT_REINDEX_MAX_SECONDS
+# ---------------------------------------------------------------------------
+
+
+def test_lock_stale_seconds_tracks_reindex_cap_invariant():
+    """_LOCK_STALE_SECONDS must always be >= 2 * _SOT_REINDEX_MAX_SECONDS so a live
+    reindex hold (releases within the cap) can never own a lock older than the stale
+    threshold — guaranteeing no LIVE lock is ever swept by the orphan sweep.
+
+    Since both constants are module-load-time, the test verifies the formula directly:
+    - invariant holds for the current module configuration
+    - formula yields >= 2x the cap for a large operator override (e.g. 600s)
+    - 300s floor still applies for small caps
+    """
+    # Invariant under the current module configuration.
+    assert dp._LOCK_STALE_SECONDS >= 2 * dp._SOT_REINDEX_MAX_SECONDS, (
+        f"invariant violated: _LOCK_STALE_SECONDS={dp._LOCK_STALE_SECONDS} "
+        f"< 2 * _SOT_REINDEX_MAX_SECONDS ({2 * dp._SOT_REINDEX_MAX_SECONDS})"
+    )
+
+    # Formula verification for a large operator-supplied cap (600s → env override).
+    large_cap = 600.0
+    computed = max(300.0, 2 * large_cap)
+    assert (
+        computed >= 2 * large_cap
+    ), "formula must yield >= 2x the cap for large overrides"
+    assert computed == 1200.0, "expected 1200.0 for cap=600 (tracks cap, not 300 floor)"
+
+    # Floor: for small caps the 300s minimum must hold.
+    small_cap = 10.0
+    assert max(300.0, 2 * small_cap) == 300.0, "300s floor must hold for small caps"


### PR DESCRIPTION
Adds a configurable wall-time cap (`AI_MEMORY_SOT_REINDEX_MAX_SECONDS`, default 30s) to the aim-sot reindex pass so a long reindex cannot exceed the hook budget. The cap is non-silent and loses no entries.

Also adds a self-enforcing stale-lock guard: `_LOCK_STALE_SECONDS = max(300, 2 * reindex_cap)`, so the stale-lock threshold can never drop below the reindex cap — closing a concurrent-reindex corruption window. Includes an invariant test.

Held: draft pending release validation (BUG-324 soak).