### PR TITLE
Reconcile oversight dispatch docs to the BMAD v6.9.0 command surface

### DIFF
--- a/_ai-memory/pov/skills/aim-agent-dispatch/SKILL.md
+++ b/_ai-memory/pov/skills/aim-agent-dispatch/SKILL.md
@@ -169,18 +169,18 @@ MUST spawn fresh agent for every task -- never reuse across roles or stories.
 
 | Agent | Activation Command | Description |
 |-------|-------------------|-------------|
-| Analyst | `/bmad-agent-bmm-analyst` | Research, codebase analysis, domain investigation |
-| PM (Product Manager) | `/bmad-agent-bmm-pm` | PRD creation/validation, epics and stories |
-| Architect | `/bmad-agent-bmm-architect` | System architecture design, readiness checks |
-| Developer (DEV) | `/bmad-agent-bmm-dev` | Code implementation ONLY |
-| Developer (review) | `/bmad-bmm-code-review` | Code review ONLY -- MUST use this for ALL review agents, never /bmad-agent-bmm-dev |
+| Analyst | `/bmad-agent-analyst` | Research, codebase analysis, domain investigation |
+| PM (Product Manager) | `/bmad-agent-pm` | PRD creation/validation, epics and stories |
+| Architect | `/bmad-agent-architect` | System architecture design, readiness checks |
+| Developer (DEV) | `/bmad-agent-dev` | Code implementation ONLY |
+| Developer (review) | `/bmad-code-review` | Code review ONLY -- MUST use this for ALL review agents, never /bmad-agent-dev |
 | Scrum Master (SM) | `/bmad-agent-bmm-sm` | Sprint planning, story creation, retrospectives |
 | QA Engineer | `/bmad-agent-bmm-qa` | Test planning, test execution, quality validation |
-| UX Designer | `/bmad-agent-bmm-ux-designer` | User flows, screen design, UX research |
-| Tech Writer | `/bmad-agent-bmm-tech-writer` | Documentation writing and validation |
+| UX Designer | `/bmad-agent-ux-designer` | User flows, screen design, UX research |
+| Tech Writer | `/bmad-agent-tech-writer` | Documentation writing and validation |
 | Quick Flow Solo Dev | `/bmad-agent-bmm-quick-flow-solo-dev` | Lightweight single-dev flow (analysis through implementation) |
 
-MUST use `/bmad-agent-bmm-tech-writer` for ALL documentation tasks (writing, updating, reviewing docs). MUST use `/bmad-bmm-code-review` for ALL review agents (never `/bmad-agent-bmm-dev`). MUST use `/bmad-help` whenever unsure which agent or workflow to use -- the tables above are NOT exhaustive.
+MUST use `/bmad-agent-tech-writer` for ALL documentation tasks (writing, updating, reviewing docs). MUST use `/bmad-code-review` for ALL review agents (never `/bmad-agent-dev`). MUST use `/bmad-help` whenever unsure which agent or workflow to use -- the tables above are NOT exhaustive.
 
 #### BMAD Framework Agents
 
@@ -217,16 +217,16 @@ MUST use `/bmad-agent-bmm-tech-writer` for ALL documentation tasks (writing, upd
 
 | Phase | Agent | Workflow Command |
 |-------|-------|-----------------|
-| Research | Analyst | `/bmad-bmm-market-research`, `/bmad-bmm-domain-research`, `/bmad-bmm-technical-research` |
-| Discovery | Analyst | `/bmad-bmm-create-product-brief` |
-| Discovery (or any phase) | PM | `/bmad-bmm-create-prd`, `/bmad-bmm-validate-prd`, `/bmad-bmm-edit-prd` |
-| Architecture | Architect | `/bmad-bmm-create-architecture` |
-| Architecture | PM | `/bmad-bmm-create-epics-and-stories` |
-| Architecture | Architect | `/bmad-bmm-check-implementation-readiness` |
-| Architecture | UX Designer | `/bmad-bmm-create-ux-design` |
+| Research | Analyst | `/bmad-market-research`, `/bmad-domain-research`, `/bmad-technical-research` |
+| Discovery | Analyst | `/bmad-product-brief` |
+| Discovery (or any phase) | PM | `/bmad-create-prd`, `/bmad-validate-prd`, `/bmad-edit-prd` |
+| Architecture | Architect | `/bmad-create-architecture` |
+| Architecture | PM | `/bmad-create-epics-and-stories` |
+| Architecture | Architect | `/bmad-check-implementation-readiness` |
+| Architecture | UX Designer | `/bmad-ux` |
 | Planning | SM | `/bmad-bmm-sprint-planning`, `/bmad-bmm-create-story` |
-| Execution | DEV | `/bmad-bmm-dev-story` |
-| Execution | DEV | `/bmad-bmm-code-review` |
+| Execution | DEV | `/bmad-dev-story` |
+| Execution | DEV | `/bmad-code-review` |
 | Release | SM | `/bmad-bmm-retrospective` |
 
 Set `AI_MEMORY_AGENT_ID` environment variable when spawning.

--- a/_ai-memory/pov/skills/aim-agent-dispatch/SKILL.md
+++ b/_ai-memory/pov/skills/aim-agent-dispatch/SKILL.md
@@ -34,8 +34,8 @@ CWD drifts across Bash calls, so re-run this gate immediately before EACH spawn 
 ## Step 1: Determine Dispatch Type
 
 **BMAD dispatch** (use the [BMAD Agent Dispatch](#bmad-agent-dispatch) section below) when:
-- The task requires ANY BMAD agent role (Analyst, PM, Architect, DEV, SM, UX Designer, etc.)
-- The agent requires persona activation via `/bmad-agent-<module>-<name>` commands
+- The task requires ANY BMAD agent role (Analyst, PM, Architect, DEV, UX Designer, Tech Writer)
+- The agent requires persona activation via `/bmad-agent-<name>` commands
 
 **Generic dispatch** (use the [Generic Agent Dispatch](#generic-agent-dispatch) section below) when:
 - The agent does NOT need a BMAD persona
@@ -102,28 +102,18 @@ See [agent-selection-guide.md](data/agent-selection-guide.md) for detailed role 
 |---|---|---|---|
 | Research current codebase state | Analyst | Architect | Planning |
 | Create, validate, or update PRD | PM | Analyst | Planning |
-| Break down features into stories | PM | SM | Planning |
+| Break down features into stories | PM | Analyst | Planning |
 | Design system architecture | Architect | PM | Planning |
 | Check if implementation is ready | Architect | DEV | Planning |
-| Plan and initialize a sprint | SM | PM | Planning |
-| Create individual story files | SM | PM | Execution |
+| Plan and initialize a sprint | `/bmad-sprint-planning` (direct skill) | PM | Planning |
+| Create individual story files | `/bmad-create-story` (direct skill) | PM | Execution |
 | Write code / implement a story | DEV | Any other | Execution |
 | Review implemented code | DEV | Architect | Execution |
 | Design user flows and screens | UX Designer | PM | Planning |
 | Write or review documentation | Tech Writer | PM | Execution |
-| Write and run tests | QA Engineer | DEV | Execution |
-| Design test architecture/strategy | Test Architect (TEA) | QA Engineer | Planning |
-| Small feature, solo workflow | Quick Flow Solo Dev | DEV | Execution |
-| Build new BMAD agents | Agent Builder | DEV | Execution |
-| Build new BMAD modules | Module Builder | DEV | Execution |
-| Build new BMAD workflows | Workflow Builder | DEV | Execution |
-| BMAD framework guidance | BMAD Master | PM | Planning |
-| Brainstorming / ideation session | Brainstorming Coach | Analyst | Planning |
-| Creative problem solving | Creative Problem Solver | Analyst | Planning |
-| Design thinking facilitation | Design Thinking Coach | UX Designer | Planning |
-| Innovation strategy | Innovation Strategist | PM | Planning |
-| Presentation creation/coaching | Presentation Master | Tech Writer | Execution |
-| Narrative and storytelling | Storyteller | Tech Writer | Execution |
+| Write and run tests | `/bmad-qa-generate-e2e-tests` (direct skill) | DEV | Execution |
+| Design test architecture/strategy | `/bmad-tea` (direct skill) | DEV | Planning |
+| Small feature, solo workflow | `/bmad-quick-dev` (direct skill) | DEV | Execution |
 
 ### Agent Combination Sequences
 
@@ -133,7 +123,7 @@ Some phases require agents in sequence:
 - **Architecture phase:** Architect (design) -> PM (epics/stories) -> Architect (readiness check)
 - **Execution cycle:** DEV (implement) -> DEV (code review) -> [loop if issues] -> DEV (re-review)
 - **Integration phase:** DEV (full review) -> Architect (cohesion check)
-- **Release phase:** SM (retrospective) -> PM or Analyst (documentation update)
+- **Release phase:** `/bmad-retrospective` (direct skill) -> PM or Analyst (documentation update)
 
 ---
 

--- a/_ai-memory/pov/skills/aim-agent-dispatch/SKILL.md
+++ b/_ai-memory/pov/skills/aim-agent-dispatch/SKILL.md
@@ -174,44 +174,10 @@ MUST spawn fresh agent for every task -- never reuse across roles or stories.
 | Architect | `/bmad-agent-architect` | System architecture design, readiness checks |
 | Developer (DEV) | `/bmad-agent-dev` | Code implementation ONLY |
 | Developer (review) | `/bmad-code-review` | Code review ONLY -- MUST use this for ALL review agents, never /bmad-agent-dev |
-| Scrum Master (SM) | `/bmad-agent-bmm-sm` | Sprint planning, story creation, retrospectives |
-| QA Engineer | `/bmad-agent-bmm-qa` | Test planning, test execution, quality validation |
 | UX Designer | `/bmad-agent-ux-designer` | User flows, screen design, UX research |
 | Tech Writer | `/bmad-agent-tech-writer` | Documentation writing and validation |
-| Quick Flow Solo Dev | `/bmad-agent-bmm-quick-flow-solo-dev` | Lightweight single-dev flow (analysis through implementation) |
 
 MUST use `/bmad-agent-tech-writer` for ALL documentation tasks (writing, updating, reviewing docs). MUST use `/bmad-code-review` for ALL review agents (never `/bmad-agent-dev`). MUST use `/bmad-help` whenever unsure which agent or workflow to use -- the tables above are NOT exhaustive.
-
-#### BMAD Framework Agents
-
-| Agent | Activation Command | Description |
-|-------|-------------------|-------------|
-| BMAD Master | `/bmad-agent-bmad-master` | BMAD framework orchestration and guidance |
-
-#### Builder Agents (bmb-)
-
-| Agent | Activation Command | Description |
-|-------|-------------------|-------------|
-| Agent Builder | `/bmad-agent-bmb-agent-builder` | Build new BMAD agent definitions |
-| Module Builder | `/bmad-agent-bmb-module-builder` | Build new BMAD modules |
-| Workflow Builder | `/bmad-agent-bmb-workflow-builder` | Build new BMAD workflows |
-
-#### CIS Coaches (cis-)
-
-| Agent | Activation Command | Description |
-|-------|-------------------|-------------|
-| Brainstorming Coach | `/bmad-agent-cis-brainstorming-coach` | Facilitated brainstorming sessions |
-| Creative Problem Solver | `/bmad-agent-cis-creative-problem-solver` | Creative approaches to complex problems |
-| Design Thinking Coach | `/bmad-agent-cis-design-thinking-coach` | Design thinking methodology facilitation |
-| Innovation Strategist | `/bmad-agent-cis-innovation-strategist` | Innovation strategy and ideation |
-| Presentation Master | `/bmad-agent-cis-presentation-master` | Presentation creation and coaching |
-| Storyteller | `/bmad-agent-cis-storyteller` | Narrative crafting and storytelling |
-
-#### Test Agents (tea-)
-
-| Agent | Activation Command | Description |
-|-------|-------------------|-------------|
-| Test Architect (TEA) | `/bmad-agent-tea-tea` | Test architecture and strategy design |
 
 **Workflow commands by phase** (sent AFTER activation, when in planning mode):
 
@@ -224,10 +190,10 @@ MUST use `/bmad-agent-tech-writer` for ALL documentation tasks (writing, updatin
 | Architecture | PM | `/bmad-create-epics-and-stories` |
 | Architecture | Architect | `/bmad-check-implementation-readiness` |
 | Architecture | UX Designer | `/bmad-ux` |
-| Planning | SM | `/bmad-bmm-sprint-planning`, `/bmad-bmm-create-story` |
+| Planning | (direct skill) | `/bmad-sprint-planning`, `/bmad-create-story` |
 | Execution | DEV | `/bmad-dev-story` |
 | Execution | DEV | `/bmad-code-review` |
-| Release | SM | `/bmad-bmm-retrospective` |
+| Release | (direct skill) | `/bmad-retrospective` |
 
 Set `AI_MEMORY_AGENT_ID` environment variable when spawning.
 

--- a/_ai-memory/pov/skills/aim-agent-dispatch/SKILL.md
+++ b/_ai-memory/pov/skills/aim-agent-dispatch/SKILL.md
@@ -191,7 +191,7 @@ Set `AI_MEMORY_AGENT_ID` environment variable when spawning.
 
 Do NOT send any task instruction until the teammate has emitted its activation output -- the BMAD persona greeting plus its numbered menu, or an explicit "ready" ack -- not idle, not mid-load. Verify by reading the spawn's first response (Claude-native) or `tmux capture-pane` (tmux).
 
-- Activated (greeting + menu, clean state, no prior task context) -> send the task as a SEPARATE message (one task per instruction), and include an explicit "do not idle until X" plus a concrete numbered step list. BMAD `bmm-dev`/reviewers early-idle otherwise.
+- Activated (greeting + menu, clean state, no prior task context) -> send the task as a SEPARATE message (one task per instruction), and include an explicit "do not idle until X" plus a concrete numbered step list. BMAD `bmad-agent-dev`/reviewers early-idle otherwise.
 - Not activated after one retry of the activation command -> spawn a FRESH agent. Never send an instruction to an unverified agent; check configuration if it repeats.
 
 #### B5. Dispatch Complete

--- a/_ai-memory/pov/skills/aim-agent-dispatch/data/agent-selection-guide.md
+++ b/_ai-memory/pov/skills/aim-agent-dispatch/data/agent-selection-guide.md
@@ -85,7 +85,9 @@ The following roles represent common capabilities. Actual agent names and activa
 
 ---
 
-### SM (Scrum Master)
+### Sprint & Story Capabilities (direct skills)
+
+**v6.9.0 note**: In BMAD v6.9.0 these are direct skills — `/bmad-sprint-planning`, `/bmad-create-story`, `/bmad-retrospective` — invoked directly, not via two-phase agent activation.
 
 **Strengths**: Sprint planning, story creation, sprint tracking, retrospectives, velocity assessment.
 
@@ -117,7 +119,9 @@ The following roles represent common capabilities. Actual agent names and activa
 
 ---
 
-### QA (Quality Assurance)
+### Test Capabilities (direct skills)
+
+**v6.9.0 note**: In BMAD v6.9.0 these are direct skills — automated test generation via `/bmad-qa-generate-e2e-tests`, and test architecture/strategy via `/bmad-tea` (with `/bmad-testarch-*`) — invoked directly, not via a dispatchable agent.
 
 **Strengths**: Test planning, test execution, regression testing, integration testing, edge case identification.
 
@@ -139,10 +143,10 @@ The following roles represent common capabilities. Actual agent names and activa
 | Init | Analyst | -- | Planning | Assess current state, no implementation |
 | Discovery | Analyst, PM | -- | Planning | Research first, then requirements |
 | Architecture | Architect, PM | Analyst | Planning | Architect designs, PM decomposes into epics |
-| Planning | SM | -- | Planning | Sprint initialization and story creation |
+| Planning | (direct skills) | -- | Planning | Sprint init/story creation via `/bmad-sprint-planning`, `/bmad-create-story` |
 | Execution | DEV | Architect (if needed) | Execution | Core loop: implement, review, fix |
-| Integration | DEV, Architect | QA | Execution | Full review pass + cohesion check |
-| Release | SM | DEV (if fixes needed) | Execution | Retrospective + documentation |
+| Integration | DEV, Architect | (test skills) | Execution | Full review pass + cohesion check; tests via `/bmad-qa-generate-e2e-tests` |
+| Release | (direct skill) | DEV (if fixes needed) | Execution | Retrospective via `/bmad-retrospective` + documentation |
 | Maintenance | DEV | Analyst (if research needed) | Execution | Bug fix or improvement implementation |
 
 ---
@@ -157,10 +161,10 @@ What type of work is this?
       |-- Research / Analysis    -> Analyst
       |-- Requirements / Scope   -> PM
       |-- Design / Architecture  -> Architect
-      |-- Sprint / Planning      -> SM
+      |-- Sprint / Planning      -> direct skills (/bmad-sprint-planning, /bmad-create-story)
       |-- Implementation / Fix   -> DEV
       |-- UI / UX Design         -> UX Designer
-      |-- Testing / QA           -> QA
+      |-- Testing / QA           -> direct skills (/bmad-qa-generate-e2e-tests, /bmad-tea)
       |
 Is the agent available in current team config?
       |

--- a/_ai-memory/pov/skills/aim-model-dispatch/evals/evals.json
+++ b/_ai-memory/pov/skills/aim-model-dispatch/evals/evals.json
@@ -5,7 +5,7 @@
       "id": 1,
       "name": "bmad-review-openrouter",
       "prompt": "dispatch a code review to openrouter for the file .claude/skills/model-dispatch/scripts/install.sh — use the cheapest model available. Report what the review finds.",
-      "expected_output": "Agent reads the skill, identifies this as a BMAD task, follows bmad-dispatch workflow (not tmux-dispatch), routes code review to the /bmad-bmm-code-review workflow (NOT dev-agent activation), determines OpenRouter backend, presents model options, and dispatches the review workflow in a tmux pane.",
+      "expected_output": "Agent reads the skill, identifies this as a BMAD task, follows bmad-dispatch workflow (not tmux-dispatch), routes code review to the /bmad-code-review workflow (NOT dev-agent activation), determines OpenRouter backend, presents model options, and dispatches the review workflow in a tmux pane.",
       "files": [],
       "assertions": [
         {
@@ -17,11 +17,11 @@
           "type": "workflow_loading"
         },
         {
-          "text": "Agent routed code review to the /bmad-bmm-code-review workflow (NOT /bmad-agent-bmm-dev activation)",
+          "text": "Agent routed code review to the /bmad-code-review workflow (NOT /bmad-agent-dev activation)",
           "type": "agent_resolution"
         },
         {
-          "text": "Agent invoked /bmad-bmm-code-review directly (no CR menu code, no dev-agent two-phase activation)",
+          "text": "Agent invoked /bmad-code-review directly (no CR menu code, no dev-agent two-phase activation)",
           "type": "review_routing"
         },
         {
@@ -50,7 +50,7 @@
           "type": "workflow_routing"
         },
         {
-          "text": "Agent resolved the correct BMAD agent: PM agent with activation command /bmad-agent-bmm-pm",
+          "text": "Agent resolved the correct BMAD agent: PM agent with activation command /bmad-agent-pm",
           "type": "agent_resolution"
         },
         {
@@ -83,7 +83,7 @@
           "type": "workflow_routing"
         },
         {
-          "text": "Agent resolved the correct BMAD agent: Analyst with activation command /bmad-agent-bmm-analyst",
+          "text": "Agent resolved the correct BMAD agent: Analyst with activation command /bmad-agent-analyst",
           "type": "agent_resolution"
         },
         {

--- a/_ai-memory/pov/skills/aim-model-dispatch/references/bmad-agents.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/references/bmad-agents.md
@@ -4,12 +4,12 @@
 
 | Agent Type | Activation Command |
 |---|---|
-| Developer | `/bmad-agent-bmm-dev` |
-| PM (Product Manager) | `/bmad-agent-bmm-pm` |
-| Analyst | `/bmad-agent-bmm-analyst` |
-| Architect | `/bmad-agent-bmm-architect` |
-| UX Designer | `/bmad-agent-bmm-ux-designer` |
-| Tech Writer | `/bmad-agent-bmm-tech-writer` |
+| Developer | `/bmad-agent-dev` |
+| PM (Product Manager) | `/bmad-agent-pm` |
+| Analyst | `/bmad-agent-analyst` |
+| Architect | `/bmad-agent-architect` |
+| UX Designer | `/bmad-agent-ux-designer` |
+| Tech Writer | `/bmad-agent-tech-writer` |
 | BMAD Master | `/bmad-agent-bmad-master` |
 | Agent Builder | `/bmad-agent-bmb-agent-builder` |
 | Module Builder | `/bmad-agent-bmb-module-builder` |
@@ -34,7 +34,7 @@ When the task description does not specify an agent:
 | Break down features into stories | PM | `CE` |
 | Design system architecture | Architect | Use menu |
 | Write code / implement a story | DEV | `/bmad-dev-story` (or `DS`) |
-| Review implemented code | Code Review (NOT the dev agent) | `/bmad-bmm-code-review` |
+| Review implemented code | Code Review (NOT the dev agent) | `/bmad-code-review` |
 | Design user flows | UX Designer | Use menu |
 | Write or review documentation | Tech Writer | `WD` |
 | Validate documentation | Tech Writer | `VD` |
@@ -48,10 +48,10 @@ When the user specifies a direct workflow command, map it to two-phase activatio
 
 | Direct Command | Activate Agent | Menu Code |
 |---|---|---|
-| `/bmad-bmm-code-review` | (direct review workflow — no dev-agent activation) | — |
-| `/bmad-dev-story` | `/bmad-agent-bmm-dev` | `DS` |
-| `/bmad-create-prd` | `/bmad-agent-bmm-pm` | `CP` |
-| `/bmad-validate-prd` | `/bmad-agent-bmm-pm` | `VP` |
-| `/bmad-create-epics-and-stories` | `/bmad-agent-bmm-pm` | `CE` |
-| `/bmad-create-architecture` | `/bmad-agent-bmm-architect` | Use menu |
-| `/bmad-create-ux-design` | `/bmad-agent-bmm-ux-designer` | Use menu |
+| `/bmad-code-review` | (direct review workflow — no dev-agent activation) | — |
+| `/bmad-dev-story` | `/bmad-agent-dev` | `DS` |
+| `/bmad-create-prd` | `/bmad-agent-pm` | `CP` |
+| `/bmad-validate-prd` | `/bmad-agent-pm` | `VP` |
+| `/bmad-create-epics-and-stories` | `/bmad-agent-pm` | `CE` |
+| `/bmad-create-architecture` | `/bmad-agent-architect` | Use menu |
+| `/bmad-ux` | `/bmad-agent-ux-designer` | Use menu |

--- a/_ai-memory/pov/skills/aim-model-dispatch/references/bmad-agents.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/references/bmad-agents.md
@@ -10,17 +10,6 @@
 | Architect | `/bmad-agent-architect` |
 | UX Designer | `/bmad-agent-ux-designer` |
 | Tech Writer | `/bmad-agent-tech-writer` |
-| BMAD Master | `/bmad-agent-bmad-master` |
-| Agent Builder | `/bmad-agent-bmb-agent-builder` |
-| Module Builder | `/bmad-agent-bmb-module-builder` |
-| Workflow Builder | `/bmad-agent-bmb-workflow-builder` |
-| Brainstorming Coach | `/bmad-agent-cis-brainstorming-coach` |
-| Creative Problem Solver | `/bmad-agent-cis-creative-problem-solver` |
-| Design Thinking Coach | `/bmad-agent-cis-design-thinking-coach` |
-| Innovation Strategist | `/bmad-agent-cis-innovation-strategist` |
-| Presentation Master | `/bmad-agent-cis-presentation-master` |
-| Storyteller | `/bmad-agent-cis-storyteller` |
-| Test Architect (TEA) | `/bmad-agent-tea-tea` |
 
 ## Task-to-Agent Selection Guide
 

--- a/_ai-memory/pov/skills/aim-model-dispatch/references/bmad-agents.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/references/bmad-agents.md
@@ -27,9 +27,6 @@ When the task description does not specify an agent:
 | Design user flows | UX Designer | Use menu |
 | Write or review documentation | Tech Writer | `WD` |
 | Validate documentation | Tech Writer | `VD` |
-| Build new BMAD agents | Agent Builder | Use menu |
-| Build new BMAD modules | Module Builder | Use menu |
-| Build new BMAD workflows | Workflow Builder | Use menu |
 
 ## Direct Command to Agent Mapping
 

--- a/_ai-memory/pov/skills/aim-model-dispatch/references/user-guide.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/references/user-guide.md
@@ -317,16 +317,6 @@ use ollama: Activate tech-writer agent, validate the SKILL.md
 | Analyst | `/bmad-agent-analyst` | Research, analysis |
 | Architect | `/bmad-agent-architect` | Design, architecture |
 | UX Designer | `/bmad-agent-ux-designer` | User flow, design |
-| Agent Builder | `/bmad-agent-bmb-agent-builder` | Create new agents |
-| Module Builder | `/bmad-agent-bmb-module-builder` | Build modules |
-| Workflow Builder | `/bmad-agent-bmb-workflow-builder` | Build workflows |
-| Brainstorming Coach | `/bmad-agent-cis-brainstorming-coach` | Ideation |
-| Creative Problem Solver | `/bmad-agent-cis-creative-problem-solver` | Problem solving |
-| Design Thinking Coach | `/bmad-agent-cis-design-thinking-coach` | Design thinking |
-| Innovation Strategist | `/bmad-agent-cis-innovation-strategist` | Innovation |
-| Presentation Master | `/bmad-agent-cis-presentation-master` | Presentations |
-| Storyteller | `/bmad-agent-cis-storyteller` | Narrative |
-| Tea | `/bmad-agent-tea-tea` | Test Architect (TEA) |
 
 ---
 

--- a/_ai-memory/pov/skills/aim-model-dispatch/references/user-guide.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/references/user-guide.md
@@ -282,21 +282,21 @@ All BMAD tasks use two-phase activation: first the agent persona loads, then you
 ### Code Review
 
 ```
-dispatch to ollama: /bmad-bmm-code-review to review auth module
-send to openrouter with claude-sonnet-4-6: /bmad-bmm-code-review on api/
+dispatch to ollama: /bmad-code-review to review auth module
+send to openrouter with claude-sonnet-4-6: /bmad-code-review on api/
 ```
 
 ### Implement a Story
 
 ```
-dispatch to ollama: Activate /bmad-agent-bmm-dev, then DS for story 1.5
+dispatch to ollama: Activate /bmad-agent-dev, then DS for story 1.5
 use openrouter with openai/gpt-4o: Activate dev agent, DS story-1-6.md
 ```
 
 ### Create PRD
 
 ```
-dispatch to claude: Activate /bmad-agent-bmm-pm, then CP for notification system
+dispatch to claude: Activate /bmad-agent-pm, then CP for notification system
 send to ollama: Activate PM agent, CP to create PRD for billing
 ```
 
@@ -311,12 +311,12 @@ use ollama: Activate tech-writer agent, validate the SKILL.md
 
 | Agent | Command | Use |
 |-------|---------|-----|
-| Dev | `/bmad-agent-bmm-dev` | Code, implementation |
-| PM | `/bmad-agent-bmm-pm` | PRD, epics, planning |
-| Tech Writer | `/bmad-agent-bmm-tech-writer` | Docs, explanation |
-| Analyst | `/bmad-agent-bmm-analyst` | Research, analysis |
-| Architect | `/bmad-agent-bmm-architect` | Design, architecture |
-| UX Designer | `/bmad-agent-bmm-ux-designer` | User flow, design |
+| Dev | `/bmad-agent-dev` | Code, implementation |
+| PM | `/bmad-agent-pm` | PRD, epics, planning |
+| Tech Writer | `/bmad-agent-tech-writer` | Docs, explanation |
+| Analyst | `/bmad-agent-analyst` | Research, analysis |
+| Architect | `/bmad-agent-architect` | Design, architecture |
+| UX Designer | `/bmad-agent-ux-designer` | User flow, design |
 | Agent Builder | `/bmad-agent-bmb-agent-builder` | Create new agents |
 | Module Builder | `/bmad-agent-bmb-module-builder` | Build modules |
 | Workflow Builder | `/bmad-agent-bmb-workflow-builder` | Build workflows |

--- a/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-01-resolve-agent.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-01-resolve-agent.md
@@ -52,9 +52,6 @@ If the task description does not specify an agent, use this selection guide:
 | Design user flows | UX Designer | Use menu |
 | Write or review documentation | Tech Writer | `WD` |
 | Validate documentation | Tech Writer | `VD` |
-| Build new BMAD agents | Agent Builder | Use menu |
-| Build new BMAD modules | Module Builder | Use menu |
-| Build new BMAD workflows | Workflow Builder | Use menu |
 
 **IMPORTANT**: `/bmad-code-review` is a direct review workflow — invoke it directly; do NOT route review through dev-agent two-phase activation. Other direct workflow commands like `/bmad-dev-story` still map to their parent agent + menu code:
 

--- a/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-01-resolve-agent.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-01-resolve-agent.md
@@ -31,12 +31,12 @@ From the task description, determine which BMAD agent is needed.
 
 | Agent Type | Activation Command |
 |---|---|
-| Developer | `/bmad-agent-bmm-dev` |
-| PM (Product Manager) | `/bmad-agent-bmm-pm` |
-| Analyst | `/bmad-agent-bmm-analyst` |
-| Architect | `/bmad-agent-bmm-architect` |
-| UX Designer | `/bmad-agent-bmm-ux-designer` |
-| Tech Writer | `/bmad-agent-bmm-tech-writer` |
+| Developer | `/bmad-agent-dev` |
+| PM (Product Manager) | `/bmad-agent-pm` |
+| Analyst | `/bmad-agent-analyst` |
+| Architect | `/bmad-agent-architect` |
+| UX Designer | `/bmad-agent-ux-designer` |
+| Tech Writer | `/bmad-agent-tech-writer` |
 | BMAD Master | `/bmad-agent-bmad-master` |
 | Agent Builder | `/bmad-agent-bmb-agent-builder` |
 | Module Builder | `/bmad-agent-bmb-module-builder` |
@@ -59,7 +59,7 @@ If the task description does not specify an agent, use this selection guide:
 | Break down features into stories | PM | `CE` |
 | Design system architecture | Architect | Use menu |
 | Write code / implement a story | DEV | `/bmad-dev-story` (or `DS`) |
-| Review implemented code | Code Review (NOT the dev agent) | `/bmad-bmm-code-review` |
+| Review implemented code | Code Review (NOT the dev agent) | `/bmad-code-review` |
 | Design user flows | UX Designer | Use menu |
 | Write or review documentation | Tech Writer | `WD` |
 | Validate documentation | Tech Writer | `VD` |
@@ -67,17 +67,17 @@ If the task description does not specify an agent, use this selection guide:
 | Build new BMAD modules | Module Builder | Use menu |
 | Build new BMAD workflows | Workflow Builder | Use menu |
 
-**IMPORTANT**: `/bmad-bmm-code-review` is a direct review workflow — invoke it directly; do NOT route review through dev-agent two-phase activation. Other direct workflow commands like `/bmad-dev-story` still map to their parent agent + menu code:
+**IMPORTANT**: `/bmad-code-review` is a direct review workflow — invoke it directly; do NOT route review through dev-agent two-phase activation. Other direct workflow commands like `/bmad-dev-story` still map to their parent agent + menu code:
 
 | Direct Command | Activate Agent | Menu Code |
 |---|---|---|
-| `/bmad-bmm-code-review` | (direct review workflow — no dev-agent activation) | — |
-| `/bmad-dev-story` | `/bmad-agent-bmm-dev` | `DS` |
-| `/bmad-create-prd` | `/bmad-agent-bmm-pm` | `CP` |
-| `/bmad-validate-prd` | `/bmad-agent-bmm-pm` | `VP` |
-| `/bmad-create-epics-and-stories` | `/bmad-agent-bmm-pm` | `CE` |
-| `/bmad-create-architecture` | `/bmad-agent-bmm-architect` | Use menu |
-| `/bmad-create-ux-design` | `/bmad-agent-bmm-ux-designer` | Use menu |
+| `/bmad-code-review` | (direct review workflow — no dev-agent activation) | — |
+| `/bmad-dev-story` | `/bmad-agent-dev` | `DS` |
+| `/bmad-create-prd` | `/bmad-agent-pm` | `CP` |
+| `/bmad-validate-prd` | `/bmad-agent-pm` | `VP` |
+| `/bmad-create-epics-and-stories` | `/bmad-agent-pm` | `CE` |
+| `/bmad-create-architecture` | `/bmad-agent-architect` | Use menu |
+| `/bmad-ux` | `/bmad-agent-ux-designer` | Use menu |
 
 ### 2. Determine Backend
 
@@ -140,7 +140,7 @@ After the agent menu appears, what should be sent?
 Each agent menu has items with codes like `[DS]`, `[CR]`, `[CH]`, `[VD]`. Send the code.
 
 Examples:
-- Dev agent: `DS` (Dev Story) — code review routes to `/bmad-bmm-code-review`, not a dev-agent menu code
+- Dev agent: `DS` (Dev Story) — code review routes to `/bmad-code-review`, not a dev-agent menu code
 - Tech Writer: `VD` (Validate Documentation)
 - PM: `CP` (Create PRD), `VP` (Validate PRD), `CE` (Create Epics)
 
@@ -152,7 +152,7 @@ Choose the pattern that best fits the task. Menu codes are more reliable.
 ### 8. Record the Dispatch Plan
 
 Store these values:
-- **AGENT_COMMAND**: The activation command (e.g., `/bmad-agent-bmm-dev`)
+- **AGENT_COMMAND**: The activation command (e.g., `/bmad-agent-dev`)
 - **TASK_INPUT**: The text to send after menu appears (e.g., `DS`)
 - **TASK_FOLLOW_UP**: Any additional input needed later (empty if not known)
 - **AGENT_NAME**: Human-readable name (e.g., `bmad-dev`, `bmad-tech-writer`)

--- a/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-01-resolve-agent.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-01-resolve-agent.md
@@ -37,17 +37,6 @@ From the task description, determine which BMAD agent is needed.
 | Architect | `/bmad-agent-architect` |
 | UX Designer | `/bmad-agent-ux-designer` |
 | Tech Writer | `/bmad-agent-tech-writer` |
-| BMAD Master | `/bmad-agent-bmad-master` |
-| Agent Builder | `/bmad-agent-bmb-agent-builder` |
-| Module Builder | `/bmad-agent-bmb-module-builder` |
-| Workflow Builder | `/bmad-agent-bmb-workflow-builder` |
-| Brainstorming Coach | `/bmad-agent-cis-brainstorming-coach` |
-| Creative Problem Solver | `/bmad-agent-cis-creative-problem-solver` |
-| Design Thinking Coach | `/bmad-agent-cis-design-thinking-coach` |
-| Innovation Strategist | `/bmad-agent-cis-innovation-strategist` |
-| Presentation Master | `/bmad-agent-cis-presentation-master` |
-| Storyteller | `/bmad-agent-cis-storyteller` |
-| Test Architect (TEA) | `/bmad-agent-tea-tea` |
 
 If the task description does not specify an agent, use this selection guide:
 

--- a/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-02-launch-and-activate.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-02-launch-and-activate.md
@@ -109,7 +109,7 @@ sleep 5
 
 ```bash
 # Send the BMAD agent activation command
-# AGENT_COMMAND is from step-01, e.g., "/bmad-agent-bmm-dev"
+# AGENT_COMMAND is from step-01, e.g., "/bmad-agent-dev"
 tmux send-keys -t "$PANE_TARGET" "${AGENT_COMMAND}"
 
 # Pause 2 seconds for the TUI to render

--- a/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-03-detect-ready-and-send-task.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-03-detect-ready-and-send-task.md
@@ -28,7 +28,7 @@ Style A — Legacy universal menu. Contains:
 - `[MH]` — Menu Help
 - `[DA]` — Dismiss Agent
 
-Style B — Custom numbered Intent picker. Contains a "Type something" option literal, typically rendered as a numbered line such as `5. Type something` or similar. The Intent picker appears in newer skills (e.g., `/bmad-agent-bmb-agent-builder`) and does NOT carry the `[MH]`/`[DA]` markers.
+Style B — Custom numbered Intent picker. Contains a "Type something" option literal, typically rendered as a numbered line such as `5. Type something` or similar. The Intent picker appears in skills that render a custom numbered menu (e.g., `Build / Analyze / … / Type something / Chat`) and does NOT carry the `[MH]`/`[DA]` markers.
 
 Detection SUCCESS = Style A matched OR Style B matched.
 
@@ -93,12 +93,12 @@ Only runs when `MENU_STYLE=intent_picker`. Skipped for legacy menus — the lega
 
 BMAD Intent pickers interpret the first non-navigation input as confirmation of the currently-highlighted option. Free-form text has no navigation prefix, so it is treated as confirmation of the wrong option. The dispatch layer must navigate to the "Type something" option first.
 
-For `/bmad-agent-bmb-agent-builder`, "Type something" is option 5 (Build=1, Analyze=2, Edit=3, Rebuild=4, Type something=5, Chat=6). Navigation is four Down presses followed by Enter.
+In a typical Style-B picker, "Type something" sits partway down the list — for example option 5 of a `Build=1, Analyze=2, Edit=3, Rebuild=4, Type something=5, Chat=6` menu, reached by four Down presses followed by Enter. The actual offset is detected dynamically (below), so this is only the fallback default.
 
 ```bash
 if [ "$MENU_STYLE" = "intent_picker" ]; then
   # Count the offset to the "Type something" option
-  # For bmad-agent-bmb-agent-builder the literal is at option 5 → 4 Down presses
+  # Fallback default: in a typical Style-B picker the literal is at option 5 → 4 Down presses
   DOWN_COUNT=4
 
   # Derive dynamically from pane text if possible; fall back to default

--- a/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-03-detect-ready-and-send-task.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/workflows/bmad-dispatch/steps/step-03-detect-ready-and-send-task.md
@@ -30,6 +30,8 @@ Style A — Legacy universal menu. Contains:
 
 Style B — Custom numbered Intent picker. Contains a "Type something" option literal, typically rendered as a numbered line such as `5. Type something` or similar. The Intent picker appears in skills that render a custom numbered menu (e.g., `Build / Analyze / … / Type something / Chat`) and does NOT carry the `[MH]`/`[DA]` markers.
 
+> Note: as of BMAD v6.9.0, no skill in the installed SOT presents a Style-B Intent picker (it originated in the now-removed bmb module). The Style-B detection and navigation below are retained defensively but are likely a dead branch — a candidate for future cleanup.
+
 Detection SUCCESS = Style A matched OR Style B matched.
 
 Poll the pane every 2 seconds for up to 20 seconds (10 attempts). Step-02 already waits ~10 seconds for initialization, so the menu typically appears on the first or second check:

--- a/_ai-memory/pov/skills/aim-model-dispatch/workflows/claude-native/workflow.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/workflows/claude-native/workflow.md
@@ -36,7 +36,7 @@ EC-01, EC-04, EC-05, EC-06, EC-09, EC-10
 - Rule 4: CWD must be project root (document_pipeline/) before spawn — NEVER DocIntel/
 - Rule 5: /bmad-code-review for reviews, /bmad-agent-dev for implementation only
 - Rule 6: Dual review mandatory (Sonnet + Opus)
-- Rule 7: One story per SM dispatch — shutdown after each
+- Rule 7: One story per story-creation dispatch — shutdown after each
 - Rule 8: Don't rush-nudge idle agents
 - Rule 9: Two-phase BMAD activation (activate → wait for idle → send instruction)
 - Rule 11: ALWAYS include explicit story ID + file list in instruction

--- a/_ai-memory/pov/skills/aim-model-dispatch/workflows/claude-native/workflow.md
+++ b/_ai-memory/pov/skills/aim-model-dispatch/workflows/claude-native/workflow.md
@@ -34,7 +34,7 @@ EC-01, EC-04, EC-05, EC-06, EC-09, EC-10
 **Process Rules (project-status.md):**
 - Rule 3: Fresh agents for EVERY role — never reuse across tasks
 - Rule 4: CWD must be project root (document_pipeline/) before spawn — NEVER DocIntel/
-- Rule 5: /bmad-bmm-code-review for reviews, /bmad-agent-bmm-dev for implementation only
+- Rule 5: /bmad-code-review for reviews, /bmad-agent-dev for implementation only
 - Rule 6: Dual review mandatory (Sonnet + Opus)
 - Rule 7: One story per SM dispatch — shutdown after each
 - Rule 8: Don't rush-nudge idle agents
@@ -162,7 +162,7 @@ Agent:
   model: opus
   mode: plan
   run_in_background: true
-  prompt: "/bmad-agent-bmm-architect"
+  prompt: "/bmad-agent-architect"
 ```
 
 Teammate sends plan_approval_request when ready. Lead reviews and approves or rejects with feedback.
@@ -219,7 +219,7 @@ Agent:
   model: sonnet
   mode: bypassPermissions
   run_in_background: true
-  prompt: "/bmad-agent-bmm-dev"
+  prompt: "/bmad-agent-dev"
 
 # Wait for idle (persona loaded, menu shown)
 
@@ -255,7 +255,7 @@ Agent:
   model: sonnet
   mode: bypassPermissions
   run_in_background: true
-  prompt: "/bmad-bmm-code-review"
+  prompt: "/bmad-code-review"
 
 Agent:
   name: "review-opus"
@@ -263,7 +263,7 @@ Agent:
   model: opus
   mode: bypassPermissions
   run_in_background: true
-  prompt: "/bmad-bmm-code-review"
+  prompt: "/bmad-code-review"
 
 # After both load, send the review instruction directly (review workflow takes it — no CR menu code)
 SendMessage:
@@ -301,7 +301,7 @@ Agent:
   model: sonnet
   mode: bypassPermissions
   run_in_background: true
-  prompt: "/bmad-agent-bmm-dev"
+  prompt: "/bmad-agent-dev"
 
 Agent:
   name: "dev-services"
@@ -309,7 +309,7 @@ Agent:
   model: sonnet
   mode: bypassPermissions
   run_in_background: true
-  prompt: "/bmad-agent-bmm-dev"
+  prompt: "/bmad-agent-dev"
 
 Agent:
   name: "dev-observability"
@@ -317,7 +317,7 @@ Agent:
   model: sonnet
   mode: bypassPermissions
   run_in_background: true
-  prompt: "/bmad-agent-bmm-dev"
+  prompt: "/bmad-agent-dev"
 
 # After idle, send instructions — each owns different files
 ```

--- a/_ai-memory/pov/skills/aim-parzival-team-builder/SKILL.md
+++ b/_ai-memory/pov/skills/aim-parzival-team-builder/SKILL.md
@@ -55,7 +55,7 @@ provider: claude
 model: claude-sonnet-4-6
 agent: dev
 agent_id: dev-auth
-bmad_agent_type: bmm-dev
+bmad_agent_type: dev
 task_summary: "Implement Story 4.2 password-reset endpoint"
 files:
   - /abs/path/src/auth/reset.py
@@ -88,9 +88,9 @@ not collapse to prose.
 # Dispatch Plan v1
 provider: claude | openrouter | ollama | gemini | deepseek | groq | cerebras | mistral | openai | vertex-ai | siliconflow
 model: <exact-model-id-string>       # verbatim, e.g., "glm-5.1:cloud", "claude-sonnet-4-6"
-agent: <role-name>                   # dev | sm | pm | architect | analyst | ux-designer | qa | tech-writer | code-reviewer | <generic>
-agent_id: <AI_MEMORY_AGENT_ID>       # e.g., "dev-auth", "review-opus", "sm-sprint-2"
-bmad_agent_type: <bmm-agent>         # intended BMAD agent type: bmm-dev | bmm-sm | bmm-pm | bmm-architect | bmm-analyst | bmm-ux-designer | bmm-qa | bmm-tech-writer | null (null for generic, non-BMAD agents)
+agent: <role-name>                   # dev | pm | architect | analyst | ux-designer | tech-writer | code-reviewer | <generic>
+agent_id: <AI_MEMORY_AGENT_ID>       # e.g., "dev-auth", "review-opus", "architect-design"
+bmad_agent_type: <agent-type>        # intended BMAD agent type: dev | pm | architect | analyst | ux-designer | tech-writer | null (null for generic, non-BMAD agents)
 task_summary: <one-line>
 files:
   - <absolute-path-1>
@@ -149,7 +149,7 @@ Before running the full 6-step design process, check if the work matches a prese
 **When**: Completed stories need automated test coverage
 **Structure**: 2-tier — Architect Lead (Opus) → 2 test workers (Sonnet, run `/bmad-qa-generate-e2e-tests`)
 **Workflow commands**: Workers run `/bmad-qa-generate-e2e-tests` — generates automated API and E2E tests for completed story implementations
-**Requires**: sprint-status.yaml, TEA module installed
+**Requires**: sprint-status.yaml, bmm + tea modules installed
 **Customize**: which stories to test, test framework
 
 ### Preset: Architecture Review (`architecture-review`)
@@ -177,7 +177,7 @@ Models: [role defaults or overrides]
 Stories/Tasks: [customized assignments]
 File Ownership: [per-worker paths]
 Workflow Commands: [per-worker commands]
-BMAD Agent Types: [per-worker bmad_agent_type, e.g. bmm-dev, bmm-sm; null for generic]
+BMAD Agent Types: [per-worker bmad_agent_type, e.g. dev, pm; null for generic]
 Requires: [prerequisites — verify they exist]
 Approve?
 ```
@@ -217,7 +217,7 @@ Store provider and model selections in the dispatch plan.
 
 ### Step 2: Team Composition
 
-1. Assign agent roles from available BMAD agents (analyst, pm, architect, dev, sm, ux-designer)
+1. Assign agent roles from available BMAD agents (analyst, pm, architect, dev, ux-designer, tech-writer)
 2. Size teams: 3-5 teammates recommended, 5-6 tasks per teammate for productive sizing
 3. **Assign agent identity**: Each agent MUST have a unique `AI_MEMORY_AGENT_ID`:
    - **Domain-named** (recommended): `dev-auth`, `dev-api`, `review-auth` -- same agent always works on same domain
@@ -250,7 +250,7 @@ A sparse NxN matrix wastes tokens on columns of "—" entries. The assignment li
 
 For each agent, prepare:
 - ROLE: Agent type and assigned identity (AI_MEMORY_AGENT_ID)
-- BMAD AGENT TYPE: Intended BMAD agent type (`bmad_agent_type`), e.g. bmm-dev; null for generic, non-BMAD agents
+- BMAD AGENT TYPE: Intended BMAD agent type (`bmad_agent_type`), e.g. dev; null for generic, non-BMAD agents
 - TASK: Specific work items with acceptance criteria
 - FILES: Owned files (absolute paths)
 - CONSTRAINTS: "DO NOT modify any files outside your SCOPE list." — do not enumerate every other agent's files; the ownership map in Step 3 is the source of truth
@@ -310,4 +310,4 @@ Parzival activates all agents himself — the user does not run agents.
 **MANDATORY NEXT STEP**: After user approves the dispatch plan:
 - All agents (BMAD and generic) → /aim-agent-dispatch
 
-Pass the full Dispatch Plan object verbatim — including exact model ID, full file list, `agent_id`, and `bmad_agent_type` (see `Dispatch Plan Schema`). Downstream skills re-emit the plan for round-trip verification. (`bmad_agent_type` identifies the intended BMAD agent type, e.g. bmm-dev; null for generic agents.)
+Pass the full Dispatch Plan object verbatim — including exact model ID, full file list, `agent_id`, and `bmad_agent_type` (see `Dispatch Plan Schema`). Downstream skills re-emit the plan for round-trip verification. (`bmad_agent_type` identifies the intended BMAD agent type, e.g. dev; null for generic agents.)

--- a/_ai-memory/pov/skills/aim-parzival-team-builder/SKILL.md
+++ b/_ai-memory/pov/skills/aim-parzival-team-builder/SKILL.md
@@ -134,35 +134,35 @@ Before running the full 6-step design process, check if the work matches a prese
 ### Preset: Sprint Development (`sprint-dev`)
 **When**: 2-3 stories need parallel implementation with code review
 **Structure**: 2-tier — SM Lead (Opus) → 2 DEV workers (Sonnet) + 1 DEV reviewer (Opus)
-**Workflow commands**: Workers run `/bmad-bmm-dev-story`, reviewer runs `/bmad-bmm-code-review`
+**Workflow commands**: Workers run `/bmad-dev-story`, reviewer runs `/bmad-code-review`
 **Requires**: sprint-status.yaml, architecture doc
 **Customize**: story assignments, file ownership per story
 
 ### Preset: Story Preparation (`story-prep`)
 **When**: Multiple stories need to be created from epics in bulk
 **Structure**: 2-tier — PM Lead (Opus) → 2-3 SM story creators (Sonnet)
-**Workflow commands**: Workers run `/bmad-bmm-create-story`
+**Workflow commands**: Workers run `/bmad-create-story`
 **Requires**: epics doc, sprint-status.yaml
 **Customize**: which stories to create, epic references
 
 ### Preset: Test Automation (`test-automation`)
 **When**: Completed stories need automated test coverage
 **Structure**: 2-tier — TEA Lead (Opus) → 2 QA workers (Sonnet)
-**Workflow commands**: Workers run `/bmad-bmm-qa-generate-e2e-tests` — generates automated API and E2E tests for completed story implementations
+**Workflow commands**: Workers run `/bmad-qa-generate-e2e-tests` — generates automated API and E2E tests for completed story implementations
 **Requires**: sprint-status.yaml, TEA module installed
 **Customize**: which stories to test, test framework
 
 ### Preset: Architecture Review (`architecture-review`)
 **When**: Pre-sprint architecture work with parallel research
 **Structure**: 2-tier — Architect Lead (Opus) → Analyst worker (Sonnet) + UX Designer worker (Sonnet)
-**Workflow commands**: Analyst runs `/bmad-bmm-technical-research`, UX runs `/bmad-bmm-create-ux-design`
+**Workflow commands**: Analyst runs `/bmad-technical-research`, UX runs `/bmad-ux`
 **Requires**: PRD
 **Customize**: research focus areas, UX scope
 
 ### Preset: Research (`research`)
 **When**: Phase 1 parallel research across market, domain, and technical
 **Structure**: 2-tier — Analyst Lead (Opus) → 3 Analyst workers (Sonnet)
-**Workflow commands**: `/bmad-bmm-market-research`, `/bmad-bmm-domain-research`, `/bmad-bmm-technical-research`
+**Workflow commands**: `/bmad-market-research`, `/bmad-domain-research`, `/bmad-technical-research`
 **Requires**: Nothing (recommended: project-context.md)
 **Customize**: research focus, industry, technology areas
 

--- a/_ai-memory/pov/skills/aim-parzival-team-builder/SKILL.md
+++ b/_ai-memory/pov/skills/aim-parzival-team-builder/SKILL.md
@@ -133,21 +133,21 @@ Before running the full 6-step design process, check if the work matches a prese
 
 ### Preset: Sprint Development (`sprint-dev`)
 **When**: 2-3 stories need parallel implementation with code review
-**Structure**: 2-tier — SM Lead (Opus) → 2 DEV workers (Sonnet) + 1 DEV reviewer (Opus)
+**Structure**: Parzival-coordinated — 2 DEV workers (Sonnet) + 1 DEV reviewer (Opus)
 **Workflow commands**: Workers run `/bmad-dev-story`, reviewer runs `/bmad-code-review`
 **Requires**: sprint-status.yaml, architecture doc
 **Customize**: story assignments, file ownership per story
 
 ### Preset: Story Preparation (`story-prep`)
 **When**: Multiple stories need to be created from epics in bulk
-**Structure**: 2-tier — PM Lead (Opus) → 2-3 SM story creators (Sonnet)
+**Structure**: 2-tier — PM Lead (Opus) → 2-3 story-creator workers (Sonnet, run `/bmad-create-story`)
 **Workflow commands**: Workers run `/bmad-create-story`
 **Requires**: epics doc, sprint-status.yaml
 **Customize**: which stories to create, epic references
 
 ### Preset: Test Automation (`test-automation`)
 **When**: Completed stories need automated test coverage
-**Structure**: 2-tier — TEA Lead (Opus) → 2 QA workers (Sonnet)
+**Structure**: 2-tier — Architect Lead (Opus) → 2 test workers (Sonnet, run `/bmad-qa-generate-e2e-tests`)
 **Workflow commands**: Workers run `/bmad-qa-generate-e2e-tests` — generates automated API and E2E tests for completed story implementations
 **Requires**: sprint-status.yaml, TEA module installed
 **Customize**: which stories to test, test framework
@@ -227,7 +227,7 @@ Store provider and model selections in the dispatch plan.
    - Naming rules: domain-named agents always work the same domain/files across sessions; numbered agents are interchangeable for generic parallel work; single-instance agents use role name directly
 4. Select models per agent role:
    - Planning agents (Analyst, PM, Architect): Opus
-   - Execution agents (DEV, SM, QA, review): Sonnet
+   - Execution agents (DEV, review): Sonnet
    - Simple/high-volume tasks: Haiku
    Present defaults to user. Apply overrides if user requests.
 

--- a/_ai-memory/pov/skills/aim-parzival-team-builder/SKILL.md
+++ b/_ai-memory/pov/skills/aim-parzival-team-builder/SKILL.md
@@ -133,14 +133,14 @@ Before running the full 6-step design process, check if the work matches a prese
 
 ### Preset: Sprint Development (`sprint-dev`)
 **When**: 2-3 stories need parallel implementation with code review
-**Structure**: Parzival-coordinated — 2 DEV workers (Sonnet) + 1 DEV reviewer (Opus)
+**Structure**: 2-tier — PM Lead (Opus) → 2 DEV workers (Sonnet) + 1 DEV reviewer (Opus)
 **Workflow commands**: Workers run `/bmad-dev-story`, reviewer runs `/bmad-code-review`
 **Requires**: sprint-status.yaml, architecture doc
 **Customize**: story assignments, file ownership per story
 
 ### Preset: Story Preparation (`story-prep`)
 **When**: Multiple stories need to be created from epics in bulk
-**Structure**: 2-tier — PM Lead (Opus) → 2-3 story-creator workers (Sonnet, run `/bmad-create-story`)
+**Structure**: 2-tier — PM Lead (Opus) → 2-3 story-creation workers (Sonnet, run `/bmad-create-story`)
 **Workflow commands**: Workers run `/bmad-create-story`
 **Requires**: epics doc, sprint-status.yaml
 **Customize**: which stories to create, epic references

--- a/_ai-memory/pov/workflows/cycles/agent-dispatch/steps-c/step-03-activate-agent.md
+++ b/_ai-memory/pov/workflows/cycles/agent-dispatch/steps-c/step-03-activate-agent.md
@@ -33,7 +33,7 @@ Use the appropriate agent activation command within the teammate context:
 - PM: /bmad-agent-pm
 - Architect: /bmad-agent-architect
 - UX Designer: /bmad-agent-ux-designer
-- SM: /bmad-agent-sm (NOT INSTALLED -- 2026-04-11)
+- Sprint/story/retro: direct skills /bmad-sprint-planning, /bmad-create-story, /bmad-retrospective (no SM agent in v6.9.0)
 - DEV (implementation): /bmad-agent-dev
 - DEV (code review): /bmad-code-review
 - Tech Writer: /bmad-agent-tech-writer

--- a/_ai-memory/pov/workflows/phases/planning/instructions.md
+++ b/_ai-memory/pov/workflows/phases/planning/instructions.md
@@ -9,7 +9,7 @@ description: 'Planning phase: review state, run retrospective, dispatch SM for s
 ## Prerequisites
 
 - Approved architecture and epics/stories from the architecture phase
-- Sprint Master agent (`bmad-agent-sm`) is available (NOT INSTALLED — 2026-04-11)
+- Sprint planning and story creation are available via direct skills (`/bmad-sprint-planning`, `/bmad-create-story`)
 - `sprint-status.yaml` is accessible for update
 - Prior sprint retrospective data is available (if this is not the first sprint)
 


### PR DESCRIPTION
## What
Aligns the Parzival oversight (POV) dispatch documentation with the canonical BMAD **v6.9.0** command surface:
- Drops the `bmm-` module infix from agent/skill command names; applies real renames (`create-ux-design` → `bmad-ux`, `create-product-brief` → `bmad-product-brief`).
- Removes agents that no longer exist in v6.9.0 (Scrum Master, QA, Quick Flow Solo Dev, the builder/`bmb` agents, the creative/`cis` coach agents, BMAD Master, and the `tea` agent form) from the dispatch tables, selection matrix, selection guide, and team-builder presets.
- Remaps the still-existing capabilities to their v6.9.0 direct skills (`bmad-sprint-planning`, `bmad-create-story`, `bmad-retrospective`, `bmad-qa-generate-e2e-tests`, `bmad-tea`/`bmad-testarch-*`, `bmad-quick-dev`).
- Reconciles the team-builder Dispatch Plan Schema enums (`agent`, `bmad_agent_type`) to the v6.9.0 roster.

## Why
A live test surfaced that the dispatch docs referenced BMAD commands that do not exist in v6.9.0 (the go-forward standard), which would route dispatch to non-existent agents. v6.9.0 is a model change — six core agents plus direct skills — not a simple rename.

## Scope
Documentation only (POV dispatch docs + the model-dispatch evals fixture). No `src/`, no `CHANGELOG`, no version files. The broader "Scrum-Master-as-dispatchable-agent" workflow model in the phase step-files is a separate, larger reconciliation tracked as follow-up tech debt.

## Verification
Command names verified against a fresh v6.9.0 install; full-tree name+token census confirms zero remaining references to removed agents.

_Held: do not merge until the v2.8.1 tag sequence._
