### PR TITLE
Bake en_core_web_sm into Dockerfile.worker

### DIFF
--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -11,6 +11,10 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# SPEC-009: Download SpaCy NER model for security scanning Layer 3
+# en_core_web_sm: Small English model (~12MB) optimized for NER
+RUN python3 -m spacy download en_core_web_sm
+
 # Copy application code
 COPY src/ /app/src/
 COPY scripts/ /app/scripts/


### PR DESCRIPTION
Bakes the spaCy `en_core_web_sm` model into `docker/Dockerfile.worker` (mirroring the github-sync image) so the classifier worker's in-container scanner loads the model instead of running degraded.

Held: draft pending release validation (BUG-324 soak).