### PR TITLE
pov: per-initiative living-plan lifecycle (template + start gate + closeout audit)

### DIFF
--- a/_ai-memory/pov/constraints/execution/EC-11-plan-gate-before-initiative-dispatch.md
+++ b/_ai-memory/pov/constraints/execution/EC-11-plan-gate-before-initiative-dispatch.md
@@ -1,0 +1,52 @@
+---
+id: EC-11
+name: No Initiative Task-Dispatch Without an Approved Active Plan
+severity: HIGH
+phase: execution
+---
+
+# EC-11: No Initiative Task-Dispatch Without an Approved Active Plan
+
+## Constraint
+
+No task may be dispatched for an **initiative** unless an approved (or active) per-initiative plan exists for it. The gate is **proportionate — it triggers on scope, never on effort or time**.
+
+## Explanation
+
+WHY THIS EXISTS:
+- An initiative dispatched with no plan executes into a vacuum: no agreed done-condition, no forward checklist, no continuity chain.
+- The plan is the one place the what/why + done-condition + forward checklist live (per-initiative, forward-looking). Dispatching without it means those are improvised per session.
+
+PROPORTIONATE ROUTER (classify by scope):
+- **SKIP the gate** (no plan required): one-file / single-surface / reversible / reactive one-off / pure discussion or status.
+- **REQUIRE an approved plan**: multi-file / multi-surface, uncertain approach, a verification / research / ops initiative, multi-session, or work touching the runtime-under-test.
+
+WHEN A PLAN IS REQUIRED BUT ABSENT:
+- Drafting a plan and getting user approval is the FIRST action — ahead of any task dispatch.
+- The plan uses `PLAN_TEMPLATE.md`, saved as `{oversight_path}/plans/PLAN-<SLUG>-<YYYY-MM-DD>.md`, and must reach `status: approved | active` before dispatch.
+
+## Examples
+
+**Permitted**:
+- Dispatching an initiative only after its plan is `approved`/`active`
+- Skipping the gate for a typo fix, a tracker flip, or a single-surface reversible change
+
+**Never permitted**:
+- Dispatching a multi-surface / multi-session initiative with no approved plan
+- Treating "it's a small amount of effort" as grounds to skip the gate (the gate is scope-based, not effort-based)
+
+## Cross-Reference
+
+- GC-15 (template usage) — governs which template the plan is created from.
+- EC-04 (no scope expansion) — EC-11 gates dispatch on an approved plan; EC-04 keeps work inside that plan's scope thereafter.
+- `session/start` step-02b (plan-bearings) evaluates this gate at session start; `session/close` step-02b updates the plan at close.
+
+## Enforcement
+
+Parzival self-checks at every 10-message interval: "For any initiative-scale work, is there an approved/active plan before I dispatch tasks?"
+
+## Violation Response
+
+1. Halt dispatch immediately
+2. Draft the plan from `PLAN_TEMPLATE.md` and get user approval
+3. Resume dispatch only once the plan is `approved | active`

--- a/_ai-memory/pov/constraints/execution/constraints.md
+++ b/_ai-memory/pov/constraints/execution/constraints.md
@@ -33,6 +33,7 @@ Execution is the most constraint-dense phase because it is the most frequent. Ev
 | EC-08 | Security Requirements Must Be Addressed for All Applicable Stories | CRITICAL |
 | EC-09 | Sprint Status Must Be Updated After Every Story State Transition | MEDIUM |
 | EC-10 | Observability Requirements for New Code | HIGH |
+| EC-11 | No Initiative Task-Dispatch Without an Approved Active Plan | HIGH |
 
 **Note**: EC-02 (Use Instruction Template) has been moved to the aim-agent-dispatch skill as a Layer 3 constraint. It applies during agent dispatch, not as a phase constraint.
 
@@ -49,6 +50,7 @@ Run this checklist after every 10 messages during Execution:
 - EC-08: Have security requirements been addressed for applicable stories?
 - EC-09: Is sprint-status.yaml current after every state transition?
 - EC-10: Does the current story involve new scripts, services, or features? If yes, have I included observability requirements in agent instructions?
+- EC-11: For any initiative-scale work, is there an approved/active plan before I dispatch tasks?
 
 PLUS all 21 global constraint checks from global/constraints.md
 
@@ -67,3 +69,4 @@ IF ANY CHECK FAILS: Course-correct IMMEDIATELY before continuing.
 | EC-08: Security requirements skipped | CRITICAL | Run security checklist, fix all gaps |
 | EC-09: sprint-status.yaml not updated on transition | MEDIUM | Update immediately, verify accuracy |
 | EC-10: New code without observability requirements | HIGH | Add observability checklist to agent instructions, verify compliance |
+| EC-11: Initiative dispatched without an approved plan | HIGH | Halt dispatch, draft plan from PLAN_TEMPLATE.md, get approval |

--- a/_ai-memory/pov/constraints/global/GC-15-template-usage.md
+++ b/_ai-memory/pov/constraints/global/GC-15-template-usage.md
@@ -22,11 +22,13 @@ be referenced across sessions.
 | Root cause analysis | `{oversight_path}/bugs/ROOT_CAUSE_TEMPLATE.md` |
 | Complex fix spec (>2 sub-issues or >2 files) | `{oversight_path}/specs/FIX_SPEC_TEMPLATE.md` |
 | Architectural decision record | `{oversight_path}/decisions/DECISION_TEMPLATE.md` |
-| Plan (major initiative) | `{oversight_path}/plans/PLAN_TEMPLATE.md` |
+| Per-initiative plan (living plan + checklist) | `{oversight_path}/plans/PLAN_TEMPLATE.md` |
 | System audit | `{oversight_path}/audits/AUDIT_TEMPLATE.md` |
 | Validation report | `{oversight_path}/validation/VALIDATION_TEMPLATE.md` |
 | Verification report | `{oversight_path}/verification/checklists/` (story/code/production) |
 | Fix verification | `{project-root}/_ai-memory/pov/templates/verification-fix.template.md` |
+
+> Plans are **per-initiative**: one living plan per initiative, saved as `{oversight_path}/plans/PLAN-<SLUG>-<YYYY-MM-DD>.md` from `PLAN_TEMPLATE.md`, chained to its predecessor via the `previous_plan` front-matter field. Drafting one is gated proportionately (by scope, not effort) — see EC-11 (execution) and MC-09 (maintenance).
 
 ## Applies To
 

--- a/_ai-memory/pov/constraints/maintenance/MC-09-plan-gate-when-fix-becomes-initiative.md
+++ b/_ai-memory/pov/constraints/maintenance/MC-09-plan-gate-when-fix-becomes-initiative.md
@@ -1,0 +1,52 @@
+---
+id: MC-09
+name: Maintenance Work That Grows Into an Initiative Requires an Approved Plan
+severity: HIGH
+phase: maintenance
+---
+
+# MC-09: Maintenance Work That Grows Into an Initiative Requires an Approved Plan
+
+## Constraint
+
+A reactive maintenance fix does not need a plan. But the moment maintenance work crosses into **initiative scope**, no further task dispatch may occur without an approved (or active) per-initiative plan. The gate is **proportionate — it triggers on scope, never on effort or time**.
+
+## Explanation
+
+WHY THIS EXISTS:
+- Maintenance is the most scope-unstable phase: fixes look simple, then sprawl across surfaces and sessions. Once that happens the work is an initiative, and an initiative dispatched with no plan executes into a vacuum.
+
+PROPORTIONATE ROUTER (classify by scope):
+- **SKIP the gate** (no plan required): a reactive one-off — single-surface, reversible fix scoped to one issue.
+- **REQUIRE an approved plan**: the fix turns multi-file / multi-surface, the approach is uncertain, it spans multiple sessions, or it touches the runtime-under-test.
+
+WHEN A PLAN IS REQUIRED BUT ABSENT:
+- Stop dispatching. Draft a plan and get user approval first — this pairs with MC-03 (new feature requests route to Planning): initiative-scale maintenance routes through a plan, not deeper into ad-hoc maintenance.
+- The plan uses `PLAN_TEMPLATE.md`, saved as `{oversight_path}/plans/PLAN-<SLUG>-<YYYY-MM-DD>.md`, and must reach `status: approved | active` before dispatch.
+
+## Examples
+
+**Permitted**:
+- Fixing a single-surface reactive bug with no plan
+- Pausing an expanding fix to draft and approve a plan before continuing
+
+**Never permitted**:
+- Letting a fix grow into a multi-surface, multi-session effort with no approved plan
+- Justifying skipping the gate because the remaining effort "feels small" (the gate is scope-based, not effort-based)
+
+## Cross-Reference
+
+- MC-03 (new features route to Planning) — the routing companion: initiative-scale work leaves ad-hoc maintenance.
+- MC-02 (strict fix scope) — MC-02 keeps a fix inside its issue; MC-09 fires when the work is no longer a single fix.
+- EC-11 — the execution-phase counterpart of this gate.
+- `session/start` step-02b evaluates the gate at session start.
+
+## Enforcement
+
+Parzival self-checks at every 10-message interval: "Has any maintenance fix grown into an initiative? If so, is there an approved/active plan before I dispatch further?"
+
+## Violation Response
+
+1. Halt further dispatch immediately
+2. Draft the plan from `PLAN_TEMPLATE.md` and get user approval
+3. Resume only once the plan is `approved | active`

--- a/_ai-memory/pov/constraints/maintenance/constraints.md
+++ b/_ai-memory/pov/constraints/maintenance/constraints.md
@@ -32,6 +32,7 @@ Maintenance is the most scope-unstable phase. Issues arrive reactively. Fixes se
 | MC-06 | CHANGELOG.md Must Be Updated for Every Approved Fix | MEDIUM |
 | MC-07 | CRITICAL and HIGH Fixes Must Have a Deployment Plan Before Closing | HIGH |
 | MC-08 | Queued Issues Are Prioritized by Severity — Always | MEDIUM |
+| MC-09 | Maintenance Work That Grows Into an Initiative Requires an Approved Plan | HIGH |
 
 ## Self-Check Schedule
 
@@ -45,6 +46,7 @@ Run this checklist after every 10 messages during Maintenance:
 - MC-06: Has CHANGELOG.md been updated for all approved fixes?
 - MC-07: Do CRITICAL/HIGH fixes have a deployment plan before closing?
 - MC-08: Are queued issues being addressed in severity order?
+- MC-09: Has any maintenance fix grown into an initiative? If so, is there an approved/active plan before I dispatch further?
 
 PLUS all 21 global constraint checks from global/constraints.md
 
@@ -62,3 +64,4 @@ IF ANY CHECK FAILS: Course-correct IMMEDIATELY before continuing.
 | MC-06: CHANGELOG.md not updated after approval | MEDIUM | Update immediately, before next session |
 | MC-07: CRITICAL/HIGH approved without deployment plan | HIGH | Create deployment plan before deployment |
 | MC-08: Lower priority work done ahead of higher priority | MEDIUM | Reorder queue, address higher priority first |
+| MC-09: Initiative-scale maintenance dispatched without an approved plan | HIGH | Halt dispatch, draft plan from PLAN_TEMPLATE.md, get approval |

--- a/_ai-memory/pov/workflows/session/close/steps-c/step-01-summarize-session.md
+++ b/_ai-memory/pov/workflows/session/close/steps-c/step-01-summarize-session.md
@@ -6,7 +6,7 @@ nextStepFile: './step-02-update-tracking.md'
 
 # Step 1: Summarize Session Work
 
-**Progress: Step 1 of 5** — Next: Update Tracking Files
+**Progress: Step 1 of 6** — Next: Update Tracking Files
 
 ## STEP GOAL:
 

--- a/_ai-memory/pov/workflows/session/close/steps-c/step-02-update-tracking.md
+++ b/_ai-memory/pov/workflows/session/close/steps-c/step-02-update-tracking.md
@@ -1,12 +1,12 @@
 ---
 name: 'step-02-update-tracking'
 description: 'Update all tracking files with session outcomes, with user confirmation for status changes'
-nextStepFile: './step-03-create-handoff.md'
+nextStepFile: './step-02b-update-plan.md'
 ---
 
 # Step 2: Update Tracking Files
 
-**Progress: Step 2 of 5** — Next: Create Handoff Document
+**Progress: Step 2 of 6** — Next: Update Active Plan
 
 ## STEP GOAL:
 

--- a/_ai-memory/pov/workflows/session/close/steps-c/step-02b-update-plan.md
+++ b/_ai-memory/pov/workflows/session/close/steps-c/step-02b-update-plan.md
@@ -1,0 +1,77 @@
+---
+name: 'step-02b-update-plan'
+description: 'Update the active initiative plan and run the completeness / supersession audit'
+nextStepFile: './step-03-create-handoff.md'
+---
+
+# Step 2b: Update Active Plan
+
+**Progress: Step 2b of 6** — Next: Create Handoff Document
+
+## STEP GOAL:
+
+Bring the active per-initiative plan into sync with what actually happened this session: update item statuses, run the completeness / supersession audit so no plan ends with silent open items, and confirm the done-condition by evidence when the plan is done.
+
+**Scope:**
+- Available context: Session summary from Step 1, updated tracking from Step 2, plans under `{oversight_path}/plans/`
+- Focus: Active-plan update and audit only — do not create the handoff document yet
+- Limits: Only the active plan is touched; superseded/abandoned plans are not rewritten
+- Dependencies: Session summary from Step 1 and updated tracking from Step 2
+
+- Update the active plan's item statuses and append every status change to the Continuity Log
+**Behavioral Constraints:**
+- FORBIDDEN to close a plan `done` without confirming the done-condition by evidence (verify, do not assert)
+- Approach: Update statuses → audit for open items → resolve every open item explicitly (roll forward, or supersede/abandon with a reason)
+- If no active plan applies to this session's work, note "no active plan" and continue
+
+## Sequence
+
+### 0. Locate the Active Plan
+
+Identify the active plan for this session's work under `{oversight_path}/plans/` — the one whose front-matter `status:` is `active` or `approved` and whose subject matches the worked initiative.
+
+- If none applies (trivial/reactive work with no plan) → note "no active plan" and advance to `{nextStepFile}`.
+- If one applies → proceed.
+- If multiple match → the most recent by `plan_id` date; note the ambiguity in the Continuity Log.
+
+---
+
+### 1. Update Item Statuses
+
+For each `## 3. Work Items` row touched this session, update `Status` to reflect reality (`todo` / `doing` / `done` / `blocked`). Preserve the single-`doing` invariant — at most one item `doing` when the session ends. Append a dated line to the `## 7. Continuity Log` for every status change.
+
+---
+
+### 2. Completeness / Supersession Audit
+
+A plan MUST NOT end a session with silent open items. For every item still `todo`, `doing`, or `blocked`, resolve it explicitly by one of:
+
+- **Roll forward** — carry the open item into the successor plan. The successor's front-matter sets `previous_plan:` to this plan's filename; record the roll-forward in this plan's Continuity Log. If ALL of this plan's remaining open items are rolled forward, set THIS plan's `status: superseded` (naming the successor) and log the reason in the Continuity Log — a plan must never stay `active`/`approved` with its work moved into a successor.
+- **Supersede** — set this plan's `status: superseded` WITH a reason in the Continuity Log (and name the superseding plan).
+- **Abandon** — set this plan's `status: abandoned` WITH a reason in the Continuity Log.
+
+Never leave an open item unaccounted for.
+
+---
+
+### 3. Confirm Done-Condition on Completion (Verify-Not-Assert)
+
+If all items are `done` and the plan is being closed:
+
+- Re-read the plan's `## 2. Done-Condition` and confirm it is met **by evidence** (independent check / observable end state), not by assertion that the work was performed.
+- Only then set front-matter `status: done`.
+- In the successor plan (if the initiative continues), set `previous_completed: yes`. If the done-condition is NOT confirmed, do NOT set `status: done` — instead add a new Work Item (status `todo`) capturing the unmet gap, keep the plan `active`, and record it in the Continuity Log.
+
+---
+
+### 4. Verify Plan State
+
+After updates, confirm:
+- Item statuses match the session's actual outcomes; at most one item is `doing`
+- Every open item is accounted for (rolled forward, or plan superseded/abandoned with a reason)
+- Continuity Log records each status change and any supersession/abandonment reason
+- A `done` plan's done-condition was confirmed by evidence before the status flip
+
+## CRITICAL STEP COMPLETION NOTE
+
+ONLY when the active plan is updated and the completeness / supersession audit is clean, load and read fully {nextStepFile}

--- a/_ai-memory/pov/workflows/session/close/steps-c/step-03-create-handoff.md
+++ b/_ai-memory/pov/workflows/session/close/steps-c/step-03-create-handoff.md
@@ -7,7 +7,7 @@ handoffTemplate: '{project-root}/_ai-memory/pov/templates/session-handoff.templa
 
 # Step 3: Create Handoff Document
 
-**Progress: Step 3 of 5** — Next: Enforce Caps
+**Progress: Step 3 of 6** — Next: Enforce Caps
 
 ## STEP GOAL:
 

--- a/_ai-memory/pov/workflows/session/close/steps-c/step-04-enforce-caps.md
+++ b/_ai-memory/pov/workflows/session/close/steps-c/step-04-enforce-caps.md
@@ -6,7 +6,7 @@ nextStepFile: './step-05-save-and-confirm.md'
 
 # Step 4: Enforce Oversight-File Caps
 
-**Progress: Step 4 of 5** — Next: Save and Confirm
+**Progress: Step 4 of 6** — Next: Save and Confirm
 
 ## STEP GOAL:
 

--- a/_ai-memory/pov/workflows/session/start/steps-c/step-01-load-context.md
+++ b/_ai-memory/pov/workflows/session/start/steps-c/step-01-load-context.md
@@ -7,7 +7,7 @@ scaffold: '{workflows_path}/STEP-SCAFFOLD.md'
 
 # Step 1: Load Context
 
-**Progress: Step 1 of 4** — Next: Parzival Cross-Session Memory Bootstrap
+**Progress: Step 1 of 5** — Next: Parzival Cross-Session Memory Bootstrap
 
 ## STEP GOAL:
 

--- a/_ai-memory/pov/workflows/session/start/steps-c/step-01b-parzival-bootstrap.md
+++ b/_ai-memory/pov/workflows/session/start/steps-c/step-01b-parzival-bootstrap.md
@@ -6,7 +6,7 @@ nextStepFile: './step-02-compile-status.md'
 
 # Step 1b: Parzival Cross-Session Memory Bootstrap
 
-**Progress: Step 1b of 4** — Next: Compile Status Report
+**Progress: Step 1b of 5** — Next: Compile Status Report
 
 ## STEP GOAL:
 

--- a/_ai-memory/pov/workflows/session/start/steps-c/step-02-compile-status.md
+++ b/_ai-memory/pov/workflows/session/start/steps-c/step-02-compile-status.md
@@ -1,12 +1,12 @@
 ---
 name: 'step-02-compile-status'
 description: 'Compile all loaded context into a structured session status report'
-nextStepFile: './step-03-present-and-wait.md'
+nextStepFile: './step-02b-plan-bearings.md'
 ---
 
 # Step 2: Compile Status Report
 
-**Progress: Step 2 of 4** — Next: Present and Wait for Direction
+**Progress: Step 2 of 5** — Next: Plan Bearings
 
 ## STEP GOAL:
 

--- a/_ai-memory/pov/workflows/session/start/steps-c/step-02b-plan-bearings.md
+++ b/_ai-memory/pov/workflows/session/start/steps-c/step-02b-plan-bearings.md
@@ -1,0 +1,73 @@
+---
+name: 'step-02b-plan-bearings'
+description: 'Load the active initiative plan, take resume-bearings, and apply the proportionate plan-gate'
+nextStepFile: './step-03-present-and-wait.md'
+---
+
+# Step 2b: Plan Bearings
+
+**Progress: Step 2b of 5** — Next: Present and Wait for Direction
+
+## STEP GOAL:
+
+Enrich the status report compiled in Step 2 with plan bearings: load the active per-initiative plan, identify the resume point, and apply the proportionate plan-gate so no initiative is dispatched into a vacuum.
+
+**Scope:**
+- Available context: The compiled status report from Step 2, plans under `{oversight_path}/plans/`
+- Focus: Plan loading, resume-bearings, and gate evaluation only — do not present or start work
+- Limits: Read-only — do not modify any plan file at session start
+- Dependencies: Compiled status report from Step 2
+
+- Load the active plan (front-matter + item table, capped) and fold its bearings into the report
+**Behavioral Constraints:**
+- FORBIDDEN to dispatch or start work — this step only informs the Step 3 recommendation
+- Approach: Cheap machine read of front-matter first; pull item-table detail on demand
+- If no plan applies (trivial/reactive/one-surface work), note "no plan required" and continue — do not fabricate a gate
+
+## Sequence
+
+### 1. Locate the Active Plan
+
+Scan `{oversight_path}/plans/PLAN-*.md` filenames (no full reads yet). Identify the plan for the current initiative — the one whose front-matter `status:` is `active` or `approved` and whose subject matches the current task/initiative from the Step 2 report.
+
+- If exactly one active/approved plan matches → that is the active plan.
+- If none exists → record "no active plan" (feeds the gate in Section 3).
+- If multiple match → the most recent by `plan_id` date; note the ambiguity in the report.
+
+---
+
+### 2. Load Plan Front-Matter + Resume-Bearings (Capped)
+
+Read only the front-matter block and the `## 3. Work Items` table of the active plan (skip the prose sections — pulled on demand later):
+
+- **Front-matter**: `plan_id`, `type`, `status`, `previous_plan`, `previous_completed`.
+- **Resume point**: the highest-priority not-done item — the single `doing` item if present, else the first `todo`. Name it in the report. If more than one item is `doing`, flag it as an anomaly (same treatment as the adjacent baseline-drift flag) rather than silently assuming a single `doing` item.
+- **Baseline check**: confirm the resume point still matches reality (the item's stated target still exists / is still open). Flag any drift between the plan and current tracking state as an anomaly (do not resolve it here).
+
+Surface a one-line plan-status rollup into the compiled report:
+`plan: <plan_id> — status <status>, resume at item #<n> "<item>" (<done>/<total> done)`
+
+If all Work Items are `done` (close-out pending), surface instead: `plan: <plan_id> — all items done, pending close-out`.
+
+If no active plan exists, surface instead: `plan: none active for current work`.
+
+---
+
+### 3. Apply the Proportionate Plan-Gate
+
+Gate on **scope, never effort or time**. Classify the pending work:
+
+- **SKIP the gate** (no plan required): one-file / single-surface / reversible / reactive one-off / pure discussion or status. Note "no plan required" and continue.
+- **REQUIRE an approved plan** (initiative): multi-file / multi-surface, uncertain approach, a verification / research / ops initiative, multi-session, or work touching the runtime-under-test.
+
+If the pending work is an **initiative** AND no `status: approved | active` plan exists for it, then the first recommended action in Step 3 MUST be **"draft a plan and get user approval before any task dispatch"** — ahead of any execution recommendation.
+
+---
+
+### 4. Hand Bearings to Step 3
+
+Fold the plan-status rollup, the resume point, any plan/tracking anomaly, and the gate outcome into the compiled report so Step 3's recommendation reflects them. Do not present here.
+
+## CRITICAL STEP COMPLETION NOTE
+
+ONLY when the plan bearings and gate outcome are folded into the report, load and read fully {nextStepFile}

--- a/templates/oversight/plans/PLAN_TEMPLATE.md
+++ b/templates/oversight/plans/PLAN_TEMPLATE.md
@@ -1,333 +1,46 @@
-# Project Plan
-
-**ID**: PLAN-XXX
-**Date**: [YYYY-MM-DD]
-**Status**: [Draft|Active|On Hold|Complete|Cancelled]
-**Type**: [Sprint|Release|Migration|Refactor|Feature|Fix]
-
 ---
-
-## Executive Summary
-
-[High-level overview of what this plan covers and why]
-
+plan_id: PLAN-<SLUG>-<YYYY-MM-DD>
+type: build | ops | maintenance | verification | research
+status: draft | approved | active | done | superseded | abandoned
+previous_plan: <PLAN-… filename | none>
+previous_completed: yes | no | n/a
+approved_by: <user> | pending
+approved_date: <YYYY-MM-DD> | pending
 ---
+# <Plan Title>
 
-## Objectives
+> Per-initiative living plan + checklist. One plan per initiative. Chain to the predecessor via `previous_plan`; append every status change to the Continuity Log at closeout.
 
-### Primary Goals
-1. [Goal 1]
-2. [Goal 2]
-3. [Goal 3]
+## 1. Goal
 
-### Success Criteria
-- [ ] [Measurable criterion 1]
-- [ ] [Measurable criterion 2]
-- [ ] [Measurable criterion 3]
+[1–2 sentences: what this initiative ships and why.]
 
-### Out of Scope
-[What this plan explicitly does NOT include]
+## 2. Done-Condition
 
----
+[Written FIRST. Testable, external, evidence-based — the observable end state an independent check can confirm, not "code written".]
 
-## Background
+## 3. Work Items
 
-### Context
-[Why is this work needed?]
+| # | Item | Owner | Status |
+|---|------|-------|--------|
+| 1 | [item] | [owner] | todo |
+| 2 | [item] | [owner] | doing |
+| 3 | [item] | [owner] | done |
 
-### Problem Statement
-[What problem are we solving?]
+_Status ∈ todo / doing / done / blocked. Exactly one item is `doing` at a time._
 
-### Related Work
-- Related Decisions: DEC-XXX
-- Related Specs: SPEC-XXX
-- Related Tasks: TASK-XXX
+## 4. Out of Scope / Non-Goals
 
----
+- [What this plan explicitly does NOT cover.]
 
-## Scope
+## 5. Verification
 
-### In Scope
-- [Item 1]
-- [Item 2]
-- [Item 3]
+[How the Done-Condition is confirmed by evidence or independent check — not by assertion.]
 
-### Out of Scope
-- [Item that's explicitly excluded]
-- [Another excluded item]
+## 6. Open Questions
 
-### Dependencies
-| Dependency | Type | Owner | Status | Due Date |
-|------------|------|-------|--------|----------|
-| [Dependency 1] | External/Internal | [Name] | [Status] | [Date] |
-| [Dependency 2] | External/Internal | [Name] | [Status] | [Date] |
+- [Unresolved question — mark RESOLVED with the answer, who decided, and when once closed.]
 
----
+## 7. Continuity Log
 
-## Work Breakdown
-
-### Phase 1: [Phase Name]
-**Duration**: [X days/weeks]
-**Start**: [YYYY-MM-DD]
-**End**: [YYYY-MM-DD]
-
-#### Tasks
-| ID | Task | Owner | Estimate | Dependencies | Status |
-|----|------|-------|----------|--------------|--------|
-| TASK-001 | [Task 1] | [Name] | [Xh] | - | [Status] |
-| TASK-002 | [Task 2] | [Name] | [Xh] | TASK-001 | [Status] |
-
-#### Deliverables
-- [ ] [Deliverable 1]
-- [ ] [Deliverable 2]
-
----
-
-### Phase 2: [Phase Name]
-**Duration**: [X days/weeks]
-**Start**: [YYYY-MM-DD]
-**End**: [YYYY-MM-DD]
-
-#### Tasks
-| ID | Task | Owner | Estimate | Dependencies | Status |
-|----|------|-------|----------|--------------|--------|
-| TASK-003 | [Task 3] | [Name] | [Xh] | Phase 1 | [Status] |
-
-#### Deliverables
-- [ ] [Deliverable 1]
-- [ ] [Deliverable 2]
-
----
-
-### Phase 3: [Phase Name]
-[Repeat structure]
-
----
-
-## Timeline
-
-### Milestones
-| Milestone | Date | Status | Dependencies |
-|-----------|------|--------|--------------|
-| [Milestone 1] | [YYYY-MM-DD] | [Status] | [Deps] |
-| [Milestone 2] | [YYYY-MM-DD] | [Status] | [Deps] |
-| [Milestone 3] | [YYYY-MM-DD] | [Status] | [Deps] |
-
-### Critical Path
-[Identify the critical path through the project]
-
-### Gantt Chart
-```
-[ASCII Gantt chart or description of timing]
-Week 1: [Activities]
-Week 2: [Activities]
-Week 3: [Activities]
-```
-
----
-
-## Resources
-
-### Team
-| Role | Name | Allocation | Duration |
-|------|------|------------|----------|
-| Tech Lead | [Name] | 100% | Full project |
-| Developer | [Name] | 50% | Phases 1-2 |
-| QA | [Name] | 25% | All phases |
-
-### Budget
-| Category | Estimated Cost | Notes |
-|----------|----------------|-------|
-| Personnel | $[X] | [Details] |
-| Infrastructure | $[X] | [Details] |
-| Tools/Licenses | $[X] | [Details] |
-| **Total** | **$[X]** | |
-
-### Infrastructure Needs
-- [Resource 1]
-- [Resource 2]
-
----
-
-## Risk Management
-
-### Risk Register
-| Risk ID | Description | Probability | Impact | Mitigation | Owner |
-|---------|-------------|-------------|--------|------------|-------|
-| RISK-001 | [Risk 1] | High/Med/Low | High/Med/Low | [Strategy] | [Name] |
-| RISK-002 | [Risk 2] | High/Med/Low | High/Med/Low | [Strategy] | [Name] |
-
-### Contingency Plans
-- **Risk 1**: [Contingency plan]
-- **Risk 2**: [Contingency plan]
-
----
-
-## Communication Plan
-
-### Stakeholders
-| Stakeholder | Role | Interest | Communication Frequency |
-|-------------|------|----------|-------------------------|
-| [Name] | [Role] | High/Med/Low | Weekly/Biweekly/Monthly |
-| [Name] | [Role] | High/Med/Low | Weekly/Biweekly/Monthly |
-
-### Status Reporting
-- **Format**: [Email/Meeting/Dashboard]
-- **Frequency**: [Daily/Weekly/Biweekly]
-- **Recipients**: [Distribution list]
-
-### Escalation Path
-1. [First level]
-2. [Second level]
-3. [Third level]
-
----
-
-## Quality Assurance
-
-### Quality Criteria
-- [ ] [Quality criterion 1]
-- [ ] [Quality criterion 2]
-- [ ] [Quality criterion 3]
-
-### Testing Strategy
-- **Unit Testing**: [Approach]
-- **Integration Testing**: [Approach]
-- **User Acceptance Testing**: [Approach]
-
-### Code Review Process
-[How code reviews will be conducted]
-
----
-
-## Deployment Strategy
-
-### Deployment Approach
-[Describe the deployment strategy - big bang, phased, blue-green, etc.]
-
-### Deployment Phases
-1. **Phase 1**: [What gets deployed]
-   - Date: [YYYY-MM-DD]
-   - Scope: [What's included]
-
-2. **Phase 2**: [What gets deployed]
-   - Date: [YYYY-MM-DD]
-   - Scope: [What's included]
-
-### Rollback Plan
-[How to revert if deployment fails]
-
----
-
-## Monitoring and Success Metrics
-
-### Key Performance Indicators
-| KPI | Target | Measurement Method | Frequency |
-|-----|--------|-------------------|-----------|
-| [KPI 1] | [Target] | [How measured] | [When] |
-| [KPI 2] | [Target] | [How measured] | [When] |
-
-### Monitoring
-- [What will be monitored]
-- [Alert thresholds]
-- [Response procedures]
-
----
-
-## Assumptions
-
-1. [Assumption 1]
-2. [Assumption 2]
-3. [Assumption 3]
-
----
-
-## Constraints
-
-### Technical Constraints
-- [Constraint 1]
-- [Constraint 2]
-
-### Business Constraints
-- [Constraint 1]
-- [Constraint 2]
-
-### Resource Constraints
-- [Constraint 1]
-- [Constraint 2]
-
----
-
-## Change Management
-
-### Change Control Process
-[How changes to the plan will be managed]
-
-### Scope Change Log
-| Date | Change | Reason | Impact | Approved By |
-|------|--------|--------|--------|-------------|
-| [Date] | [Change] | [Reason] | [Impact] | [Name] |
-
----
-
-## Documentation
-
-### Documentation Deliverables
-- [ ] Technical documentation
-- [ ] User documentation
-- [ ] API documentation
-- [ ] Runbooks
-- [ ] Training materials
-
-### Knowledge Transfer
-[How knowledge will be transferred to the team/stakeholders]
-
----
-
-## Post-Implementation
-
-### Handoff Plan
-[How the project will be handed off after completion]
-
-### Support Model
-[How ongoing support will be provided]
-
-### Lessons Learned Session
-**Scheduled**: [YYYY-MM-DD]
-**Participants**: [Names]
-
----
-
-## Approvals
-
-| Role | Name | Date | Signature |
-|------|------|------|-----------|
-| Project Sponsor | [Name] | [YYYY-MM-DD] | [Initials] |
-| Technical Lead | [Name] | [YYYY-MM-DD] | [Initials] |
-| Product Owner | [Name] | [YYYY-MM-DD] | [Initials] |
-
----
-
-## Metadata
-
-- **Created**: [YYYY-MM-DD]
-- **Modified**: [YYYY-MM-DD]
-- **Author**: [Name]
-- **Version**: 1.0
-- **Status**: [Draft|Approved|In Progress|Complete]
-- **Tags**: [tag1, tag2, tag3]
-
----
-
-## Revision History
-
-| Version | Date | Author | Changes |
-|---------|------|--------|---------|
-| 1.0 | [YYYY-MM-DD] | [Name] | Initial plan |
-| 1.1 | [YYYY-MM-DD] | [Name] | Updated timeline |
-
----
-
-## Notes
-
-[Additional context, observations, or considerations]
+- [YYYY-MM-DD] — [status change / items rolled forward to the next plan / supersession or abandonment reason.]


### PR DESCRIPTION
## Summary

Adds a per-initiative living-plan discipline to the Parzival oversight module so an initiative always has an approved, checklist-tracked plan with a continuity chain, and no plan ends with silent open items.

## Changes

- **Plan template** (`templates/oversight/plans/PLAN_TEMPLATE.md`) — rewritten as a lean per-initiative living plan + checklist: front-matter continuity fields (`previous_plan`, `previous_completed`, `status`), a done-condition written first, and a work-items checklist. Replaces the prior long-form template (preserved in history, blob `d99393f`).
- **Session start** — new `step-02b-plan-bearings`: loads the active plan, derives the resume point, and applies a proportionate plan-gate — initiative-scale work requires an approved plan; trivial reactive work skips it (gated on scope, not effort).
- **Closeout** — new `step-02b-update-plan`: syncs item statuses and runs a completeness/supersession audit (open items roll forward to a successor plan, or the plan is superseded/abandoned with a reason); confirms the done-condition by evidence before a plan is marked done.
- **Constraints** — GC-15 points at the new template; EC-11 (execution) and MC-09 (maintenance) encode the plan-gate in the phase constraints.

Both new steps are wired into their chains (start now 5 steps, close now 6); the `Step N of M` counts and `nextStepFile` links are updated across the affected step files.

## Testing

- Process/workflow suite green: `tests/process/` (step-chain, step-frontmatter, workflow-map, workflow-frontmatter) + session-close + Parzival-loader tests — 740 passed, 0 failed.
- **Recommended before merge:** a behavioral install-and-run check of the new start/closeout steps against a real plan (static review only so far).
