### PR TITLE
Fix POV dispatch skill drift and add dispatch spawn gate

### DIFF
--- a/_ai-memory/pov/skills/aim-agent-dispatch/SKILL.md
+++ b/_ai-memory/pov/skills/aim-agent-dispatch/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Read
 
 # Agent Dispatch -- Generic and BMAD Agent Activation
 
-**Purpose**: Prepare instructions for all agents (generic and BMAD). Determines if BMAD persona is needed and routes accordingly. BMAD routing is handled within this skill -- aim-bmad-dispatch no longer exists as a separate skill.
+**Purpose**: Prepare instructions for all agents (generic and BMAD). Determines if BMAD persona is needed and routes accordingly. BMAD routing is handled within this skill.
 
 ---
 
@@ -20,11 +20,22 @@ allowed-tools: Read
 
 ---
 
+## Step 0: Pre-Spawn Sentinel Gate (MANDATORY -- re-run before EVERY spawn)
+
+Before routing any dispatch, assert the current directory is the workspace root by confirming co-presence of `_ai-memory/`, `_bmad/`, and `oversight/` (CLAUDE.md workspace-root sentinel). Concretely: `test -d _ai-memory && test -d _bmad && test -d oversight`.
+
+- PASS -> proceed to Step 1.
+- FAIL -> **ABORT the spawn.** Report: "CWD drift -- not at workspace root; return to root before spawning." Do NOT route to /aim-model-dispatch or /aim-agent-lifecycle.
+
+CWD drifts across Bash calls, so re-run this gate immediately before EACH spawn -- not once per session.
+
+---
+
 ## Step 1: Determine Dispatch Type
 
 **BMAD dispatch** (use the [BMAD Agent Dispatch](#bmad-agent-dispatch) section below) when:
 - The task requires ANY BMAD agent role (Analyst, PM, Architect, DEV, SM, UX Designer, etc.)
-- The agent requires persona activation via `/bmad-agent-*` commands
+- The agent requires persona activation via `/bmad-agent-<module>-<name>` commands
 
 **Generic dispatch** (use the [Generic Agent Dispatch](#generic-agent-dispatch) section below) when:
 - The agent does NOT need a BMAD persona
@@ -158,18 +169,18 @@ MUST spawn fresh agent for every task -- never reuse across roles or stories.
 
 | Agent | Activation Command | Description |
 |-------|-------------------|-------------|
-| Analyst | `/bmad-agent-analyst` | Research, codebase analysis, domain investigation |
-| PM (Product Manager) | `/bmad-agent-pm` | PRD creation/validation, epics and stories |
-| Architect | `/bmad-agent-architect` | System architecture design, readiness checks |
-| Developer (DEV) | `/bmad-agent-dev` | Code implementation ONLY |
-| Developer (review) | `/bmad-code-review` | Code review ONLY -- MUST use this for ALL review agents, never /bmad-agent-dev |
-| Scrum Master (SM) | `/bmad-agent-sm` (NOT INSTALLED -- 2026-04-11) | Sprint planning, story creation, retrospectives |
-| QA Engineer | `/bmad-agent-qa` (NOT INSTALLED -- 2026-04-11) | Test planning, test execution, quality validation |
-| UX Designer | `/bmad-agent-ux-designer` | User flows, screen design, UX research |
-| Tech Writer | `/bmad-agent-tech-writer` | Documentation writing and validation |
-| Quick Flow Solo Dev | `/bmad-agent-quick-flow-solo-dev` (NOT INSTALLED -- 2026-04-11) | Lightweight single-dev flow (analysis through implementation) |
+| Analyst | `/bmad-agent-bmm-analyst` | Research, codebase analysis, domain investigation |
+| PM (Product Manager) | `/bmad-agent-bmm-pm` | PRD creation/validation, epics and stories |
+| Architect | `/bmad-agent-bmm-architect` | System architecture design, readiness checks |
+| Developer (DEV) | `/bmad-agent-bmm-dev` | Code implementation ONLY |
+| Developer (review) | `/bmad-bmm-code-review` | Code review ONLY -- MUST use this for ALL review agents, never /bmad-agent-bmm-dev |
+| Scrum Master (SM) | `/bmad-agent-bmm-sm` | Sprint planning, story creation, retrospectives |
+| QA Engineer | `/bmad-agent-bmm-qa` | Test planning, test execution, quality validation |
+| UX Designer | `/bmad-agent-bmm-ux-designer` | User flows, screen design, UX research |
+| Tech Writer | `/bmad-agent-bmm-tech-writer` | Documentation writing and validation |
+| Quick Flow Solo Dev | `/bmad-agent-bmm-quick-flow-solo-dev` | Lightweight single-dev flow (analysis through implementation) |
 
-MUST use `/bmad-agent-tech-writer` for ALL documentation tasks (writing, updating, reviewing docs). MUST use `/bmad-code-review` for ALL review agents (never `/bmad-agent-dev`). MUST use `/bmad-help` whenever unsure which agent or workflow to use -- the tables above are NOT exhaustive.
+MUST use `/bmad-agent-bmm-tech-writer` for ALL documentation tasks (writing, updating, reviewing docs). MUST use `/bmad-bmm-code-review` for ALL review agents (never `/bmad-agent-bmm-dev`). MUST use `/bmad-help` whenever unsure which agent or workflow to use -- the tables above are NOT exhaustive.
 
 #### BMAD Framework Agents
 
@@ -181,56 +192,51 @@ MUST use `/bmad-agent-tech-writer` for ALL documentation tasks (writing, updatin
 
 | Agent | Activation Command | Description |
 |-------|-------------------|-------------|
-| Agent Builder | `/bmad-agent-builder` | Build new BMAD agent definitions |
-| Module Builder | `/bmad-module-builder` | Build new BMAD modules |
-| Workflow Builder | `/bmad-workflow-builder` | Build new BMAD workflows |
+| Agent Builder | `/bmad-agent-bmb-agent-builder` | Build new BMAD agent definitions |
+| Module Builder | `/bmad-agent-bmb-module-builder` | Build new BMAD modules |
+| Workflow Builder | `/bmad-agent-bmb-workflow-builder` | Build new BMAD workflows |
 
 #### CIS Coaches (cis-)
 
 | Agent | Activation Command | Description |
 |-------|-------------------|-------------|
-| Brainstorming Coach | `/bmad-cis-agent-brainstorming-coach` | Facilitated brainstorming sessions |
-| Creative Problem Solver | `/bmad-cis-agent-creative-problem-solver` | Creative approaches to complex problems |
-| Design Thinking Coach | `/bmad-cis-agent-design-thinking-coach` | Design thinking methodology facilitation |
-| Innovation Strategist | `/bmad-cis-agent-innovation-strategist` | Innovation strategy and ideation |
-| Presentation Master | `/bmad-cis-agent-presentation-master` | Presentation creation and coaching |
-| Storyteller | `/bmad-cis-agent-storyteller` | Narrative crafting and storytelling |
+| Brainstorming Coach | `/bmad-agent-cis-brainstorming-coach` | Facilitated brainstorming sessions |
+| Creative Problem Solver | `/bmad-agent-cis-creative-problem-solver` | Creative approaches to complex problems |
+| Design Thinking Coach | `/bmad-agent-cis-design-thinking-coach` | Design thinking methodology facilitation |
+| Innovation Strategist | `/bmad-agent-cis-innovation-strategist` | Innovation strategy and ideation |
+| Presentation Master | `/bmad-agent-cis-presentation-master` | Presentation creation and coaching |
+| Storyteller | `/bmad-agent-cis-storyteller` | Narrative crafting and storytelling |
 
 #### Test Agents (tea-)
 
 | Agent | Activation Command | Description |
 |-------|-------------------|-------------|
-| Test Architect (TEA) | `/bmad-tea` | Test architecture and strategy design |
+| Test Architect (TEA) | `/bmad-agent-tea-tea` | Test architecture and strategy design |
 
 **Workflow commands by phase** (sent AFTER activation, when in planning mode):
 
 | Phase | Agent | Workflow Command |
 |-------|-------|-----------------|
-| Research | Analyst | `/bmad-market-research`, `/bmad-domain-research`, `/bmad-technical-research` |
-| Discovery | Analyst | `/bmad-product-brief` |
-| Discovery (or any phase) | PM | `/bmad-create-prd`, `/bmad-validate-prd`, `/bmad-edit-prd` |
-| Architecture | Architect | `/bmad-create-architecture` |
-| Architecture | PM | `/bmad-create-epics-and-stories` |
-| Architecture | Architect | `/bmad-check-implementation-readiness` |
-| Architecture | UX Designer | `/bmad-create-ux-design` |
-| Planning | SM | `/bmad-sprint-planning`, `/bmad-create-story` |
-| Execution | DEV | `/bmad-dev-story` |
-| Execution | DEV | `/bmad-code-review` |
-| Release | SM | `/bmad-retrospective` |
+| Research | Analyst | `/bmad-bmm-market-research`, `/bmad-bmm-domain-research`, `/bmad-bmm-technical-research` |
+| Discovery | Analyst | `/bmad-bmm-create-product-brief` |
+| Discovery (or any phase) | PM | `/bmad-bmm-create-prd`, `/bmad-bmm-validate-prd`, `/bmad-bmm-edit-prd` |
+| Architecture | Architect | `/bmad-bmm-create-architecture` |
+| Architecture | PM | `/bmad-bmm-create-epics-and-stories` |
+| Architecture | Architect | `/bmad-bmm-check-implementation-readiness` |
+| Architecture | UX Designer | `/bmad-bmm-create-ux-design` |
+| Planning | SM | `/bmad-bmm-sprint-planning`, `/bmad-bmm-create-story` |
+| Execution | DEV | `/bmad-bmm-dev-story` |
+| Execution | DEV | `/bmad-bmm-code-review` |
+| Release | SM | `/bmad-bmm-retrospective` |
 
 Set `AI_MEMORY_AGENT_ID` environment variable when spawning.
 
-#### B4. Verify Activation
+#### B4. Verify Activation (MANDATORY gate before first instruction)
 
-Confirm the agent is active and ready:
-- Agent responds with its identity/role confirmation
-- Agent is in a clean state (no prior task context)
-- Agent is ready to receive instruction
+Do NOT send any task instruction until the teammate has emitted its activation output -- the BMAD persona greeting plus its numbered menu, or an explicit "ready" ack -- not idle, not mid-load. Verify by reading the spawn's first response (Claude-native) or `tmux capture-pane` (tmux).
 
-If activation fails:
-- Retry the activation command
-- If repeated failure, check configuration
-- Do not send instruction to an unverified agent
+- Activated (greeting + menu, clean state, no prior task context) -> send the task as a SEPARATE message (one task per instruction), and include an explicit "do not idle until X" plus a concrete numbered step list. BMAD `bmm-dev`/reviewers early-idle otherwise.
+- Not activated after one retry of the activation command -> spawn a FRESH agent. Never send an instruction to an unverified agent; check configuration if it repeats.
 
 #### B5. Dispatch Complete
 

--- a/_ai-memory/pov/skills/aim-agent-lifecycle/SKILL.md
+++ b/_ai-memory/pov/skills/aim-agent-lifecycle/SKILL.md
@@ -31,11 +31,15 @@ Max 3 correction loops -- escalate to user if unresolved.
 
 ## Step 1: Spawn Agent
 
+**Pre-spawn sentinel gate (MANDATORY -- re-run before EVERY spawn):** assert the current directory is the workspace root by confirming co-presence of `_ai-memory/`, `_bmad/`, and `oversight/` (CLAUDE.md workspace-root sentinel) -- `test -d _ai-memory && test -d _bmad && test -d oversight`. On FAIL, **ABORT the spawn** ("CWD drift -- not at workspace root; return to root before spawning") and do NOT invoke /aim-model-dispatch. CWD drifts across Bash calls, so re-run before each spawn, not once per session.
+
 Invoke /aim-model-dispatch with the dispatch plan. Model-dispatch routes to the correct tmux workflow for the provider and spawns the agent.
 
 For BMAD agents, the tmux bmad-dispatch workflow handles two-phase activation (persona command → menu detection → task instruction).
 
 For generic agents, the tmux-dispatch workflow sends the instruction directly.
+
+**Activation gate (MANDATORY before first instruction):** do NOT send the task instruction until `tmux capture-pane` shows the teammate's activation output -- BMAD persona greeting plus numbered menu, or an explicit "ready" ack -- not idle, not mid-load. Then send the task as a SEPARATE message (one task per instruction) including an explicit "do not idle until X" plus a concrete numbered step list. If still idle after one retry of the activation command, shut down (Step 4) and spawn FRESH. Never instruct an unverified agent.
 
 **Handle clarification requests:**
 - Agent asks BEFORE starting: provide clarification with citation. Never guess.

--- a/_ai-memory/pov/skills/aim-parzival-loader/loader_common.py
+++ b/_ai-memory/pov/skills/aim-parzival-loader/loader_common.py
@@ -260,22 +260,45 @@ def _tail_entries(section_text: str, budget_bytes: int) -> tuple[str, int]:
     return body, dropped
 
 
+def _owner_needs_first_breath(owner_block: str) -> bool:
+    """True when BOND's ``## Owner`` Name field still needs First Breath.
+
+    Combined rule (TD-737): the Owner needs First Breath iff the
+    ``**Name:** {user_name}`` placeholder token is still present, OR no real
+    Name value has been filled in *and* the ``_Filled during First Breath`` seed
+    line survives. A real Name alongside a surviving seed line must NOT
+    re-trigger -- gating on the seed string alone false-positives in that case.
+    """
+    if "**Name:** {user_name}" in owner_block:
+        return True
+    has_real_name = False
+    for line in owner_block.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("**Name:**"):
+            value = stripped[len("**Name:**") :].strip()
+            if value and value != "{user_name}":
+                has_real_name = True
+                break
+    return not has_real_name and "_Filled during First Breath" in owner_block
+
+
 def first_breath_marker(bond_text: str) -> bool:
-    """True when BOND.md's ``## Owner`` section still carries the scaffold marker.
+    """True when BOND.md's ``## Owner`` section still needs First Breath.
 
     A cheap marker-scan (NOT a full Tier-B load): activation reads only this
-    signal from BOND.md. The marker ``_Filled during First Breath`` seeds both
-    ``## Owner`` and ``## Working Style`` while BOND is unfilled, so a full-document
-    substring match would fire on scaffold prose surviving in *any* section (e.g.
-    an unfilled Working Style) even after the owner is known -- a destructive
-    re-First-Breath false positive. The scan is scoped to the ``## Owner`` block,
-    since establishing the owner is exactly what First Breath does; a BOND with no
-    ``## Owner`` section returns False (fail-safe: never re-trigger First Breath).
+    signal from BOND.md. The scan is scoped to the ``## Owner`` block, since
+    establishing the owner is exactly what First Breath does. The check gates on
+    the Owner *Name* field (placeholder vs real value) via the combined rule in
+    ``_owner_needs_first_breath``, NOT on bare presence of the
+    ``_Filled during First Breath`` seed string -- a surviving seed line
+    alongside real Name content must NOT re-trigger a destructive
+    re-First-Breath (TD-737). A BOND with no ``## Owner`` section returns False
+    (fail-safe: never re-trigger First Breath).
     """
     _, sections = split_h2(bond_text)
     for title, block in sections:
         if title == "Owner":
-            return "_Filled during First Breath" in block
+            return _owner_needs_first_breath(block)
     return False
 
 

--- a/_ai-memory/pov/skills/aim-parzival-loader/loader_common.py
+++ b/_ai-memory/pov/skills/aim-parzival-loader/loader_common.py
@@ -261,13 +261,22 @@ def _tail_entries(section_text: str, budget_bytes: int) -> tuple[str, int]:
 
 
 def first_breath_marker(bond_text: str) -> bool:
-    """True when BOND.md still carries the First-Breath scaffold marker.
+    """True when BOND.md's ``## Owner`` section still carries the scaffold marker.
 
     A cheap marker-scan (NOT a full Tier-B load): activation reads only this
-    signal from BOND.md. The marker ``_Filled during First Breath`` is present
-    under ``## Owner`` / ``## Working Style`` while BOND is unfilled.
+    signal from BOND.md. The marker ``_Filled during First Breath`` seeds both
+    ``## Owner`` and ``## Working Style`` while BOND is unfilled, so a full-document
+    substring match would fire on scaffold prose surviving in *any* section (e.g.
+    an unfilled Working Style) even after the owner is known -- a destructive
+    re-First-Breath false positive. The scan is scoped to the ``## Owner`` block,
+    since establishing the owner is exactly what First Breath does; a BOND with no
+    ``## Owner`` section returns False (fail-safe: never re-trigger First Breath).
     """
-    return "_Filled during First Breath" in bond_text
+    _, sections = split_h2(bond_text)
+    for title, block in sections:
+        if title == "Owner":
+            return "_Filled during First Breath" in block
+    return False
 
 
 def resolve_paths(project_root: Path) -> dict[str, Path]:

--- a/tests/unit/test_parzival_loaders.py
+++ b/tests/unit/test_parzival_loaders.py
@@ -294,6 +294,17 @@ def test_first_breath_marker_real_name_with_surviving_seed():
     assert not lc.first_breath_marker(bond)
 
 
+def test_first_breath_marker_blank_name_with_surviving_seed():
+    # ## Owner with a blank/whitespace-only Name value (no real name, no
+    # {user_name} placeholder token) alongside a surviving seed line -> the
+    # owner has not been established, so First Breath IS still needed (TD-737).
+    bond = (
+        "# Bond\n\n## Owner\n\n**Name:**   \nRole: founder.\n\n"
+        "_Filled during First Breath: role, what success looks like._\n"
+    )
+    assert lc.first_breath_marker(bond)
+
+
 def test_resolve_paths_substitutes_root(workspace: Path):
     paths = lc.resolve_paths(workspace)
     assert paths["sanctum_path"] == workspace / "_ai-memory/sanctum"

--- a/tests/unit/test_parzival_loaders.py
+++ b/tests/unit/test_parzival_loaders.py
@@ -283,6 +283,17 @@ def test_first_breath_marker_scoped_to_owner():
     assert not lc.first_breath_marker("# Bond\n\n## Working Style\n\nfast.\n")
 
 
+def test_first_breath_marker_real_name_with_surviving_seed():
+    # The fill workflow appended a real owner Name but left the seed line in
+    # ## Owner. A real Name alongside a surviving seed line must NOT re-trigger
+    # First Breath (TD-737 false-positive case).
+    bond = (
+        "# Bond\n\n## Owner\n\n**Name:** Will\nRole: founder.\n\n"
+        "_Filled during First Breath: role, what success looks like._\n"
+    )
+    assert not lc.first_breath_marker(bond)
+
+
 def test_resolve_paths_substitutes_root(workspace: Path):
     paths = lc.resolve_paths(workspace)
     assert paths["sanctum_path"] == workspace / "_ai-memory/sanctum"

--- a/tests/unit/test_parzival_loaders.py
+++ b/tests/unit/test_parzival_loaders.py
@@ -265,6 +265,24 @@ def test_first_breath_marker_and_phase():
     assert lc.current_phase("no phase here") is None
 
 
+def test_first_breath_marker_scoped_to_owner():
+    # Owner filled, scaffold prose surviving in another section (Working Style)
+    # must NOT re-trigger First Breath (the D9-F1 false positive).
+    filled = (
+        "# Bond\n\n## Owner\n\n**Name:** wb\nRole: founder.\n\n"
+        "## Working Style\n\n_Filled during First Breath and refined over time._\n"
+    )
+    assert not lc.first_breath_marker(filled)
+    # Genuinely-empty Owner (scaffold marker present) -> True.
+    empty = (
+        "# Bond\n\n## Owner\n\n**Name:** {user_name}\n\n"
+        "_Filled during First Breath: role, what success looks like._\n"
+    )
+    assert lc.first_breath_marker(empty)
+    # No ## Owner section at all -> fail-safe False (never re-First-Breath).
+    assert not lc.first_breath_marker("# Bond\n\n## Working Style\n\nfast.\n")
+
+
 def test_resolve_paths_substitutes_root(workspace: Path):
     paths = lc.resolve_paths(workspace)
     assert paths["sanctum_path"] == workspace / "_ai-memory/sanctum"


### PR DESCRIPTION
## Summary

Reconciles drifted dispatch documentation in the Parzival POV skills and adds a mechanical spawn-safety gate. Four changes across three skills plus a test:

- **Activation/workflow command drift** in `aim-agent-dispatch/SKILL.md` — every BMAD command was in the pre-module-prefix flat form and three roles were falsely tagged "NOT INSTALLED".
- **Dispatch spawn gate** in `aim-agent-dispatch` and `aim-agent-lifecycle` — no mechanical check enforced workspace-root launch or teammate activation before instructing.
- **First-Breath false positive** in `loader_common.first_breath_marker` — a full-document scan re-triggered First Breath (destructive) when scaffold prose survived in any BOND section.

Source-of-truth verified against two independent runtime sources that agree: `_bmad/_config/agents/*.customize.yaml` and the installed slash-command registry.

---

## Change records

### 1. `aim-agent-dispatch/SKILL.md` — reconcile commands (TD-717, TD-609)

**Symptom:** the dispatch tables list activation/workflow commands in the flat form (`/bmad-agent-dev`, `/bmad-code-review`, `/bmad-tea`, …) and tag SM/QA/Quick-Flow-Solo-Dev as "NOT INSTALLED -- 2026-04-11". A dispatcher following the table sends commands that don't resolve and reads installed agents as unavailable.

**Root cause:** BMAD moved to module-namespaced slash-commands (`/bmad-agent-<module>-<agent>`, `/bmad-bmm-<workflow>`); this file was never reconciled after that change. The "NOT INSTALLED" notes predate the current install, which ships `sm`, `qa`, and `quick-flow-solo-dev`.

**Fix:** every command reconciled to its installed form; the three "NOT INSTALLED" tags removed; the residual mention of the removed `aim-bmad-dispatch` skill dropped from the Purpose paragraph. The `/bmad-agent-bmad-master` row (core module, no prefix) was already correct and is unchanged.

**Verification:** post-edit grep of the file — `aim-bmad-dispatch` → 0, `NOT INSTALLED` → 0, flat `/bmad-agent-<name>` without a module segment → 0 (only `bmad-master` exempt), flat `/bmad-<workflow>` without `bmm` → 0 (only `/bmad-help`). All 37 written commands confirmed present in the installed skill registry.

### 2. `aim-agent-dispatch` + `aim-agent-lifecycle` — dispatch spawn gate (TD-731)

**Symptom:** teammates were repeatedly spawned from a non-root directory (BMAD skills then unresolved) and instructions were sent before the teammate finished activating (lost/misexecuted into an idle agent).

**Root cause:** the dispatch pipeline relied on the operator remembering to check CWD and wait for activation; no mechanical gate made skipping impossible.

**Fix:**
- **Pre-spawn sentinel gate** — new mandatory step asserting workspace-root via co-presence of `_ai-memory/` + `_bmad/` + `oversight/`; aborts the spawn on drift; re-run before every spawn (added as "Step 0" in `aim-agent-dispatch` and at the top of `aim-agent-lifecycle` Step 1).
- **Activation gate** — the advisory "Verify Activation" step is hardened into a mandatory gate: no instruction until the persona greeting + menu (or explicit ready ack) is observed; instruction sent as a separate message with an explicit "do not idle until X" + step list (same gate added to `aim-agent-lifecycle`).

### 3. `loader_common.first_breath_marker` — scope to `## Owner` (D9-F1)

**Symptom:** `first_breath_marker()` returned True for an already-filled BOND whenever the scaffold string survived anywhere in the document (e.g. Owner filled but `## Working Style` still scaffold) → activation re-ran First Breath → destructive overwrite risk.

**Root cause:** a full-document substring match (`"_Filled during First Breath" in bond_text`). Per `BOND-template.md` the marker seeds both `## Owner` and `## Working Style`, so any unfilled section tripped the whole-doc match.

**Fix:** scope the scan to the `## Owner` block using the existing `split_h2` helper (establishing the owner is exactly what First Breath does); a BOND with no `## Owner` section returns False (fail-safe — never re-trigger First Breath).

**Verification:** new field-level test `test_first_breath_marker_scoped_to_owner` — FALSE on a filled Owner with scaffold surviving in Working Style, TRUE on a genuinely-empty Owner, FALSE on a BOND with no Owner section. Existing `test_first_breath_marker_and_phase` stays green.

---

## Verification

- `black --check` / `ruff check` / `isort --check-only` on the changed Python files — all clean.
- `pytest tests/unit/test_parzival_loaders.py` — 19 passed (2 first-breath, no regressions).

## Scope notes

- The same flat-command class also exists in `aim-model-dispatch/**` and `evals/evals.json` — out of scope here, tracked separately (TD-735).
- Duplicate `qa.md`/`quinn.md` agent definitions tracked separately (TD-736); this PR maps QA Engineer → `/bmad-agent-bmm-qa`.
- TD-690 (team-builder route) verified already resolved at this branch base — no code change in this PR.
