### PR TITLE
[e2e] deps: bump fastapi to 0.138.0, resolving starlette to 1.3.1 (TD-757)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bumped dependency constraints: `structlog` `<26.0.0` → `<27.0.0` (resolves 26.1.0), `pytest-randomly` `<4.0.0` → `<5.0.0` (resolves 4.1.0), `click` `>=8.2.1` → `>=8.4.1`, `typer` `>=0.12.0` → `>=0.26.7`, `actions/cache` `v5` → `v6` (CI-only).
+- Bumped `fastapi` `0.128.0` → `0.138.0`, which resolves `starlette` `0.50.0` → `1.3.1`, clearing 5 open starlette Dependabot advisories. `ruff` and the streamlit `structlog` constraint updated to match.
 
 ## [2.8.2] - 2026-06-30
 

--- a/docker/embedding/requirements.txt
+++ b/docker/embedding/requirements.txt
@@ -3,7 +3,7 @@
 # All versions pinned per ACT-003
 
 # Core FastAPI dependencies
-fastapi[standard]==0.128.0
+fastapi[standard]==0.138.0
 pydantic==2.12.5
 pydantic-settings==2.14.2
 

--- a/docker/streamlit/requirements.txt
+++ b/docker/streamlit/requirements.txt
@@ -9,7 +9,7 @@ httpx==0.28.1
 # Required by memory module import chain (memory/__init__.py)
 # BUG-091: Same class of bug as github-sync missing deps
 anthropic>=0.89.0,<1.0.0
-structlog>=24.0.0,<26.0.0
+structlog>=24.0.0,<27.0.0
 pydantic==2.12.5
 pydantic-settings==2.14.2
 tenacity==9.1.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ dev = [
     # fastapi pinned to match the shipped image (docker/embedding/requirements.txt:
     # fastapi[standard]==0.138.0); only the framework + TestClient are needed here, not
     # the [standard] server stack. httpx is required by fastapi.testclient.TestClient.
-    "fastapi==0.128.0",
+    "fastapi==0.138.0",
     "httpx>=0.27,<1.0",
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ playwright==1.60.0
 
 # Code Quality
 black==26.5.1
-ruff==0.15.19
+ruff==0.15.20
 isort>=5.13.0,<9.0.0
 mypy==1.20.0
 

--- a/uv.lock
+++ b/uv.lock
@@ -82,7 +82,7 @@ requires-dist = [
     { name = "croniter", specifier = ">=2.0.0,<7.0.0" },
     { name = "detect-secrets", marker = "extra == 'dev'", specifier = ">=1.4.0" },
     { name = "en-core-web-sm", url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" },
-    { name = "fastapi", marker = "extra == 'dev'", specifier = "==0.128.0" },
+    { name = "fastapi", marker = "extra == 'dev'", specifier = "==0.138.0" },
     { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27,<1.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.0.0,<7.0.0" },
@@ -806,17 +806,18 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.128.0"
+version = "0.138.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", hash = "sha256:1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a", size = 365682, upload-time = "2025-12-27T15:21:13.714Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/58/ff455d9fe47c60abadb34b9e05a304b1f05f5ab8000ac01565156b6f5e43/fastapi-0.138.0.tar.gz", hash = "sha256:d445a4877636ad191e7053e08c9bf98cb921a6756776848400bb773d1740c061", size = 419240, upload-time = "2026-06-20T01:18:05.259Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", hash = "sha256:aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d", size = 103094, upload-time = "2025-12-27T15:21:12.154Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ff/8496d9847a5fedae775eb49460722d3efaa80487854273e9647ae876218c/fastapi-0.138.0-py3-none-any.whl", hash = "sha256:b6f54fd1bd72c80b0f899f172c61a600f6f7af9b43d4d772a018f35624048cb0", size = 126779, upload-time = "2026-06-20T01:18:03.483Z" },
 ]
 
 [[package]]
@@ -3379,15 +3380,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.50.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `fastapi` 0.128.0 → 0.138.0 across `pyproject.toml` and `docker/embedding/requirements.txt`. fastapi 0.138.x dropped its starlette upper-bound (now `starlette>=0.46.0`), which lets the resolver pick up starlette 1.3.1 — clearing 5 open starlette Dependabot advisories.
- Coordinated hygiene: `ruff` 0.15.19 → 0.15.20 (`requirements-dev.txt`), streamlit `structlog` constraint `<26.0.0` → `<27.0.0` (`docker/streamlit/requirements.txt`).
- `uv.lock` re-resolved: `fastapi` 0.128.0→0.138.0, `starlette` 0.50.0→1.3.1. No other package versions changed.

This is a starlette 0.x→1.x MAJOR bump. Build-only PR — no image rebuild, no merge.

## Test plan
- [x] Clean `.[dev]` venv install, confirmed `fastapi==0.138.0` / `starlette==1.3.1` live.
- [x] `tests/test_embedding_requirements_parity.py` — 3 passed.
- [x] Full suite: 5047 passed, 664 skipped, 12 failed. All 12 failures reproduce identically against unmodified `origin/main` (control venv, fastapi 0.128.0/starlette 0.50.0) — pre-existing, unrelated to this bump (8 are order-dependent test-leak per TD-592; 4 in `test_langfuse_stop_hook.py` are a pre-existing subprocess-timeout flake, confirmed via isolated control run).
- [ ] CI `[e2e]` job green (pending).