### PR TITLE
Reconcile BMAD command names and code-review routing in aim-model-dispatch

### DIFF
--- a/_ai-memory/pov/skills/aim-model-dispatch/SKILL.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/SKILL.md
@@ -24,7 +24,7 @@ allowed-tools: Read
 | Agent Role | Default | Override When |
 |------------|---------|---------------|
 | DEV (implementation) | Sonnet | Opus if architectural changes or complex refactoring |
-| DEV (code review) | Sonnet | Opus if reviewing architectural decisions |
+| Code review | Sonnet | Opus if reviewing architectural decisions |
 | Analyst | Sonnet | Opus if deep architectural analysis |
 | PM | Sonnet | Opus if complex domain modeling |
 | Architect | Opus | Already at highest tier |

--- a/_ai-memory/pov/skills/aim-model-dispatch/evals/evals.json
+++ b/_ai-memory/pov/skills/aim-model-dispatch/evals/evals.json
@@ -17,7 +17,7 @@
           "type": "workflow_loading"
         },
         {
-          "text": "Agent resolved the correct BMAD agent: Dev agent with activation command /bmad-agent-dev",
+          "text": "Agent resolved the correct BMAD agent: Dev agent with activation command /bmad-agent-bmm-dev",
           "type": "agent_resolution"
         },
         {
@@ -50,7 +50,7 @@
           "type": "workflow_routing"
         },
         {
-          "text": "Agent resolved the correct BMAD agent: PM agent with activation command /bmad-agent-pm",
+          "text": "Agent resolved the correct BMAD agent: PM agent with activation command /bmad-agent-bmm-pm",
           "type": "agent_resolution"
         },
         {
@@ -83,7 +83,7 @@
           "type": "workflow_routing"
         },
         {
-          "text": "Agent resolved the correct BMAD agent: Analyst with activation command /bmad-agent-analyst",
+          "text": "Agent resolved the correct BMAD agent: Analyst with activation command /bmad-agent-bmm-analyst",
           "type": "agent_resolution"
         },
         {

--- a/_ai-memory/pov/skills/aim-model-dispatch/evals/evals.json
+++ b/_ai-memory/pov/skills/aim-model-dispatch/evals/evals.json
@@ -3,9 +3,9 @@
   "evals": [
     {
       "id": 1,
-      "name": "bmad-dev-openrouter",
-      "prompt": "dispatch a BMAD dev agent to openrouter to do a code review of the file .claude/skills/model-dispatch/scripts/install.sh — use the cheapest model available. Report what the dev agent finds.",
-      "expected_output": "Agent reads the skill, identifies this as a BMAD task, follows bmad-dispatch workflow (not tmux-dispatch), resolves the Dev agent activation command, determines OpenRouter backend, presents model options, and attempts two-phase activation in a tmux pane.",
+      "name": "bmad-review-openrouter",
+      "prompt": "dispatch a code review to openrouter for the file .claude/skills/model-dispatch/scripts/install.sh — use the cheapest model available. Report what the review finds.",
+      "expected_output": "Agent reads the skill, identifies this as a BMAD task, follows bmad-dispatch workflow (not tmux-dispatch), routes code review to the /bmad-bmm-code-review workflow (NOT dev-agent activation), determines OpenRouter backend, presents model options, and dispatches the review workflow in a tmux pane.",
       "files": [],
       "assertions": [
         {
@@ -17,12 +17,12 @@
           "type": "workflow_loading"
         },
         {
-          "text": "Agent resolved the correct BMAD agent: Dev agent with activation command /bmad-agent-bmm-dev",
+          "text": "Agent routed code review to the /bmad-bmm-code-review workflow (NOT /bmad-agent-bmm-dev activation)",
           "type": "agent_resolution"
         },
         {
-          "text": "Agent determined the menu code CR (Code Review) for the task",
-          "type": "menu_code"
+          "text": "Agent invoked /bmad-bmm-code-review directly (no CR menu code, no dev-agent two-phase activation)",
+          "type": "review_routing"
         },
         {
           "text": "Agent resolved OpenRouter as the backend with provider-dispatch openrouter as wrapper",

--- a/_ai-memory/pov/skills/aim-model-dispatch/references/bmad-agents.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/references/bmad-agents.md
@@ -33,8 +33,8 @@ When the task description does not specify an agent:
 | Validate a PRD | PM | `VP` |
 | Break down features into stories | PM | `CE` |
 | Design system architecture | Architect | Use menu |
-| Write code / implement a story | DEV | `DS` |
-| Review implemented code | DEV | `CR` |
+| Write code / implement a story | DEV | `/bmad-dev-story` (or `DS`) |
+| Review implemented code | Code Review (NOT the dev agent) | `/bmad-bmm-code-review` |
 | Design user flows | UX Designer | Use menu |
 | Write or review documentation | Tech Writer | `WD` |
 | Validate documentation | Tech Writer | `VD` |
@@ -48,7 +48,7 @@ When the user specifies a direct workflow command, map it to two-phase activatio
 
 | Direct Command | Activate Agent | Menu Code |
 |---|---|---|
-| `/bmad-code-review` | `/bmad-agent-bmm-dev` | `CR` |
+| `/bmad-bmm-code-review` | (direct review workflow — no dev-agent activation) | — |
 | `/bmad-dev-story` | `/bmad-agent-bmm-dev` | `DS` |
 | `/bmad-create-prd` | `/bmad-agent-bmm-pm` | `CP` |
 | `/bmad-validate-prd` | `/bmad-agent-bmm-pm` | `VP` |

--- a/_ai-memory/pov/skills/aim-model-dispatch/references/bmad-agents.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/references/bmad-agents.md
@@ -4,12 +4,12 @@
 
 | Agent Type | Activation Command |
 |---|---|
-| Developer | `/bmad-agent-dev` |
-| PM (Product Manager) | `/bmad-agent-pm` |
-| Analyst | `/bmad-agent-analyst` |
-| Architect | `/bmad-agent-architect` |
-| UX Designer | `/bmad-agent-ux-designer` |
-| Tech Writer | `/bmad-agent-tech-writer` |
+| Developer | `/bmad-agent-bmm-dev` |
+| PM (Product Manager) | `/bmad-agent-bmm-pm` |
+| Analyst | `/bmad-agent-bmm-analyst` |
+| Architect | `/bmad-agent-bmm-architect` |
+| UX Designer | `/bmad-agent-bmm-ux-designer` |
+| Tech Writer | `/bmad-agent-bmm-tech-writer` |
 | BMAD Master | `/bmad-agent-bmad-master` |
 | Agent Builder | `/bmad-agent-bmb-agent-builder` |
 | Module Builder | `/bmad-agent-bmb-module-builder` |
@@ -48,10 +48,10 @@ When the user specifies a direct workflow command, map it to two-phase activatio
 
 | Direct Command | Activate Agent | Menu Code |
 |---|---|---|
-| `/bmad-code-review` | `/bmad-agent-dev` | `CR` |
-| `/bmad-dev-story` | `/bmad-agent-dev` | `DS` |
-| `/bmad-create-prd` | `/bmad-agent-pm` | `CP` |
-| `/bmad-validate-prd` | `/bmad-agent-pm` | `VP` |
-| `/bmad-create-epics-and-stories` | `/bmad-agent-pm` | `CE` |
-| `/bmad-create-architecture` | `/bmad-agent-architect` | Use menu |
-| `/bmad-create-ux-design` | `/bmad-agent-ux-designer` | Use menu |
+| `/bmad-code-review` | `/bmad-agent-bmm-dev` | `CR` |
+| `/bmad-dev-story` | `/bmad-agent-bmm-dev` | `DS` |
+| `/bmad-create-prd` | `/bmad-agent-bmm-pm` | `CP` |
+| `/bmad-validate-prd` | `/bmad-agent-bmm-pm` | `VP` |
+| `/bmad-create-epics-and-stories` | `/bmad-agent-bmm-pm` | `CE` |
+| `/bmad-create-architecture` | `/bmad-agent-bmm-architect` | Use menu |
+| `/bmad-create-ux-design` | `/bmad-agent-bmm-ux-designer` | Use menu |

--- a/_ai-memory/pov/skills/aim-model-dispatch/references/user-guide.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/references/user-guide.md
@@ -282,8 +282,8 @@ All BMAD tasks use two-phase activation: first the agent persona loads, then you
 ### Code Review
 
 ```
-dispatch to ollama: Activate /bmad-agent-bmm-dev, then CR to review auth module
-send to openrouter with claude-sonnet-4-6: Activate dev agent, run CR on api/
+dispatch to ollama: /bmad-bmm-code-review to review auth module
+send to openrouter with claude-sonnet-4-6: /bmad-bmm-code-review on api/
 ```
 
 ### Implement a Story
@@ -311,7 +311,7 @@ use ollama: Activate tech-writer agent, validate the SKILL.md
 
 | Agent | Command | Use |
 |-------|---------|-----|
-| Dev | `/bmad-agent-bmm-dev` | Code, review, implementation |
+| Dev | `/bmad-agent-bmm-dev` | Code, implementation |
 | PM | `/bmad-agent-bmm-pm` | PRD, epics, planning |
 | Tech Writer | `/bmad-agent-bmm-tech-writer` | Docs, explanation |
 | Analyst | `/bmad-agent-bmm-analyst` | Research, analysis |

--- a/_ai-memory/pov/skills/aim-model-dispatch/references/user-guide.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/references/user-guide.md
@@ -282,21 +282,21 @@ All BMAD tasks use two-phase activation: first the agent persona loads, then you
 ### Code Review
 
 ```
-dispatch to ollama: Activate /bmad-agent-dev, then CR to review auth module
+dispatch to ollama: Activate /bmad-agent-bmm-dev, then CR to review auth module
 send to openrouter with claude-sonnet-4-6: Activate dev agent, run CR on api/
 ```
 
 ### Implement a Story
 
 ```
-dispatch to ollama: Activate /bmad-agent-dev, then DS for story 1.5
+dispatch to ollama: Activate /bmad-agent-bmm-dev, then DS for story 1.5
 use openrouter with openai/gpt-4o: Activate dev agent, DS story-1-6.md
 ```
 
 ### Create PRD
 
 ```
-dispatch to claude: Activate /bmad-agent-pm, then CP for notification system
+dispatch to claude: Activate /bmad-agent-bmm-pm, then CP for notification system
 send to ollama: Activate PM agent, CP to create PRD for billing
 ```
 
@@ -311,12 +311,12 @@ use ollama: Activate tech-writer agent, validate the SKILL.md
 
 | Agent | Command | Use |
 |-------|---------|-----|
-| Dev | `/bmad-agent-dev` | Code, review, implementation |
-| PM | `/bmad-agent-pm` | PRD, epics, planning |
-| Tech Writer | `/bmad-agent-tech-writer` | Docs, explanation |
-| Analyst | `/bmad-agent-analyst` | Research, analysis |
-| Architect | `/bmad-agent-architect` | Design, architecture |
-| UX Designer | `/bmad-agent-ux-designer` | User flow, design |
+| Dev | `/bmad-agent-bmm-dev` | Code, review, implementation |
+| PM | `/bmad-agent-bmm-pm` | PRD, epics, planning |
+| Tech Writer | `/bmad-agent-bmm-tech-writer` | Docs, explanation |
+| Analyst | `/bmad-agent-bmm-analyst` | Research, analysis |
+| Architect | `/bmad-agent-bmm-architect` | Design, architecture |
+| UX Designer | `/bmad-agent-bmm-ux-designer` | User flow, design |
 | Agent Builder | `/bmad-agent-bmb-agent-builder` | Create new agents |
 | Module Builder | `/bmad-agent-bmb-module-builder` | Build modules |
 | Workflow Builder | `/bmad-agent-bmb-workflow-builder` | Build workflows |

--- a/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-01-resolve-agent.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-01-resolve-agent.md
@@ -140,7 +140,7 @@ After the agent menu appears, what should be sent?
 Each agent menu has items with codes like `[DS]`, `[CR]`, `[CH]`, `[VD]`. Send the code.
 
 Examples:
-- Dev agent: `DS` (Dev Story)  — code review routes to `/bmad-bmm-code-review`, not a dev-agent menu code
+- Dev agent: `DS` (Dev Story) — code review routes to `/bmad-bmm-code-review`, not a dev-agent menu code
 - Tech Writer: `VD` (Validate Documentation)
 - PM: `CP` (Create PRD), `VP` (Validate PRD), `CE` (Create Epics)
 

--- a/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-01-resolve-agent.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-01-resolve-agent.md
@@ -58,8 +58,8 @@ If the task description does not specify an agent, use this selection guide:
 | Validate a PRD | PM | `VP` |
 | Break down features into stories | PM | `CE` |
 | Design system architecture | Architect | Use menu |
-| Write code / implement a story | DEV | `DS` |
-| Review implemented code | DEV | `CR` |
+| Write code / implement a story | DEV | `/bmad-dev-story` (or `DS`) |
+| Review implemented code | Code Review (NOT the dev agent) | `/bmad-bmm-code-review` |
 | Design user flows | UX Designer | Use menu |
 | Write or review documentation | Tech Writer | `WD` |
 | Validate documentation | Tech Writer | `VD` |
@@ -67,11 +67,11 @@ If the task description does not specify an agent, use this selection guide:
 | Build new BMAD modules | Module Builder | Use menu |
 | Build new BMAD workflows | Workflow Builder | Use menu |
 
-**IMPORTANT**: Even if the user specifies a direct workflow command like `/bmad-code-review` or `/bmad-dev-story`, you MUST still use two-phase activation. Map the direct command to its parent agent + menu code:
+**IMPORTANT**: `/bmad-bmm-code-review` is a direct review workflow — invoke it directly; do NOT route review through dev-agent two-phase activation. Other direct workflow commands like `/bmad-dev-story` still map to their parent agent + menu code:
 
 | Direct Command | Activate Agent | Menu Code |
 |---|---|---|
-| `/bmad-code-review` | `/bmad-agent-bmm-dev` | `CR` |
+| `/bmad-bmm-code-review` | (direct review workflow — no dev-agent activation) | — |
 | `/bmad-dev-story` | `/bmad-agent-bmm-dev` | `DS` |
 | `/bmad-create-prd` | `/bmad-agent-bmm-pm` | `CP` |
 | `/bmad-validate-prd` | `/bmad-agent-bmm-pm` | `VP` |
@@ -140,7 +140,7 @@ After the agent menu appears, what should be sent?
 Each agent menu has items with codes like `[DS]`, `[CR]`, `[CH]`, `[VD]`. Send the code.
 
 Examples:
-- Dev agent: `DS` (Dev Story), `CR` (Code Review)
+- Dev agent: `DS` (Dev Story)  — code review routes to `/bmad-bmm-code-review`, not a dev-agent menu code
 - Tech Writer: `VD` (Validate Documentation)
 - PM: `CP` (Create PRD), `VP` (Validate PRD), `CE` (Create Epics)
 

--- a/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-01-resolve-agent.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-01-resolve-agent.md
@@ -31,12 +31,12 @@ From the task description, determine which BMAD agent is needed.
 
 | Agent Type | Activation Command |
 |---|---|
-| Developer | `/bmad-agent-dev` |
-| PM (Product Manager) | `/bmad-agent-pm` |
-| Analyst | `/bmad-agent-analyst` |
-| Architect | `/bmad-agent-architect` |
-| UX Designer | `/bmad-agent-ux-designer` |
-| Tech Writer | `/bmad-agent-tech-writer` |
+| Developer | `/bmad-agent-bmm-dev` |
+| PM (Product Manager) | `/bmad-agent-bmm-pm` |
+| Analyst | `/bmad-agent-bmm-analyst` |
+| Architect | `/bmad-agent-bmm-architect` |
+| UX Designer | `/bmad-agent-bmm-ux-designer` |
+| Tech Writer | `/bmad-agent-bmm-tech-writer` |
 | BMAD Master | `/bmad-agent-bmad-master` |
 | Agent Builder | `/bmad-agent-bmb-agent-builder` |
 | Module Builder | `/bmad-agent-bmb-module-builder` |
@@ -71,13 +71,13 @@ If the task description does not specify an agent, use this selection guide:
 
 | Direct Command | Activate Agent | Menu Code |
 |---|---|---|
-| `/bmad-code-review` | `/bmad-agent-dev` | `CR` |
-| `/bmad-dev-story` | `/bmad-agent-dev` | `DS` |
-| `/bmad-create-prd` | `/bmad-agent-pm` | `CP` |
-| `/bmad-validate-prd` | `/bmad-agent-pm` | `VP` |
-| `/bmad-create-epics-and-stories` | `/bmad-agent-pm` | `CE` |
-| `/bmad-create-architecture` | `/bmad-agent-architect` | Use menu |
-| `/bmad-create-ux-design` | `/bmad-agent-ux-designer` | Use menu |
+| `/bmad-code-review` | `/bmad-agent-bmm-dev` | `CR` |
+| `/bmad-dev-story` | `/bmad-agent-bmm-dev` | `DS` |
+| `/bmad-create-prd` | `/bmad-agent-bmm-pm` | `CP` |
+| `/bmad-validate-prd` | `/bmad-agent-bmm-pm` | `VP` |
+| `/bmad-create-epics-and-stories` | `/bmad-agent-bmm-pm` | `CE` |
+| `/bmad-create-architecture` | `/bmad-agent-bmm-architect` | Use menu |
+| `/bmad-create-ux-design` | `/bmad-agent-bmm-ux-designer` | Use menu |
 
 ### 2. Determine Backend
 
@@ -152,7 +152,7 @@ Choose the pattern that best fits the task. Menu codes are more reliable.
 ### 8. Record the Dispatch Plan
 
 Store these values:
-- **AGENT_COMMAND**: The activation command (e.g., `/bmad-agent-dev`)
+- **AGENT_COMMAND**: The activation command (e.g., `/bmad-agent-bmm-dev`)
 - **TASK_INPUT**: The text to send after menu appears (e.g., `DS`)
 - **TASK_FOLLOW_UP**: Any additional input needed later (empty if not known)
 - **AGENT_NAME**: Human-readable name (e.g., `bmad-dev`, `bmad-tech-writer`)

--- a/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-02-launch-and-activate.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-02-launch-and-activate.md
@@ -109,7 +109,7 @@ sleep 5
 
 ```bash
 # Send the BMAD agent activation command
-# AGENT_COMMAND is from step-01, e.g., "/bmad-agent-dev"
+# AGENT_COMMAND is from step-01, e.g., "/bmad-agent-bmm-dev"
 tmux send-keys -t "$PANE_TARGET" "${AGENT_COMMAND}"
 
 # Pause 2 seconds for the TUI to render

--- a/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-03-detect-ready-and-send-task.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-03-detect-ready-and-send-task.md
@@ -98,7 +98,7 @@ For `/bmad-agent-bmb-agent-builder`, "Type something" is option 5 (Build=1, Anal
 ```bash
 if [ "$MENU_STYLE" = "intent_picker" ]; then
   # Count the offset to the "Type something" option
-  # For bmad-agent-builder the literal is at option 5 → 4 Down presses
+  # For bmad-agent-bmb-agent-builder the literal is at option 5 → 4 Down presses
   DOWN_COUNT=4
 
   # Derive dynamically from pane text if possible; fall back to default

--- a/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-03-detect-ready-and-send-task.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-03-detect-ready-and-send-task.md
@@ -28,7 +28,7 @@ Style A — Legacy universal menu. Contains:
 - `[MH]` — Menu Help
 - `[DA]` — Dismiss Agent
 
-Style B — Custom numbered Intent picker. Contains a "Type something" option literal, typically rendered as a numbered line such as `5. Type something` or similar. The Intent picker appears in newer skills (e.g., `/bmad-agent-builder`) and does NOT carry the `[MH]`/`[DA]` markers.
+Style B — Custom numbered Intent picker. Contains a "Type something" option literal, typically rendered as a numbered line such as `5. Type something` or similar. The Intent picker appears in newer skills (e.g., `/bmad-agent-bmb-agent-builder`) and does NOT carry the `[MH]`/`[DA]` markers.
 
 Detection SUCCESS = Style A matched OR Style B matched.
 
@@ -93,7 +93,7 @@ Only runs when `MENU_STYLE=intent_picker`. Skipped for legacy menus — the lega
 
 BMAD Intent pickers interpret the first non-navigation input as confirmation of the currently-highlighted option. Free-form text has no navigation prefix, so it is treated as confirmation of the wrong option. The dispatch layer must navigate to the "Type something" option first.
 
-For `/bmad-agent-builder`, "Type something" is option 5 (Build=1, Analyze=2, Edit=3, Rebuild=4, Type something=5, Chat=6). Navigation is four Down presses followed by Enter.
+For `/bmad-agent-bmb-agent-builder`, "Type something" is option 5 (Build=1, Analyze=2, Edit=3, Rebuild=4, Type something=5, Chat=6). Navigation is four Down presses followed by Enter.
 
 ```bash
 if [ "$MENU_STYLE" = "intent_picker" ]; then

--- a/_ai-memory/pov/skills/aim-model-dispatch/workflows/claude-native/workflow.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/workflows/claude-native/workflow.md
@@ -34,7 +34,7 @@ EC-01, EC-04, EC-05, EC-06, EC-09, EC-10
 **Process Rules (project-status.md):**
 - Rule 3: Fresh agents for EVERY role — never reuse across tasks
 - Rule 4: CWD must be project root (document_pipeline/) before spawn — NEVER DocIntel/
-- Rule 5: /bmad-code-review for reviews, /bmad-agent-bmm-dev for implementation only
+- Rule 5: /bmad-bmm-code-review for reviews, /bmad-agent-bmm-dev for implementation only
 - Rule 6: Dual review mandatory (Sonnet + Opus)
 - Rule 7: One story per SM dispatch — shutdown after each
 - Rule 8: Don't rush-nudge idle agents
@@ -255,7 +255,7 @@ Agent:
   model: sonnet
   mode: bypassPermissions
   run_in_background: true
-  prompt: "/bmad-agent-bmm-dev"
+  prompt: "/bmad-bmm-code-review"
 
 Agent:
   name: "review-opus"
@@ -263,16 +263,16 @@ Agent:
   model: opus
   mode: bypassPermissions
   run_in_background: true
-  prompt: "/bmad-agent-bmm-dev"
+  prompt: "/bmad-bmm-code-review"
 
-# After both idle, send review instructions
+# After both load, send the review instruction directly (review workflow takes it — no CR menu code)
 SendMessage:
   to: "review-sonnet"
-  message: "CR\n[review instruction]"
+  message: "[review instruction]"
 
 SendMessage:
   to: "review-opus"
-  message: "CR\n[review instruction]"
+  message: "[review instruction]"
 ```
 
 ### Multi-Track Parallel Sprint

--- a/_ai-memory/pov/skills/aim-model-dispatch/workflows/claude-native/workflow.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/workflows/claude-native/workflow.md
@@ -34,7 +34,7 @@ EC-01, EC-04, EC-05, EC-06, EC-09, EC-10
 **Process Rules (project-status.md):**
 - Rule 3: Fresh agents for EVERY role — never reuse across tasks
 - Rule 4: CWD must be project root (document_pipeline/) before spawn — NEVER DocIntel/
-- Rule 5: /bmad-code-review for reviews, /bmad-agent-dev for implementation only
+- Rule 5: /bmad-code-review for reviews, /bmad-agent-bmm-dev for implementation only
 - Rule 6: Dual review mandatory (Sonnet + Opus)
 - Rule 7: One story per SM dispatch — shutdown after each
 - Rule 8: Don't rush-nudge idle agents
@@ -162,7 +162,7 @@ Agent:
   model: opus
   mode: plan
   run_in_background: true
-  prompt: "/bmad-agent-architect"
+  prompt: "/bmad-agent-bmm-architect"
 ```
 
 Teammate sends plan_approval_request when ready. Lead reviews and approves or rejects with feedback.
@@ -219,7 +219,7 @@ Agent:
   model: sonnet
   mode: bypassPermissions
   run_in_background: true
-  prompt: "/bmad-agent-dev"
+  prompt: "/bmad-agent-bmm-dev"
 
 # Wait for idle (persona loaded, menu shown)
 
@@ -255,7 +255,7 @@ Agent:
   model: sonnet
   mode: bypassPermissions
   run_in_background: true
-  prompt: "/bmad-agent-dev"
+  prompt: "/bmad-agent-bmm-dev"
 
 Agent:
   name: "review-opus"
@@ -263,7 +263,7 @@ Agent:
   model: opus
   mode: bypassPermissions
   run_in_background: true
-  prompt: "/bmad-agent-dev"
+  prompt: "/bmad-agent-bmm-dev"
 
 # After both idle, send review instructions
 SendMessage:
@@ -301,7 +301,7 @@ Agent:
   model: sonnet
   mode: bypassPermissions
   run_in_background: true
-  prompt: "/bmad-agent-dev"
+  prompt: "/bmad-agent-bmm-dev"
 
 Agent:
   name: "dev-services"
@@ -309,7 +309,7 @@ Agent:
   model: sonnet
   mode: bypassPermissions
   run_in_background: true
-  prompt: "/bmad-agent-dev"
+  prompt: "/bmad-agent-bmm-dev"
 
 Agent:
   name: "dev-observability"
@@ -317,7 +317,7 @@ Agent:
   model: sonnet
   mode: bypassPermissions
   run_in_background: true
-  prompt: "/bmad-agent-dev"
+  prompt: "/bmad-agent-bmm-dev"
 
 # After idle, send instructions — each owns different files
 ```


### PR DESCRIPTION
## Summary

Reconciles BMAD agent command names and code-review routing in the `aim-model-dispatch` skill to match the installed BMAD (v6.0.0-Beta.4).

- Modernizes stale flat `/bmad-agent-<role>` activation commands to the canonical `bmm`-infixed forms across the skill's references, workflows, and evals (TD-735).
- Routes code review through the dedicated `/bmad-bmm-code-review` workflow instead of dev-agent activation + a `CR` menu code, matching the canonical review-vs-activation rule — across the reference tables, the resolve-agent step, the claude-native dual-review example, the user guide, and the eval expectations (TD-739).

## Why

The skill previously steered readers to run code review via the dev agent (contradicting the review rule) and used command forms that do not resolve against the installed BMAD. This keeps the shipped dispatch guidance correct and self-consistent.

## Notes

- Held for the v2.8.2 release train — do not merge before the v2.8.1 tag.
- Upstream BMAD has since diverged (non-`bmm` naming, v6.9.0); that migration is tracked in TD-740 and is intentionally out of scope here.
