### PR TITLE
feat: add aim-wiki project-wiki skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`aim-wiki` skill — in-session project wiki generator & maintainer (PR #253)** — creates and maintains a wiki under `wiki/`: Claude Code authors `wiki/quickstart.md` plus linked section pages, grounding every claim in source and git evidence (no invented files, APIs, or behavior), while a Python engine (`_ai-memory/skills/aim-wiki/scripts/aim_wiki.py`) does only the deterministic work — repo inventory, wiki scaffold, run-state (content-hash + gitHead + updatedAt), git-diff since the last run, the `## Project Wiki` CLAUDE.md/AGENTS.md pointer, and a dead-citation verifier manifest. Modes: `init` (scaffold; ≤8 pages on a first run unless the repo is tiny), `update` (incremental, surgical edits; a no-op is valid when nothing relevant changed), `status` (read-only freshness report), `verify` (dead-citation precheck, then a read-only verifier subagent cross-checks page claims against cited source), and `finalize --command init|update` (post-acceptance: upserts the pointer, records state). Pointer injection is idempotent via a managed marker pair (`<!-- BEGIN/END AI-MEMORY (managed aim-wiki) -->`) so a user's own same-named `## Project Wiki` section is never overwritten, with backup-copy-first and atomic (`tempfile` + `os.replace`) writes. v1 is standalone (no Qdrant integration) and its source-drift check excludes the whole top-level `CLAUDE.md`/`AGENTS.md`, not just the pointer section.
+
 ### Changed
 
 - Bumped dependency constraints: `structlog` `<26.0.0` → `<27.0.0` (resolves 26.1.0), `pytest-randomly` `<4.0.0` → `<5.0.0` (resolves 4.1.0), `click` `>=8.2.1` → `>=8.4.1`, `typer` `>=0.12.0` → `>=0.26.7`, `actions/cache` `v5` → `v6` (CI-only).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped dependency constraints: `structlog` `<26.0.0` → `<27.0.0` (resolves 26.1.0), `pytest-randomly` `<4.0.0` → `<5.0.0` (resolves 4.1.0), `click` `>=8.2.1` → `>=8.4.1`, `typer` `>=0.12.0` → `>=0.26.7`, `actions/cache` `v5` → `v6` (CI-only).
 - Bumped `fastapi` `0.128.0` → `0.138.0`, which resolves `starlette` `0.50.0` → `1.3.1`, clearing 5 open starlette Dependabot advisories. `ruff` and the streamlit `structlog` constraint updated to match.
 
+### Fixed
+
+- **`aim-wiki finalize` now surfaces a refused pointer write distinctly from a true no-op (PR #253)** — when a top-level `CLAUDE.md`/`AGENTS.md` carries malformed AI-memory markers (stray, duplicate, or out-of-order `BEGIN`/`END`), the pointer injection is refused and the file is left byte-for-byte unchanged. Previously this was reported identically to "already current" (empty `pointer_files_changed`, exit 0), so the refusal was invisible in `--json` and non-tty capture. `finalize` now emits a distinct `pointer_files_refused` field in `--json`, a `REFUSED … resolve manually, then re-run` line in text output, and exits `2` (mirroring `scripts/merge_agents_md.py`'s malformed-marker convention); a genuine no-op still reports `already current` and exits `0`. Internally `wiki_pointer.splice_block` now raises `MalformedMarkersError` on an unsafe marker state and `upsert_pointer` returns changed/refused paths separately.
+
 ## [2.8.2] - 2026-06-30
 
 ### Upgrade Instructions

--- a/_ai-memory/skills/aim-wiki/SKILL.md
+++ b/_ai-memory/skills/aim-wiki/SKILL.md
@@ -87,6 +87,10 @@ Full page-structure, page-count, thin-page, and canonical-home rules:
      "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/_ai-memory/skills/aim-wiki/scripts/aim_wiki.py" \
      finalize --command init [--json]
    ```
+   `finalize` exits **2** if a target `CLAUDE.md`/`AGENTS.md` has malformed
+   AI-memory markers — it refuses that file's pointer write (writing nothing to
+   it) but still records run-state. Detect a refusal via the `pointer_files_refused`
+   field in `--json`, not the exit code alone (argparse also uses 2).
 
 ### `update` — incremental maintenance
 

--- a/_ai-memory/skills/aim-wiki/SKILL.md
+++ b/_ai-memory/skills/aim-wiki/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: aim-wiki
+description: Creates and maintains an up-to-date wiki of the user's current project, in-session, while you work — a dedicated wiki/ directory with a quickstart entrypoint plus section pages, grounded in source and git evidence. Claude Code itself authors the pages; a Python engine does the deterministic work (repo inventory, wiki scaffold, content-hash/gitHead state, git-diff-since-last-run, CLAUDE.md/AGENTS.md pointer, verifier manifest). Modes init | update | status, plus verify and finalize. Use when asked to create, refresh, or check the freshness of the project wiki/docs. Do NOT use for AI Memory search/save/health (use aim-search, aim-save, aim-status) or SOT drift (use aim-sot).
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task
+---
+
+# aim-wiki — Project Wiki Generator & Maintainer
+
+Creates and maintains a wiki of the current project under `wiki/`, **in-session**.
+Works on any project (new or existing) under AI Memory.
+
+**You (Claude Code) are the doc-gen agent.** The Python engine
+(`scripts/aim_wiki.py`) does only deterministic work and hands you structured
+context; you do the reasoning — analyze the code and author/refresh the pages,
+grounding every claim in source. There is no separate LLM or provider — you are
+the model.
+
+## Split of responsibilities
+
+- **Engine (Python) → deterministic**: project scoping, repo inventory, wiki
+  scaffold, run-state (content-hash + gitHead + updatedAt), git-diff since last
+  run, pointer injection, and the verifier manifest.
+- **You (Claude Code) → reasoning**: author `wiki/quickstart.md` + section pages,
+  refresh them surgically, and dispatch the read-only verifier.
+- **Correctness → a read-only verifier subagent**: after authoring,
+  cross-check page claims against source before acceptance.
+
+The engine is invoked via `run-with-env.sh` (the AI-memory run-with-env convention). All modes accept
+`--root PATH` (override the project root; default = git toplevel, else cwd) and
+`--json`.
+
+## Grounding discipline (read before authoring)
+
+Concepts adapted from OpenWiki's system prompt (MIT — paraphrased, not lifted).
+
+- **Do not invent** files, modules, APIs, business rules, or behavior. Ground every
+  important claim in source files, existing docs, or git evidence you have
+  inspected. Include inline source references so a reader can verify.
+- **Discover efficiently.** Do not read every file. Inspect the tree, package/config
+  files, README-style docs, entrypoints, routing, schema/data files, and
+  representative files per domain. Prefer `Grep`/`Glob` and short targeted reads
+  over full-file reads. Do not glob `**/*` from the repo root; exclude `.git`,
+  `node_modules`, `dist`, `build`, caches, and the `wiki/` output itself.
+- **Use git for the "why".** Use recent history and targeted `git log`/`show`/`blame`
+  on high-signal files to explain why code exists, not just what it is. Do not
+  over-index on ancient history or paste commit-hash lists into pages.
+- **Existing docs are primary source.** Treat READMEs, `docs/`, runbooks, and
+  `SKILL.md` files as source material — summarize and link rather than duplicate.
+  If existing docs conflict with the code, flag the likely-stale doc and prefer
+  current source.
+- **Subagents are read-only.** You may dispatch read-only research/verifier
+  subagents that only inspect and summarize with source paths; they must not
+  create, edit, move, or delete files, and must not write under `wiki/`. You
+  synthesize and own all writes.
+- **Security.** Never read or document secret values, credentials, keys, tokens, or
+  `.env` files. `.env.example`/samples only if they hold placeholders. Keep all
+  docs under `wiki/`.
+- **Plan file.** After discovery, before authoring, write `wiki/_plan.md` (intended
+  pages, evidence per page, open questions). **Delete it before finishing.**
+
+Full page-structure, page-count, thin-page, and canonical-home rules:
+[`references/page-structure.md`](references/page-structure.md) — read before authoring.
+
+## Flows
+
+### `init` — create the wiki from the current project
+
+1. **Engine (prep):**
+   ```bash
+   bash "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh" \
+     "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/_ai-memory/skills/aim-wiki/scripts/aim_wiki.py" \
+     init [--force] [--json]
+   ```
+   Resolves the project root, guards an existing wiki (routes you to `update`
+   unless `--force`), builds the repo inventory + git summary, and scaffolds
+   `wiki/`. Read the emitted `inventory` and `git_summary` — that is your grounding.
+2. **You (author):** write a `wiki/_plan.md` (evidence-linked), then author
+   `wiki/quickstart.md` first and the linked section pages. ≤8 pages on the first
+   run unless tiny; no thin pages; one canonical home per concept; ground every
+   claim. Delete `wiki/_plan.md` when done.
+3. **Verify** (below).
+4. **Review gate:** present the wiki diff + the verifier's report; the user accepts
+   or requests fixes (the in-session equivalent of OpenWiki's PR gate).
+5. **Engine (finalize)** on acceptance — injects the pointer and records state:
+   ```bash
+   bash "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh" \
+     "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/_ai-memory/skills/aim-wiki/scripts/aim_wiki.py" \
+     finalize --command init [--json]
+   ```
+
+### `update` — incremental maintenance
+
+1. **Engine (prep):** `aim_wiki.py update [--json]` — reads state, computes the
+   git-diff since the recorded `gitHead` (+ uncommitted), and flags whether the
+   wiki was edited since the last record.
+2. **You (author):** build a docs-impact plan (changed source → page → edit → why).
+   **Edit surgically** — prefer replacing one stale sentence over adding
+   paragraphs; do not reformat or refresh accurate pages. A **no-op is valid**: if
+   nothing relevant changed, say the wiki is already current and stop. Soft budget:
+   <5 changed source files → touch ≤1–2 pages. Also refresh the `## Project Wiki`
+   pointer only if it is missing or stale.
+3. **Verify** → **review gate** → `finalize --command update`.
+
+### `status` — freshness only (no writes)
+
+```bash
+bash "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh" \
+  "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/_ai-memory/skills/aim-wiki/scripts/aim_wiki.py" \
+  status [--json]
+```
+Reports last `updatedAt`, recorded `gitHead`, source changes since last run, and
+whether the wiki was edited since the last record. Never writes.
+
+## Verify — correctness
+
+After authoring/refreshing, run the verifier manifest:
+```bash
+bash "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh" \
+  "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/_ai-memory/skills/aim-wiki/scripts/aim_wiki.py" \
+  verify [--json]
+```
+The engine extracts every inline source citation from the wiki pages and checks
+each cited path exists (a deterministic dead-citation precheck — dead paths are
+immediate drift; fix them). Then **dispatch a read-only verifier subagent** (via
+the `Task` tool, read-only) with the manifest: it cross-checks that each page's
+**claims** match the cited source — a claim can cite a real file yet misdescribe
+it. It inspects and reports only; it does not edit. One pass, not a multi-round
+loop. Surface all discrepancies (dead citations + ungrounded/drifted claims) in
+the review gate before acceptance.
+
+## Scope & invariants
+
+- **In-session only** (v1). Multi-project: the wiki is written **only** under the
+  resolved project's `wiki/` — no cross-project bleed.
+- **Deterministic work stays in the engine**; authoring/reasoning stays with you.
+  No provider config, no keys, no deepagents.
+- **Writes** are confined to `wiki/` plus the top-level `CLAUDE.md`/`AGENTS.md`
+  pointer section (owned by `finalize`). Never edit source outside these.
+- **Known v1 limitation**: source-drift excludes the *whole* top-level
+  `CLAUDE.md`/`AGENTS.md`, not just the injected pointer section — unrelated edits
+  to those files don't register as drift. Pointer-section-scoped drift is a v2 refinement.
+- **Deferred seams** (designed-for, not built in v1): memory-store integration of
+  wiki pages, headless/CI mode + GitHub Action, and `aim-sot` doc-drift
+  composition. Do not build these here.

--- a/_ai-memory/skills/aim-wiki/references/page-structure.md
+++ b/_ai-memory/skills/aim-wiki/references/page-structure.md
@@ -1,0 +1,81 @@
+# Wiki page structure & quality rules
+
+Authoring discipline for the pages `aim-wiki` produces under `wiki/`. Concepts
+adapted from OpenWiki's system prompt (`prompt.ts:98-127`, MIT — paraphrased).
+The engine scaffolds and records; **you** (the in-session agent) author
+to these rules.
+
+## Entrypoint
+
+- `wiki/quickstart.md` is the required entrypoint and must exist.
+- It carries a high-level repository overview and links to **every** major section
+  page. A reader with zero knowledge of the repo starts here and learns what the
+  project is, how it is organized, what it does, and where to go next.
+
+## Page count & scope
+
+- **init**: at most ~8 pages on the first run unless the repo is clearly tiny.
+  Keep the initial set focused — quickstart plus the smallest set of section pages
+  that explains the repo clearly. A strong first pass, then stop; later `update`
+  runs refine.
+- **Small repos** (~10 or fewer primary source files): prefer `quickstart.md`
+  plus at most 1–2 supporting pages. Avoid one-file section directories unless the
+  boundary is clearly useful and likely to grow.
+
+## Section directories
+
+- Create a directory only when it represents a real documentation area.
+- A section directory should usually hold multiple substantive pages. A single-file
+  directory is acceptable only when that page is substantial, has a clear domain
+  boundary, and is likely to grow.
+- Prefer headings inside a broader page before creating many small directories.
+- Typical names when the repo is large enough to need them: `architecture/`,
+  `workflows/`, `domain/`, `api/`, `data-models/`, `operations/`, `integrations/`,
+  `testing/` — or names that fit the repo.
+
+## No thin pages
+
+- Avoid stub pages. If a page would mostly be a stub, source map, or short note,
+  merge it into `quickstart.md` or a broader section page instead.
+- Every page must give real explanatory value: what the area does, why it exists,
+  where to start, what to watch out for, and key source references.
+- Before finishing a run, review the `wiki/` tree and merge, move, or remove
+  low-value single-file directories and stub pages.
+
+## One canonical home per concept
+
+- Give each concept a single canonical page; link to it from elsewhere rather than
+  repeating the explanation. Keeps the wiki concise enough to maintain.
+
+## Grounding (correctness)
+
+- **Do not invent** files, modules, APIs, business rules, or behavior. Ground every
+  important claim in source, existing docs, or git evidence you have inspected.
+- Include inline source references (e.g. `` `src/app.py` `` or a link to the file)
+  where they help a reader verify or continue exploring. These citations are what
+  the `verify` manifest and the read-only verifier subagent check.
+- Prefer current source over stale docs. If existing docs conflict with the code or
+  git history, flag the likely-stale doc and prefer the source evidence.
+- Explain **why** important code exists, not only what files contain. Use git
+  history for the "why"; do not paste persistent commit-hash lists into pages
+  unless a specific historical decision matters.
+
+## Security & privacy
+
+- Never read or document secret values, credentials, keys, tokens, or `.env` files.
+  `.env.example` / sample config may be read only if it holds placeholders.
+- Document only that such configuration exists and where non-sensitive setup lives.
+
+## Scope of writes
+
+- Keep all documentation under `wiki/`.
+- The only files outside `wiki/` the flow ever touches are the top-level `CLAUDE.md`
+  / `AGENTS.md` pointer section — and the engine's `finalize` step owns that write,
+  not free-hand editing.
+
+## Temporary plan file
+
+- After discovery and before authoring, write `wiki/_plan.md`: intended pages,
+  source evidence per page, and open questions.
+- **Delete `wiki/_plan.md` before finishing.** It is excluded from the content hash
+  but must not ship in the final wiki.

--- a/_ai-memory/skills/aim-wiki/scripts/aim_wiki.py
+++ b/_ai-memory/skills/aim-wiki/scripts/aim_wiki.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""aim-wiki — engine (deterministic operations only).
+
+The skill runs inside Claude Code: this engine does the DETERMINISTIC work
+(project scoping, repo inventory, wiki scaffold, state/content-hash, git-diff,
+pointer injection, verification manifest) and hands structured context to the
+in-session agent, which does the REASONING (authoring/refreshing pages). The
+engine never authors prose and never calls a model or provider.
+
+Subcommands:
+    init   [--force]              Prep a fresh wiki: inventory + git summary +
+                                  scaffold. Emits the context bundle the agent
+                                  authors from. --force overrides existing wiki.
+    update                        Prep an incremental refresh: state + git-diff
+                                  since last run + no-op (content-hash) check.
+    status                        Read-only freshness report. No writes.
+    verify                        Emit the verifier manifest (verifier hook):
+                                  page citations + dead-path precheck.
+    finalize --command init|update
+                                  Post-acceptance writes: upsert CLAUDE.md/
+                                  AGENTS.md pointer + record run-state.
+
+Common flags: --root PATH (override project root), --json.
+Invoked via run-with-env.sh (the AI-memory run-with-env convention).
+Exit codes: 0 success (incl. routing messages like wiki-already-exists);
+1 usage/system error.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import wiki_common as wc
+from wiki_inventory import build_inventory
+from wiki_pointer import upsert_pointer
+from wiki_verify import build_manifest
+
+
+def _emit(data: dict, as_json: bool, text_fn) -> None:
+    if as_json:
+        print(json.dumps(data, indent=2))
+    else:
+        text_fn(data)
+
+
+# ---------------------------------------------------------------------------
+# init
+# ---------------------------------------------------------------------------
+
+
+def cmd_init(root: Path, force: bool, as_json: bool) -> int:
+    if wc.wiki_has_content(root) and not force:
+        data = {
+            "mode": "init",
+            "status": "wiki_exists",
+            "action": "update",
+            "wiki_dir": str(wc.wiki_dir(root)),
+            "message": "wiki/ already has content — run `update`, or `init --force` to rebuild.",
+        }
+        _emit(data, as_json, lambda d: print(d["message"]))
+        return 0
+
+    wc.wiki_dir(root).mkdir(parents=True, exist_ok=True)
+    data = {
+        "mode": "init",
+        "status": "ready",
+        "root": str(root),
+        "project_id": wc.resolve_project_id(root),
+        "wiki_dir": str(wc.wiki_dir(root)),
+        "state_file": str(wc.state_path(root)),
+        "forced": force,
+        "inventory": build_inventory(root),
+        "git_summary": wc.git_summary(root),
+        "next": "Author wiki/quickstart.md first, then section pages, grounding every "
+        "claim in the inventory/git evidence. Then run `verify`, then `finalize "
+        "--command init`.",
+    }
+
+    def _text(d):
+        inv = d["inventory"]
+        print(f"aim-wiki init — ready ({d['root']})")
+        print(f"  project_id : {d['project_id']}")
+        print(f"  wiki_dir   : {d['wiki_dir']}")
+        print(
+            f"  scanned    : {inv['files_scanned']} files"
+            + (" (truncated)" if inv["truncated"] else "")
+        )
+        for bucket in ("docs", "entrypoints", "config", "tests", "schema"):
+            print(f"  {bucket:11}: {len(inv[bucket])}")
+        print("--- git ---")
+        print(d["git_summary"])
+
+    _emit(data, as_json, _text)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# update
+# ---------------------------------------------------------------------------
+
+
+def cmd_update(root: Path, as_json: bool) -> int:
+    state = wc.read_state(root)
+    if state is None:
+        data = {
+            "mode": "update",
+            "status": "no_state" if wc.wiki_has_content(root) else "not_initialized",
+            "action": (
+                "finalize --command init" if wc.wiki_has_content(root) else "init"
+            ),
+            "message": (
+                "wiki/ exists but has no recorded state — run `finalize --command init` "
+                "to establish a baseline."
+                if wc.wiki_has_content(root)
+                else "no wiki found — run `init` first."
+            ),
+        }
+        _emit(data, as_json, lambda d: print(d["message"]))
+        return 0
+
+    changes = wc.git_changed_files(root, state.get("gitHead"))
+    current_hash = wc.content_hash(root)
+    data = {
+        "mode": "update",
+        "status": "ready",
+        "root": str(root),
+        "recorded": {
+            "updatedAt": state.get("updatedAt"),
+            "gitHead": state.get("gitHead"),
+            "contentHash": state.get("contentHash"),
+        },
+        "current_content_hash": current_hash,
+        "wiki_edited_since_record": current_hash != state.get("contentHash"),
+        "changes": changes,
+        "git_summary": wc.git_summary(root),
+        "next": "Build a docs-impact plan (changed source -> page -> edit -> why). Edit "
+        "surgically; a no-op is valid if nothing relevant changed. Then run "
+        "`verify`, then `finalize --command update`.",
+    }
+
+    def _text(d):
+        ch = d["changes"]
+        print(f"aim-wiki update — ready ({d['root']})")
+        print(
+            f"  last run : {d['recorded']['updatedAt']}  @ {d['recorded']['gitHead']}"
+        )
+        if not ch["resolvable"]:
+            print("  since    : recorded gitHead unresolvable — full re-review advised")
+        print(f"  committed changed files : {len(ch['committed'])}")
+        print(f"  uncommitted changes     : {len(ch['uncommitted'])}")
+        for f in ch["committed"][:20]:
+            print(f"    + {f}")
+
+    _emit(data, as_json, _text)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# status
+# ---------------------------------------------------------------------------
+
+
+def cmd_status(root: Path, as_json: bool) -> int:
+    state = wc.read_state(root)
+    if state is None:
+        data = {
+            "mode": "status",
+            "status": (
+                "not_initialized" if not wc.wiki_has_content(root) else "no_state"
+            ),
+            "root": str(root),
+            "message": (
+                "no wiki state recorded — run `init`."
+                if not wc.wiki_has_content(root)
+                else "wiki/ present but no recorded state — run `finalize --command init`."
+            ),
+        }
+        _emit(data, as_json, lambda d: print(d["message"]))
+        return 0
+
+    changes = wc.git_changed_files(root, state.get("gitHead"))
+    current_hash = wc.content_hash(root)
+    source_drift = len(changes["committed"]) + len(changes["uncommitted"])
+    wiki_edited = current_hash != state.get("contentHash")
+    resolvable = changes["resolvable"]
+    # An unresolvable recorded gitHead (history rewritten / commit gone) means the
+    # source-diff could not be computed — never report "current" in that case
+    # (mirrors cmd_update's full-re-review advisory).
+    if not resolvable:
+        status = "unknown"
+    elif source_drift or wiki_edited:
+        status = "drifted"
+    else:
+        status = "current"
+    data = {
+        "mode": "status",
+        "status": status,
+        "root": str(root),
+        "updatedAt": state.get("updatedAt"),
+        "gitHead": state.get("gitHead"),
+        "resolvable": resolvable,
+        "source_changes_since": source_drift,
+        "wiki_edited_since_record": wiki_edited,
+    }
+
+    def _text(d):
+        print(f"aim-wiki status — {d['status']} ({d['root']})")
+        print(f"  last run : {d['updatedAt']}  @ {d['gitHead']}")
+        if not d["resolvable"]:
+            print("  since    : recorded gitHead unresolvable — full re-review advised")
+        print(f"  source changes since last run : {d['source_changes_since']}")
+        print(f"  wiki edited since last record : {d['wiki_edited_since_record']}")
+
+    _emit(data, as_json, _text)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# verify
+# ---------------------------------------------------------------------------
+
+
+def cmd_verify(root: Path, as_json: bool) -> int:
+    if not wc.wiki_has_content(root):
+        data = {
+            "mode": "verify",
+            "status": "not_initialized",
+            "message": "no wiki to verify — run `init` first.",
+        }
+        _emit(data, as_json, lambda d: print(d["message"]))
+        return 0
+
+    manifest = build_manifest(root)
+    manifest["mode"] = "verify"
+    manifest["status"] = (
+        "dead_citations" if manifest["dead_count"] else "citations_resolve"
+    )
+
+    def _text(d):
+        print(
+            f"aim-wiki verify — {d['page_count']} pages, "
+            f"{d['citation_count']} source citations, {d['dead_count']} dead"
+        )
+        for dead in d["dead_citations"]:
+            print(f"  DEAD  {dead['page']}  ->  {dead['ref']}")
+        print(
+            "Now dispatch a read-only verifier subagent with this manifest to check "
+            "that each page's CLAIMS match the cited source (grounding, not just "
+            "existence). Surface all discrepancies before acceptance."
+        )
+
+    _emit(manifest, as_json, _text)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# finalize
+# ---------------------------------------------------------------------------
+
+
+def cmd_finalize(root: Path, command: str, as_json: bool) -> int:
+    if not wc.wiki_has_content(root):
+        data = {
+            "mode": "finalize",
+            "status": "not_initialized",
+            "command": command,
+            "root": str(root),
+            "message": "no wiki content to finalize — author wiki/ pages first "
+            "(run `init`). Pointer + state not written.",
+        }
+        _emit(data, as_json, lambda d: print(d["message"]))
+        return 0
+    pointer_changed = upsert_pointer(root)
+    head = wc.git_head(root)
+    state = wc.write_state(root, command, head)
+    data = {
+        "mode": "finalize",
+        "status": "recorded",
+        "command": command,
+        "root": str(root),
+        "pointer_files_changed": pointer_changed,
+        "state": state,
+    }
+
+    def _text(d):
+        print(f"aim-wiki finalize — recorded ({d['command']})")
+        print(f"  gitHead     : {d['state']['gitHead']}")
+        print(f"  contentHash : {d['state']['contentHash']}")
+        print(f"  updatedAt   : {d['state']['updatedAt']}")
+        pc = d["pointer_files_changed"]
+        print(f"  pointer     : {', '.join(pc) if pc else 'already current'}")
+
+    _emit(data, as_json, _text)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
+        "--root",
+        metavar="PATH",
+        help="Project root override (default: git toplevel, else cwd)",
+    )
+    common.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="Machine-readable JSON output",
+    )
+
+    parser = argparse.ArgumentParser(
+        prog="aim_wiki", description="aim-wiki engine (deterministic operations)"
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_init = sub.add_parser("init", parents=[common], help="Prep a fresh wiki")
+    p_init.add_argument(
+        "--force", action="store_true", help="Rebuild even if wiki/ already has content"
+    )
+    sub.add_parser("update", parents=[common], help="Prep an incremental refresh")
+    sub.add_parser("status", parents=[common], help="Read-only freshness report")
+    sub.add_parser("verify", parents=[common], help="Emit the verifier manifest")
+    p_fin = sub.add_parser(
+        "finalize", parents=[common], help="Upsert pointer + record run-state"
+    )
+    p_fin.add_argument(
+        "--command",
+        choices=("init", "update"),
+        required=True,
+        help="Which run is being finalized",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    root = wc.resolve_root(args.root)
+    as_json = args.as_json
+
+    if args.cmd == "init":
+        return cmd_init(root, args.force, as_json)
+    if args.cmd == "update":
+        return cmd_update(root, as_json)
+    if args.cmd == "status":
+        return cmd_status(root, as_json)
+    if args.cmd == "verify":
+        return cmd_verify(root, as_json)
+    if args.cmd == "finalize":
+        return cmd_finalize(root, args.command, as_json)
+    return 1  # unreachable (subparser required)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/_ai-memory/skills/aim-wiki/scripts/aim_wiki.py
+++ b/_ai-memory/skills/aim-wiki/scripts/aim_wiki.py
@@ -23,7 +23,9 @@ Subcommands:
 Common flags: --root PATH (override project root), --json.
 Invoked via run-with-env.sh (the AI-memory run-with-env convention).
 Exit codes: 0 success (incl. routing messages like wiki-already-exists);
-1 usage/system error.
+1 usage/system error; 2 finalize refused the pointer write (a CLAUDE.md/AGENTS.md
+had malformed AI-memory markers — resolve manually and re-run). Exit 2 mirrors
+scripts/merge_agents_md.py's malformed-marker convention.
 """
 
 import argparse
@@ -271,7 +273,7 @@ def cmd_finalize(root: Path, command: str, as_json: bool) -> int:
         }
         _emit(data, as_json, lambda d: print(d["message"]))
         return 0
-    pointer_changed = upsert_pointer(root)
+    pointer = upsert_pointer(root)
     head = wc.git_head(root)
     state = wc.write_state(root, command, head)
     data = {
@@ -279,7 +281,11 @@ def cmd_finalize(root: Path, command: str, as_json: bool) -> int:
         "status": "recorded",
         "command": command,
         "root": str(root),
-        "pointer_files_changed": pointer_changed,
+        "pointer_files_changed": pointer.changed,
+        # Distinct machine signal: files left unwritten because their AI-memory
+        # markers were malformed. A true no-op reports [] here AND [] in
+        # pointer_files_changed; a refusal is the only case that populates this.
+        "pointer_files_refused": pointer.refused,
         "state": state,
     }
 
@@ -289,10 +295,21 @@ def cmd_finalize(root: Path, command: str, as_json: bool) -> int:
         print(f"  contentHash : {d['state']['contentHash']}")
         print(f"  updatedAt   : {d['state']['updatedAt']}")
         pc = d["pointer_files_changed"]
-        print(f"  pointer     : {', '.join(pc) if pc else 'already current'}")
+        pr = d["pointer_files_refused"]
+        if pc:
+            print(f"  pointer     : {', '.join(pc)}")
+        elif not pr:
+            print("  pointer     : already current")
+        if pr:
+            print(
+                f"  pointer     : REFUSED {', '.join(pr)} — AI-memory markers "
+                f"malformed; resolve manually, then re-run"
+            )
 
     _emit(data, as_json, _text)
-    return 0
+    # A refused pointer write is an actionable failure — exit non-zero so callers
+    # and CI don't read the run as fully clean (state is still recorded).
+    return 2 if pointer.refused else 0
 
 
 # ---------------------------------------------------------------------------

--- a/_ai-memory/skills/aim-wiki/scripts/aim_wiki.py
+++ b/_ai-memory/skills/aim-wiki/scripts/aim_wiki.py
@@ -23,9 +23,12 @@ Subcommands:
 Common flags: --root PATH (override project root), --json.
 Invoked via run-with-env.sh (the AI-memory run-with-env convention).
 Exit codes: 0 success (incl. routing messages like wiki-already-exists);
-1 usage/system error; 2 finalize refused the pointer write (a CLAUDE.md/AGENTS.md
-had malformed AI-memory markers — resolve manually and re-run). Exit 2 mirrors
-scripts/merge_agents_md.py's malformed-marker convention.
+1 system error; 2 finalize refused the pointer write (a CLAUDE.md/AGENTS.md
+had malformed AI-memory markers — resolve manually and re-run), mirroring
+scripts/merge_agents_md.py's malformed-marker convention. Exit 2 is ALSO
+argparse's own usage-error code, so a programmatic caller MUST treat the
+pointer_files_refused field in --json output — not exit 2 alone — as the
+authoritative refusal signal.
 """
 
 import argparse
@@ -297,7 +300,7 @@ def cmd_finalize(root: Path, command: str, as_json: bool) -> int:
         pc = d["pointer_files_changed"]
         pr = d["pointer_files_refused"]
         if pc:
-            print(f"  pointer     : {', '.join(pc)}")
+            print(f"  pointer     : updated {', '.join(pc)}")
         elif not pr:
             print("  pointer     : already current")
         if pr:

--- a/_ai-memory/skills/aim-wiki/scripts/wiki_common.py
+++ b/_ai-memory/skills/aim-wiki/scripts/wiki_common.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""aim-wiki — shared deterministic helpers.
+
+Project/root resolution, wiki-dir layout, run-state (content-hash + gitHead +
+updatedAt), and git evidence. Pure stdlib — no external deps, so the engine runs
+under any Python without run-with-env's venv (though it is invoked via
+run-with-env.sh per the AI-memory run-with-env convention).
+
+Multi-project scoping: the wiki is written ONLY under <project_root>/wiki/, and
+the root is resolved from the current git toplevel (or an explicit --root). No
+cross-project bleed — the engine never touches another project's tree.
+"""
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+WIKI_DIRNAME = "wiki"
+STATE_FILENAME = ".last-update.json"
+PLAN_FILENAME = "_plan.md"
+# Files under wiki/ that are transient/metadata and must not count toward the
+# content hash (mirrors upstream createOpenWikiContentSnapshot excluding the
+# metadata file; _plan.md is the temporary plan the agent deletes before finish).
+_HASH_EXCLUDE = {STATE_FILENAME, PLAN_FILENAME}
+
+_GIT_TIMEOUT = 15
+
+
+# ---------------------------------------------------------------------------
+# Root + project scoping
+# ---------------------------------------------------------------------------
+
+
+def resolve_root(override: str | None = None) -> Path:
+    """Resolve the project root.
+
+    1. --root override (returned as-is; may not exist).
+    2. git toplevel of the current working directory.
+    3. Fallback: the current working directory.
+    """
+    if override is not None:
+        return Path(override)
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=_GIT_TIMEOUT,
+        )
+        return Path(result.stdout.strip())
+    except (
+        subprocess.CalledProcessError,
+        FileNotFoundError,
+        subprocess.TimeoutExpired,
+    ):
+        return Path.cwd()
+
+
+def resolve_project_id(root: Path) -> str | None:
+    """Best-effort AI-memory project id (for status display + the deferred
+    memory-store seam). Degrades to None when the memory stack is unavailable —
+    scoping is guaranteed by the resolved root, not by this id.
+    """
+    try:
+        install = os.environ.get(
+            "AI_MEMORY_INSTALL_DIR", os.path.expanduser("~/.ai-memory")
+        )
+        src = os.path.join(install, "src")
+        if src not in sys.path:
+            sys.path.insert(0, src)
+        from memory.project import resolve_project_id as _rpi  # type: ignore
+
+        return _rpi(cwd=str(root), warn=False)
+    except Exception:
+        return None
+
+
+def wiki_dir(root: Path) -> Path:
+    return root / WIKI_DIRNAME
+
+
+def state_path(root: Path) -> Path:
+    return wiki_dir(root) / STATE_FILENAME
+
+
+def wiki_has_content(root: Path) -> bool:
+    """True when wiki/ holds any authored markdown page (ignoring state + plan)."""
+    wd = wiki_dir(root)
+    if not wd.is_dir():
+        return False
+    return any(p.name not in _HASH_EXCLUDE for p in wd.rglob("*.md"))
+
+
+# ---------------------------------------------------------------------------
+# Content hash + run-state
+# ---------------------------------------------------------------------------
+
+
+def content_hash(root: Path) -> str:
+    """sha256 over the wiki's authored content: sorted (relpath, bytes), the
+    metadata + plan files excluded. Stable across runs when nothing changed —
+    this is the no-op detector (an update that changes nothing keeps the hash).
+    """
+    wd = wiki_dir(root)
+    h = hashlib.sha256()
+    if not wd.is_dir():
+        return h.hexdigest()
+    files = sorted(
+        (p for p in wd.rglob("*") if p.is_file() and p.name not in _HASH_EXCLUDE),
+        key=lambda p: p.relative_to(wd).as_posix(),
+    )
+    for p in files:
+        rel = p.relative_to(wd).as_posix()
+        h.update(rel.encode("utf-8"))
+        h.update(b"\0")
+        h.update(p.read_bytes())
+        h.update(b"\0")
+    return h.hexdigest()
+
+
+def read_state(root: Path) -> dict | None:
+    """Read wiki/.last-update.json, or None when absent/unparseable."""
+    sp = state_path(root)
+    if not sp.exists():
+        return None
+    try:
+        data = json.loads(sp.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else None
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def write_state(root: Path, command: str, git_head: str | None) -> dict:
+    """Write run-state after acceptance: updatedAt, command, gitHead, contentHash.
+
+    No `model` field (unlike upstream): Claude Code is the model — there is no
+    provider to record in v1.
+    """
+    wiki_dir(root).mkdir(parents=True, exist_ok=True)
+    state = {
+        "updatedAt": _now_iso(),
+        "command": command,
+        "gitHead": git_head,
+        "contentHash": content_hash(root),
+    }
+    state_path(root).write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+    return state
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Git evidence
+# ---------------------------------------------------------------------------
+
+
+def _git(root: Path, args: list[str]) -> str | None:
+    """Run a git command at root; return stripped stdout, or None on any failure
+    (not a git repo, git absent, timeout)."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), *args],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=_GIT_TIMEOUT,
+        )
+        return result.stdout.strip()
+    except (
+        subprocess.CalledProcessError,
+        FileNotFoundError,
+        subprocess.TimeoutExpired,
+    ):
+        return None
+
+
+def git_head(root: Path) -> str | None:
+    return _git(root, ["rev-parse", "HEAD"])
+
+
+def is_git_repo(root: Path) -> bool:
+    return _git(root, ["rev-parse", "--is-inside-work-tree"]) == "true"
+
+
+def git_summary(root: Path, n: int = 20) -> str:
+    """Recent-history summary for init grounding: branch + last n commits.
+    Empty string when the project is not a git repo."""
+    if not is_git_repo(root):
+        return "(not a git repository — no git history available)"
+    branch = _git(root, ["rev-parse", "--abbrev-ref", "HEAD"]) or "(unknown)"
+    log = _git(root, ["log", "--oneline", "-n", str(n)]) or "(no commits)"
+    return f"branch: {branch}\nrecent commits:\n{log}"
+
+
+def _is_wiki_managed(path: str) -> bool:
+    """True for paths the wiki flow owns — the wiki dir itself and the pointer
+    files. These are excluded from the SOURCE-drift signal: editing the docs (or
+    the pointer) is not the source changing out from under the docs.
+
+    Known v1 limitation: this excludes the WHOLE top-level CLAUDE.md/AGENTS.md,
+    not just the injected `## Project Wiki` pointer section — so unrelated edits to
+    those files don't register as source drift. Pointer-section-scoped drift is a
+    v2 refinement.
+    """
+    return (
+        path == "CLAUDE.md"
+        or path == "AGENTS.md"
+        or path.startswith(WIKI_DIRNAME + "/")
+    )
+
+
+def git_changed_files(root: Path, since_head: str | None) -> dict:
+    """Source files changed since the recorded gitHead + any uncommitted source
+    changes (wiki-managed paths excluded — see _is_wiki_managed).
+
+    Returns {"since": <head or None>, "committed": [...], "uncommitted": [...],
+    "resolvable": bool}. `resolvable` is False when since_head is missing or no
+    longer resolves (e.g. history rewritten) — the caller then treats the update
+    as a full re-review rather than an incremental diff.
+    """
+    committed: list[str] = []
+    resolvable = False
+    if (
+        since_head
+        and _git(root, ["cat-file", "-e", f"{since_head}^{{commit}}"]) is not None
+    ):
+        resolvable = True
+        # `-c core.quotePath=false` keeps non-ASCII paths literal (UTF-8) instead
+        # of octal-escaped + double-quoted, so they parse unmangled.
+        diff = _git(
+            root,
+            [
+                "-c",
+                "core.quotePath=false",
+                "diff",
+                "--name-only",
+                f"{since_head}..HEAD",
+            ],
+        )
+        committed = [
+            ln for ln in (diff or "").splitlines() if ln and not _is_wiki_managed(ln)
+        ]
+    porcelain = (
+        _git(root, ["-c", "core.quotePath=false", "status", "--porcelain"]) or ""
+    )
+    uncommitted = []
+    for ln in porcelain.splitlines():
+        # Robust parse: the path is the token after the XY status code, regardless
+        # of the code's leading-space alignment (which _git's strip() can eat on
+        # the first line). Renames are "ORIG -> NEW" — keep NEW.
+        parts = ln.split(None, 1)
+        if len(parts) < 2:
+            continue
+        path = parts[1]
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        if not _is_wiki_managed(path):
+            uncommitted.append(path)
+    return {
+        "since": since_head,
+        "committed": committed,
+        "uncommitted": uncommitted,
+        "resolvable": resolvable,
+    }

--- a/_ai-memory/skills/aim-wiki/scripts/wiki_inventory.py
+++ b/_ai-memory/skills/aim-wiki/scripts/wiki_inventory.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""aim-wiki — deterministic repository inventory.
+
+A bounded, heuristic scan that classifies a project's files into the buckets an
+init run needs as grounding (existing docs, entrypoints, config, tests, schema).
+Deterministic work only — the in-session agent does the reasoning over this
+inventory; the engine never authors prose.
+"""
+
+import re
+from pathlib import Path
+
+# Directories never worth walking (caches, deps, build output, VCS, the wiki
+# itself). Matched by directory name at any depth.
+_SKIP_DIRS = {
+    ".git",
+    ".hg",
+    ".svn",
+    "node_modules",
+    "dist",
+    "build",
+    "out",
+    "target",
+    ".venv",
+    "venv",
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".next",
+    ".nuxt",
+    ".cache",
+    "coverage",
+    ".idea",
+    ".vscode",
+    "vendor",
+    "wiki",
+}
+
+# Bound the walk so a huge repo can't stall the scan (Stop-hook-safe posture,
+# mirrors aim-sot's discovery budgets). Truncation is reported, never silent.
+_MAX_FILES = 20000
+
+_ENTRYPOINT_NAMES = {
+    "main.py",
+    "__main__.py",
+    "cli.py",
+    "app.py",
+    "manage.py",
+    "wsgi.py",
+    "asgi.py",
+    "index.js",
+    "index.ts",
+    "index.tsx",
+    "cli.ts",
+    "cli.tsx",
+    "server.js",
+    "server.ts",
+    "main.go",
+    "main.rs",
+    "main.c",
+    "main.cpp",
+    "Main.java",
+}
+_ENTRYPOINT_RE = re.compile(
+    r"^(main|index|cli|app|server|entrypoint)\.[a-z0-9]+$", re.I
+)
+
+_CONFIG_NAMES = {
+    "package.json",
+    "pyproject.toml",
+    "setup.py",
+    "setup.cfg",
+    "requirements.txt",
+    "Pipfile",
+    "cargo.toml",
+    "go.mod",
+    "tsconfig.json",
+    "dockerfile",
+    "docker-compose.yml",
+    "docker-compose.yaml",
+    "makefile",
+    "pnpm-workspace.yaml",
+    "pom.xml",
+    "build.gradle",
+}
+_CONFIG_EXT = {".toml", ".ini", ".cfg"}
+
+_DOC_NAMES = {
+    "readme",
+    "changelog",
+    "contributing",
+    "agents",
+    "claude",
+    "skill",
+    "license",
+}
+
+_SCHEMA_EXT = {".sql", ".prisma", ".graphql", ".gql"}
+_SCHEMA_NAME_RE = re.compile(r"^(schema|openapi|swagger)\b", re.I)
+
+_TEST_PATH_RE = re.compile(r"(^|/)(tests?|spec|__tests__)(/|$)", re.I)
+_TEST_FILE_RE = re.compile(
+    r"(^test_.*\.py$|.*_test\.(py|go|rb)$|.*\.(test|spec)\.(ts|tsx|js|jsx)$)", re.I
+)
+
+_PER_BUCKET_CAP = 60
+
+
+def _classify(rel: str, name: str) -> str | None:
+    """Return the bucket for a file, or None if it isn't inventory-notable.
+    First match wins in priority order: config, entrypoint, schema, tests, docs.
+    """
+    lname = name.lower()
+    stem = lname.rsplit(".", 1)[0]
+    ext = ("." + lname.rsplit(".", 1)[1]) if "." in lname else ""
+
+    if lname in _CONFIG_NAMES or (ext in _CONFIG_EXT and "/" not in rel):
+        return "config"
+    if ".github/workflows/" in rel:
+        return "config"
+    if lname in _ENTRYPOINT_NAMES or _ENTRYPOINT_RE.match(name):
+        return "entrypoints"
+    if (
+        ext in _SCHEMA_EXT
+        or _SCHEMA_NAME_RE.match(name)
+        or "/migrations/" in ("/" + rel)
+    ):
+        return "schema"
+    if _TEST_PATH_RE.search(rel) or _TEST_FILE_RE.match(name):
+        return "tests"
+    if stem in _DOC_NAMES or (
+        ext == ".md" and (rel.startswith("docs/") or "/docs/" in rel)
+    ):
+        return "docs"
+    if ext == ".md" and "/" not in rel:  # top-level markdown = doc
+        return "docs"
+    return None
+
+
+def build_inventory(root: Path) -> dict:
+    """Walk the project (bounded, excludes applied) and bucket notable files.
+
+    Returns a dict with per-bucket file lists (capped), top-level directories,
+    the total files scanned, and a `truncated` flag when the walk hit the cap.
+    """
+    buckets: dict[str, list[str]] = {
+        "docs": [],
+        "entrypoints": [],
+        "config": [],
+        "tests": [],
+        "schema": [],
+    }
+    top_dirs: list[str] = []
+    scanned = 0
+    truncated = False
+
+    for child in sorted(root.iterdir() if root.is_dir() else []):
+        if child.is_dir() and child.name not in _SKIP_DIRS:
+            top_dirs.append(child.name + "/")
+
+    stack = [root]
+    while stack:
+        current = stack.pop()
+        try:
+            entries = sorted(current.iterdir())
+        except OSError:
+            continue
+        for entry in entries:
+            if entry.is_dir():
+                if entry.name not in _SKIP_DIRS:
+                    stack.append(entry)
+                continue
+            scanned += 1
+            if scanned > _MAX_FILES:
+                truncated = True
+                break
+            rel = entry.relative_to(root).as_posix()
+            bucket = _classify(rel, entry.name)
+            if bucket and len(buckets[bucket]) < _PER_BUCKET_CAP:
+                buckets[bucket].append(rel)
+        if truncated:
+            break
+
+    return {
+        "root": str(root),
+        "top_level_dirs": top_dirs,
+        "files_scanned": scanned,
+        "truncated": truncated,
+        **buckets,
+    }

--- a/_ai-memory/skills/aim-wiki/scripts/wiki_pointer.py
+++ b/_ai-memory/skills/aim-wiki/scripts/wiki_pointer.py
@@ -16,9 +16,11 @@ Ownership / idempotency (BP-171 OQ-3): the pointer is delivered as a managed
 marker block delimited by `<!-- BEGIN AI-MEMORY (managed aim-wiki) -->` …
 `<!-- END AI-MEMORY (managed aim-wiki) -->`. Idempotency keys on the MARKER
 pair, never on the human-readable `## Project Wiki` heading, so a user's own
-same-named section is never clobbered. Everything outside the markers is
-preserved byte-for-byte. Writes are backup-copy-first + atomic (mirrors
-scripts/merge_settings.py and scripts/merge_agents_md.py).
+same-named section is never clobbered. Content outside the markers is preserved
+verbatim, except that the UTF-8 text-mode read/write round-trip normalizes line
+endings — a CRLF (or lone-CR) source is rewritten with LF endings on any real
+change. Writes are backup-copy-first + atomic (mirrors scripts/merge_settings.py
+and scripts/merge_agents_md.py).
 """
 
 import os
@@ -28,6 +30,7 @@ import sys
 import tempfile
 from datetime import datetime
 from pathlib import Path
+from typing import NamedTuple
 
 POINTER_HEADING = "## Project Wiki"
 
@@ -65,6 +68,29 @@ _SECTION_RE = re.compile(
 )
 
 
+class MalformedMarkersError(Exception):
+    """Raised by splice_block when the managed markers are in an unsafe state.
+
+    Safe states: (0 BEGIN + 0 END) or (exactly 1 BEGIN strictly before 1 END).
+    Any other combination — stray BEGIN or END, END before BEGIN, duplicate
+    blocks — is malformed; the caller must warn and leave the file unchanged.
+    Mirrors scripts/merge_agents_md.py's MalformedMarkersError contract.
+    """
+
+
+class PointerResult(NamedTuple):
+    """Outcome of an upsert_pointer run, split by disposition.
+
+    `changed`: repo-relative paths written (created or updated). `refused`:
+    repo-relative paths left untouched because their markers were malformed —
+    an actionable failure distinct from a true no-op (both leave `changed`
+    empty), so the CLI can signal it separately.
+    """
+
+    changed: list[str]
+    refused: list[str]
+
+
 def build_block() -> str:
     """Wrap the pointer section in the stable managed-block markers."""
     return f"{BEGIN_MARKER}\n{POINTER_SECTION.strip()}\n{END_MARKER}"
@@ -90,10 +116,14 @@ def splice_block(text: str) -> str:
     - 0 BEGIN + 0 END → migrate a legacy markerless aim-wiki section once (only
       when its body matches the template), else append the managed block. A
       user-authored `## Project Wiki` section is left untouched.
-    - Any other marker state (stray, duplicate, or out-of-order) → return the
-      text unchanged; the caller writes nothing (a WARNING is printed to stderr).
+    - Any other marker state (stray, duplicate, or out-of-order) → raise
+      MalformedMarkersError; the caller warns and leaves the file unchanged.
 
     The result is idempotent: splicing an already-spliced document reproduces it.
+
+    Raises:
+        MalformedMarkersError: markers are present but not in a safe state.
+            The caller is responsible for warning and writing nothing.
     """
     block = build_block()
     n_begin = text.count(BEGIN_MARKER)
@@ -104,6 +134,13 @@ def splice_block(text: str) -> str:
         end_idx = text.find(END_MARKER)
         if end_idx > begin_idx:
             # Replace-in-place: keep bytes before BEGIN and after END untouched.
+            # Accepted residual: a document whose ONLY markers are a single
+            # balanced BEGIN…END pair (even one wrapping purely user-authored
+            # text) is indistinguishable from a stale managed block, so
+            # replace-in-place applies. Refusing would break idempotent re-run;
+            # the prior content stays backup-recoverable. Do not change this
+            # branch to refuse — that would be a regression (mirrors
+            # scripts/merge_agents_md.py's replace-in-place caveat).
             pre = text[:begin_idx]
             post = text[end_idx + len(END_MARKER) :]
             return pre + block + post
@@ -120,15 +157,14 @@ def splice_block(text: str) -> str:
         separator = "" if text.endswith("\n") else "\n"
         return text + separator + "\n" + block + "\n"
 
-    # Malformed markers: refuse and leave the file unchanged (caller writes
-    # nothing). Never risk clobbering user content on an ambiguous marker state.
-    print(
-        f"WARNING: aim-wiki managed markers are malformed "
-        f"({n_begin} BEGIN, {n_end} END; expected 0+0 or 1 BEGIN before 1 END). "
-        f"Pointer left unchanged — resolve the markers manually, then re-run.",
-        file=sys.stderr,
+    # Malformed markers: stray BEGIN or END, END before BEGIN, or duplicates.
+    # Refuse (pure; no IO) so the caller can warn, leave the file unchanged, and
+    # signal the refusal distinctly. Never risk clobbering user content on an
+    # ambiguous marker state.
+    raise MalformedMarkersError(
+        f"{n_begin} BEGIN marker(s) and {n_end} END marker(s) found "
+        f"(expected 0+0 or 1 BEGIN before 1 END)"
     )
-    return text
 
 
 def _backup_file(path: Path) -> Path:
@@ -143,13 +179,18 @@ def _backup_file(path: Path) -> Path:
     return backup_path
 
 
-def upsert_pointer(root: Path) -> list[str]:
+def upsert_pointer(root: Path) -> PointerResult:
     """Upsert the pointer into the correct top-level file(s).
 
-    Returns the repo-relative paths that were created or changed (empty when the
-    managed block is already present and identical — a true no-op: no write, no
-    backup). On change, writes are backup-copy-first then atomic (tempfile +
-    os.replace) so a crash mid-write cannot truncate the user's file.
+    Returns a PointerResult splitting the outcome per file:
+    - `changed`: paths created or updated (empty when the managed block is
+      already present and identical — a true no-op: no write, no backup).
+    - `refused`: paths left untouched because their markers were malformed
+      (a WARNING is printed to stderr; no write, no backup) — an actionable
+      failure the caller surfaces separately from a no-op.
+
+    On change, writes are backup-copy-first then atomic (tempfile + os.replace)
+    so a crash mid-write cannot truncate the user's file.
     """
     claude = root / "CLAUDE.md"
     agents = root / "AGENTS.md"
@@ -158,9 +199,23 @@ def upsert_pointer(root: Path) -> list[str]:
         targets = [agents]  # neither exists → create AGENTS.md
 
     changed: list[str] = []
+    refused: list[str] = []
     for path in targets:
         original = path.read_text(encoding="utf-8") if path.exists() else ""
-        updated = splice_block(original)
+        try:
+            updated = splice_block(original)
+        except MalformedMarkersError as exc:
+            # Refuse: leave the file byte-for-byte unchanged (no write, no
+            # backup) and record it as refused so the caller can distinguish it
+            # from a true no-op. Keep the stderr WARNING for tty/log visibility.
+            print(
+                f"WARNING: {path.name}: aim-wiki managed markers are malformed "
+                f"({exc}). Pointer left unchanged — resolve the markers "
+                f"manually, then re-run.",
+                file=sys.stderr,
+            )
+            refused.append(path.relative_to(root).as_posix())
+            continue
         if updated == original:
             continue  # true no-op: no write, no backup
         if path.exists():
@@ -178,4 +233,4 @@ def upsert_pointer(root: Path) -> list[str]:
                 os.unlink(temp_path)
             raise
         changed.append(path.relative_to(root).as_posix())
-    return changed
+    return PointerResult(changed=changed, refused=refused)

--- a/_ai-memory/skills/aim-wiki/scripts/wiki_pointer.py
+++ b/_ai-memory/skills/aim-wiki/scripts/wiki_pointer.py
@@ -18,9 +18,12 @@ marker block delimited by `<!-- BEGIN AI-MEMORY (managed aim-wiki) -->` …
 pair, never on the human-readable `## Project Wiki` heading, so a user's own
 same-named section is never clobbered. Content outside the markers is preserved
 verbatim, except that the UTF-8 text-mode read/write round-trip normalizes line
-endings — a CRLF (or lone-CR) source is rewritten with LF endings on any real
-change. Writes are backup-copy-first + atomic (mirrors scripts/merge_settings.py
-and scripts/merge_agents_md.py).
+endings: the universal-newlines read collapses CRLF/lone-CR to `\n`, and the
+text-mode write emits `os.linesep`. On this project's POSIX/Linux/WSL deployment
+(`os.linesep == "\n"`) that rewrites a CRLF (or lone-CR) source with LF endings on
+any real change; on a platform whose `os.linesep` differs, the written ending
+follows that platform, not necessarily LF. Writes are backup-copy-first + atomic
+(mirrors scripts/merge_settings.py and scripts/merge_agents_md.py).
 """
 
 import os

--- a/_ai-memory/skills/aim-wiki/scripts/wiki_pointer.py
+++ b/_ai-memory/skills/aim-wiki/scripts/wiki_pointer.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""aim-wiki — CLAUDE.md / AGENTS.md pointer injection.
+
+Deterministic string templating: upsert an AI-memory-branded `## Project Wiki`
+reference section into the project's top-level agent-instruction file(s), so any
+coding agent is told to consult the wiki. Adapted from OpenWiki prompt.ts:57-78
+(concept reuse, MIT — paraphrased, not lifted) with an AI-memory trust-but-verify
+line added.
+
+Placement rule (mirrors prompt.ts:57-64):
+- Upsert into top-level CLAUDE.md and/or AGENTS.md wherever they already exist.
+- If NEITHER exists, create AGENTS.md containing only the section.
+- Only ever the top-level files — never nested CLAUDE.md/AGENTS.md.
+- Replace an existing section in place (idempotent); preserve surrounding content.
+"""
+
+import re
+from pathlib import Path
+
+POINTER_HEADING = "## Project Wiki"
+
+POINTER_SECTION = """\
+## Project Wiki
+
+This repository has an AI-maintained wiki in the `wiki/` directory.
+
+Start here:
+- [Wiki quickstart](wiki/quickstart.md)
+
+The wiki covers the repository overview, architecture, key workflows, domain
+concepts, operations, and testing guidance. Read the quickstart first, then
+follow its links to the area you are changing.
+
+Treat the wiki as a starting map, not ground truth: confirm any specific file,
+function, or flag against current source before relying on it. It is maintained
+with `aim-wiki` — run an update when your changes make a page stale.
+"""
+
+# Matches an existing `## Project Wiki` block: the heading through to (but not
+# including) the next heading of level <=2 (`# ` H1 or `## ` H2), or end-of-file.
+# Terminating only at `## ` (as before) swallowed a following `# H1` on replace
+# (data-loss); `#{1,2}[ \t]` stops at H1/H2 while leaving deeper `###` subsections
+# as part of the regenerated section.
+_SECTION_RE = re.compile(
+    r"^##[ \t]+Project Wiki[ \t]*$.*?(?=^#{1,2}[ \t]|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def upsert_section(text: str) -> str:
+    """Return `text` with the Project Wiki section inserted or replaced.
+
+    Existing section → replaced in place (surrounding content preserved).
+    No section → appended, separated by a blank line.
+    """
+    block = POINTER_SECTION.rstrip("\n") + "\n"
+    if _SECTION_RE.search(text):
+        return _SECTION_RE.sub(lambda _m: block, text, count=1)
+    if text and not text.endswith("\n"):
+        text += "\n"
+    if text.strip():
+        text += "\n"
+    return text + block
+
+
+def upsert_pointer(root: Path) -> list[str]:
+    """Upsert the pointer into the correct top-level file(s).
+
+    Returns the repo-relative paths that were created or changed (empty when the
+    section was already present and identical — the write is a true no-op).
+    """
+    claude = root / "CLAUDE.md"
+    agents = root / "AGENTS.md"
+    targets = [p for p in (claude, agents) if p.exists()]
+    if not targets:
+        targets = [agents]  # neither exists → create AGENTS.md
+
+    changed: list[str] = []
+    for path in targets:
+        original = path.read_text(encoding="utf-8") if path.exists() else ""
+        updated = upsert_section(original)
+        if updated != original:
+            path.write_text(updated, encoding="utf-8")
+            changed.append(path.relative_to(root).as_posix())
+    return changed

--- a/_ai-memory/skills/aim-wiki/scripts/wiki_pointer.py
+++ b/_ai-memory/skills/aim-wiki/scripts/wiki_pointer.py
@@ -11,10 +11,22 @@ Placement rule (mirrors prompt.ts:57-64):
 - Upsert into top-level CLAUDE.md and/or AGENTS.md wherever they already exist.
 - If NEITHER exists, create AGENTS.md containing only the section.
 - Only ever the top-level files — never nested CLAUDE.md/AGENTS.md.
-- Replace an existing section in place (idempotent); preserve surrounding content.
+
+Ownership / idempotency (BP-171 OQ-3): the pointer is delivered as a managed
+marker block delimited by `<!-- BEGIN AI-MEMORY (managed aim-wiki) -->` …
+`<!-- END AI-MEMORY (managed aim-wiki) -->`. Idempotency keys on the MARKER
+pair, never on the human-readable `## Project Wiki` heading, so a user's own
+same-named section is never clobbered. Everything outside the markers is
+preserved byte-for-byte. Writes are backup-copy-first + atomic (mirrors
+scripts/merge_settings.py and scripts/merge_agents_md.py).
 """
 
+import os
 import re
+import shutil
+import sys
+import tempfile
+from datetime import datetime
 from pathlib import Path
 
 POINTER_HEADING = "## Project Wiki"
@@ -36,38 +48,108 @@ function, or flag against current source before relying on it. It is maintained
 with `aim-wiki` — run an update when your changes make a page stale.
 """
 
-# Matches an existing `## Project Wiki` block: the heading through to (but not
+# Managed-block markers (BP-171 OQ-3 canonical form). aim-wiki-specific so this
+# block never collides with the Codex `<!-- BEGIN AI-MEMORY -->` guidance block
+# managed by scripts/merge_agents_md.py in the same AGENTS.md.
+BEGIN_MARKER = "<!-- BEGIN AI-MEMORY (managed aim-wiki) -->"
+END_MARKER = "<!-- END AI-MEMORY (managed aim-wiki) -->"
+
+# Matches a markerless `## Project Wiki` block: the heading through to (but not
 # including) the next heading of level <=2 (`# ` H1 or `## ` H2), or end-of-file.
-# Terminating only at `## ` (as before) swallowed a following `# H1` on replace
-# (data-loss); `#{1,2}[ \t]` stops at H1/H2 while leaving deeper `###` subsections
-# as part of the regenerated section.
+# `#{1,2}[ \t]` stops at H1/H2 while leaving deeper `###` subsections as part of
+# the section. Used ONLY to detect a legacy aim-wiki markerless section eligible
+# for one-time migration to the marked form — never to key idempotency.
 _SECTION_RE = re.compile(
     r"^##[ \t]+Project Wiki[ \t]*$.*?(?=^#{1,2}[ \t]|\Z)",
     re.MULTILINE | re.DOTALL,
 )
 
 
-def upsert_section(text: str) -> str:
-    """Return `text` with the Project Wiki section inserted or replaced.
+def build_block() -> str:
+    """Wrap the pointer section in the stable managed-block markers."""
+    return f"{BEGIN_MARKER}\n{POINTER_SECTION.strip()}\n{END_MARKER}"
 
-    Existing section → replaced in place (surrounding content preserved).
-    No section → appended, separated by a blank line.
+
+def _is_legacy_managed_section(section_text: str) -> bool:
+    """True if a markerless `## Project Wiki` section is aim-wiki's own output.
+
+    Migration is conservative: only a section whose body matches the current
+    POINTER_SECTION template is treated as a legacy aim-wiki block eligible for
+    one-time migration to the marked form. A section whose body differs is user
+    content and must be preserved.
     """
-    block = POINTER_SECTION.rstrip("\n") + "\n"
-    if _SECTION_RE.search(text):
-        return _SECTION_RE.sub(lambda _m: block, text, count=1)
-    if text and not text.endswith("\n"):
-        text += "\n"
-    if text.strip():
-        text += "\n"
-    return text + block
+    return section_text.strip() == POINTER_SECTION.strip()
+
+
+def splice_block(text: str) -> str:
+    """Return `text` with the aim-wiki managed block inserted or replaced.
+
+    Idempotency keys on the marker pair (never on the `## Project Wiki` heading):
+    - 1 BEGIN before 1 END → replace-in-place between the markers; bytes outside
+      the markers are preserved exactly.
+    - 0 BEGIN + 0 END → migrate a legacy markerless aim-wiki section once (only
+      when its body matches the template), else append the managed block. A
+      user-authored `## Project Wiki` section is left untouched.
+    - Any other marker state (stray, duplicate, or out-of-order) → return the
+      text unchanged; the caller writes nothing (a WARNING is printed to stderr).
+
+    The result is idempotent: splicing an already-spliced document reproduces it.
+    """
+    block = build_block()
+    n_begin = text.count(BEGIN_MARKER)
+    n_end = text.count(END_MARKER)
+
+    if n_begin == 1 and n_end == 1:
+        begin_idx = text.find(BEGIN_MARKER)
+        end_idx = text.find(END_MARKER)
+        if end_idx > begin_idx:
+            # Replace-in-place: keep bytes before BEGIN and after END untouched.
+            pre = text[:begin_idx]
+            post = text[end_idx + len(END_MARKER) :]
+            return pre + block + post
+
+    if n_begin == 0 and n_end == 0:
+        match = _SECTION_RE.search(text)
+        if match and _is_legacy_managed_section(match.group(0)):
+            # Migrate the legacy markerless section once, in place (no duplicate).
+            return _SECTION_RE.sub(lambda _m: block + "\n", text, count=1)
+        # Insert-if-absent: append the block, preserving existing content (incl.
+        # any user-authored `## Project Wiki` section) verbatim.
+        if not text:
+            return block + "\n"
+        separator = "" if text.endswith("\n") else "\n"
+        return text + separator + "\n" + block + "\n"
+
+    # Malformed markers: refuse and leave the file unchanged (caller writes
+    # nothing). Never risk clobbering user content on an ambiguous marker state.
+    print(
+        f"WARNING: aim-wiki managed markers are malformed "
+        f"({n_begin} BEGIN, {n_end} END; expected 0+0 or 1 BEGIN before 1 END). "
+        f"Pointer left unchanged — resolve the markers manually, then re-run.",
+        file=sys.stderr,
+    )
+    return text
+
+
+def _backup_file(path: Path) -> Path:
+    """Create a timestamped copy of an existing file (copy, not rename).
+
+    Mirrors merge_settings.py / merge_agents_md.py: copy first so the original
+    survives a crash between backup and write.
+    """
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    backup_path = path.with_name(f"{path.name}.backup.{timestamp}")
+    shutil.copy2(path, backup_path)  # copy2 preserves metadata
+    return backup_path
 
 
 def upsert_pointer(root: Path) -> list[str]:
     """Upsert the pointer into the correct top-level file(s).
 
     Returns the repo-relative paths that were created or changed (empty when the
-    section was already present and identical — the write is a true no-op).
+    managed block is already present and identical — a true no-op: no write, no
+    backup). On change, writes are backup-copy-first then atomic (tempfile +
+    os.replace) so a crash mid-write cannot truncate the user's file.
     """
     claude = root / "CLAUDE.md"
     agents = root / "AGENTS.md"
@@ -78,8 +160,22 @@ def upsert_pointer(root: Path) -> list[str]:
     changed: list[str] = []
     for path in targets:
         original = path.read_text(encoding="utf-8") if path.exists() else ""
-        updated = upsert_section(original)
-        if updated != original:
-            path.write_text(updated, encoding="utf-8")
-            changed.append(path.relative_to(root).as_posix())
+        updated = splice_block(original)
+        if updated == original:
+            continue  # true no-op: no write, no backup
+        if path.exists():
+            _backup_file(path)  # copy-first; only when content actually changes
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, temp_path = tempfile.mkstemp(
+            dir=path.parent, prefix=f".{path.name}_", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(updated)
+            os.replace(temp_path, path)  # atomic
+        except Exception:
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
+            raise
+        changed.append(path.relative_to(root).as_posix())
     return changed

--- a/_ai-memory/skills/aim-wiki/scripts/wiki_verify.py
+++ b/_ai-memory/skills/aim-wiki/scripts/wiki_verify.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""aim-wiki — verification manifest (correctness verifier, deterministic hook).
+
+This is the plumbing for the read-only verifier pass, NOT the verification
+itself. It scans the authored wiki pages, extracts every inline source citation
+(markdown links to repo files + backtick-wrapped path tokens), and resolves each
+against the project tree — a cheap deterministic "does the cited file even
+exist" precheck. Dead citations are immediate, unambiguous drift.
+
+The emitted manifest is what the in-session read-only verifier subagent consumes
+to do the semantic claims-vs-source check (a page claim grounded in a real file
+may still misdescribe it — that judgement is the agent's, not the engine's).
+"""
+
+import re
+from pathlib import Path
+
+from wiki_common import WIKI_DIRNAME, wiki_dir
+
+# Markdown link target: [text](target). Captured target is trimmed of a #anchor.
+_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+# Known source-ish file extensions. A backtick token is treated as a source
+# citation only when its basename ends in one of these — otherwise prose like
+# `array.map` or `TCP/IP` would masquerade as a dead citation.
+_SOURCE_EXTS = {
+    "py",
+    "js",
+    "ts",
+    "jsx",
+    "tsx",
+    "mjs",
+    "cjs",
+    "go",
+    "rs",
+    "rb",
+    "java",
+    "kt",
+    "kts",
+    "c",
+    "h",
+    "cpp",
+    "hpp",
+    "cc",
+    "cs",
+    "php",
+    "swift",
+    "scala",
+    "sh",
+    "bash",
+    "zsh",
+    "sql",
+    "md",
+    "rst",
+    "txt",
+    "json",
+    "yaml",
+    "yml",
+    "toml",
+    "ini",
+    "cfg",
+    "conf",
+    "xml",
+    "html",
+    "htm",
+    "css",
+    "scss",
+    "less",
+    "lock",
+    "gradle",
+    "proto",
+    "graphql",
+    "vue",
+    "svelte",
+    "pl",
+    "lua",
+}
+# Backtick-wrapped path-like token, e.g. `src/app.py` or `pkg/mod.ts:42`. The
+# known-extension gate is applied in _looks_like_source, not the regex.
+_CODE_PATH_RE = re.compile(r"`([A-Za-z0-9_./-]+(?::\d+(?:-\d+)?)?)`")
+
+
+def _looks_like_source(ref: str) -> bool:
+    """True when a backtick token is a file citation: its basename (the segment
+    after the last '/') has a known source extension. Bare dotted prose
+    (`array.map`) and slash prose (`TCP/IP`, `CI/CD`, `and/or`) are not."""
+    basename = ref.rsplit("/", 1)[-1]
+    _, dot, ext = basename.rpartition(".")
+    return bool(dot) and ext.lower() in _SOURCE_EXTS
+
+
+def _is_external(target: str) -> bool:
+    return target.startswith(("http://", "https://", "mailto:", "#"))
+
+
+def _normalize(target: str) -> str:
+    """Strip a #anchor and a :line suffix, yielding a bare repo-relative path."""
+    target = target.split("#", 1)[0].strip()
+    target = re.sub(r":\d+(-\d+)?$", "", target)
+    return target
+
+
+def _extract_citations(page: Path, wiki_root: Path) -> list[str]:
+    text = page.read_text(encoding="utf-8", errors="replace")
+    refs: set[str] = set()
+    for m in _LINK_RE.finditer(text):
+        target = m.group(1).strip()
+        if _is_external(target):
+            continue
+        norm = _normalize(target)
+        # Skip intra-wiki links (page-to-page navigation, not source claims).
+        if not norm or (norm.endswith(".md") and not _points_into_source(norm)):
+            continue
+        refs.add(norm)
+    for m in _CODE_PATH_RE.finditer(text):
+        norm = _normalize(m.group(1))
+        if _looks_like_source(norm):
+            refs.add(norm)
+    return sorted(refs)
+
+
+def _points_into_source(norm: str) -> bool:
+    # A .md link that escapes the wiki (e.g. ../README.md, docs/x.md) is a real
+    # source citation; a sibling wiki page (quickstart.md, architecture/x.md) is
+    # navigation. Heuristic: treat links containing '..' or starting outside the
+    # wiki dir prefix as source.
+    return ".." in norm or norm.startswith((WIKI_DIRNAME + "/",))
+
+
+def _resolve(root: Path, wiki_root: Path, ref: str, page: Path) -> Path:
+    """Resolve a citation to a filesystem path.
+
+    A ref may be repo-root-relative (src/app.py) or relative to the page's own
+    directory (../README.md). Try page-relative first, then repo-root-relative.
+    """
+    page_rel = (page.parent / ref).resolve()
+    if page_rel.exists():
+        return page_rel
+    return (root / ref).resolve()
+
+
+def build_manifest(root: Path) -> dict:
+    """Build the verification manifest for every authored wiki page.
+
+    Returns {"pages": [{page, citations: [{ref, exists, resolved}]}],
+             "dead_citations": [...], "page_count", "citation_count",
+             "dead_count"}.
+    """
+    wd = wiki_dir(root)
+    pages: list[dict] = []
+    dead: list[dict] = []
+    citation_count = 0
+
+    md_pages = (
+        sorted(
+            (p for p in wd.rglob("*.md") if not p.name.startswith("_")),
+            key=lambda p: p.relative_to(wd).as_posix(),
+        )
+        if wd.is_dir()
+        else []
+    )
+
+    for page in md_pages:
+        page_rel = page.relative_to(root).as_posix()
+        cites = []
+        for ref in _extract_citations(page, wd):
+            resolved = _resolve(root, wd, ref, page)
+            exists = resolved.exists()
+            citation_count += 1
+            record = {"ref": ref, "exists": exists}
+            cites.append(record)
+            if not exists:
+                dead.append({"page": page_rel, "ref": ref})
+        pages.append({"page": page_rel, "citations": cites})
+
+    return {
+        "pages": pages,
+        "dead_citations": dead,
+        "page_count": len(pages),
+        "citation_count": citation_count,
+        "dead_count": len(dead),
+    }

--- a/docs/AIM-WIKI.md
+++ b/docs/AIM-WIKI.md
@@ -83,7 +83,7 @@ bash "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh"
   finalize --command init [--json]
 ```
 
-Runs only after the human accepts the authored/refreshed wiki and the verify pass. It upserts the `## Project Wiki` pointer (below) and writes the run-state (`updatedAt`, `command`, `gitHead`, content hash) to `wiki/.last-update.json`. If `wiki/` has no authored pages yet, `finalize` refuses and writes nothing.
+Runs only after the human accepts the authored/refreshed wiki and the verify pass. It upserts the `## Project Wiki` pointer (below) and writes the run-state (`updatedAt`, `command`, `gitHead`, content hash) to `wiki/.last-update.json`. If `wiki/` has no authored pages yet, `finalize` refuses and writes nothing. If a target `CLAUDE.md`/`AGENTS.md` has malformed AI-memory markers, `finalize` refuses that file's pointer write and leaves it unchanged: the file is listed under `pointer_files_refused` in `--json`, a `REFUSED` line is printed in text output, and `finalize` exits with code **2** — while still recording the wiki run-state (see the pointer section below).
 
 ## The `## Project Wiki` pointer
 
@@ -92,7 +92,7 @@ Runs only after the human accepts the authored/refreshed wiki and the verify pas
 - **Placement**: upserted into the top-level `CLAUDE.md` and/or `AGENTS.md`, whichever already exist. If neither exists, a new `AGENTS.md` is created containing only the section. Only ever the top-level files — never a nested `CLAUDE.md`/`AGENTS.md`.
 - **Idempotency**: the section is delivered inside a managed marker pair, `<!-- BEGIN AI-MEMORY (managed aim-wiki) -->` … `<!-- END AI-MEMORY (managed aim-wiki) -->`. Idempotency keys on the marker pair, **never** on the human-readable `## Project Wiki` heading — so a user's own hand-written section with that same heading is never clobbered.
 - **Legacy migration**: a markerless `## Project Wiki` section is migrated to the marked form exactly once, and only when its body matches aim-wiki's own template verbatim — anything else is treated as user content and left untouched.
-- **Malformed markers**: any other marker state (stray, duplicate, or out-of-order BEGIN/END) is left unchanged; the engine prints a warning to stderr and writes nothing rather than risk clobbering content on an ambiguous state.
+- **Malformed markers**: any other marker state (stray, duplicate, or out-of-order BEGIN/END) is left unchanged — the engine writes nothing to that file rather than risk clobbering content on an ambiguous state. The refusal is surfaced distinctly from a no-op: the file is listed under `pointer_files_refused` in `--json`, a `pointer : REFUSED <files> …` line is printed in text output, a warning is written to stderr, and `finalize` exits with code **2** (the wiki run-state is still recorded).
 - **Write safety**: on an actual content change, the existing file is copied to a timestamped `.backup.<timestamp>` first, then the new content is written via a temp file (`tempfile.mkstemp`) and `os.replace` (atomic) — a crash mid-write cannot truncate the original. When the managed block is already present and identical, nothing is written and no backup is made.
 
 ## Staleness model

--- a/docs/AIM-WIKI.md
+++ b/docs/AIM-WIKI.md
@@ -1,0 +1,113 @@
+# Project Wiki Generator & Maintainer (aim-wiki)
+
+The `aim-wiki` skill creates and maintains a wiki of **your own project** under a `wiki/` directory, in-session. It answers "what is this repo, how is it organized, and where do I start" for any agent (or person) opening the codebase cold — a quickstart entrypoint plus linked section pages, grounded in source and git evidence rather than invented.
+
+**Claude Code is the doc-gen agent** — there is no separate LLM or provider. A Python engine does only the deterministic work (repo scoping, inventory, scaffolding, run-state, git-diff, pointer injection, verifier manifest) and hands the results to Claude Code, which does the reasoning: authoring and refreshing pages, and dispatching a read-only verifier to cross-check claims against source before acceptance.
+
+## How It Works
+
+| Part | Artifact | Location |
+|------|----------|----------|
+| **Wiki output** | `quickstart.md` + section pages | `wiki/` (project root, committed like any other doc) |
+| **Skill** | `aim-wiki` (`init` · `update` · `status` · `verify` · `finalize`) | `_ai-memory/skills/aim-wiki/` |
+| **Engine (deterministic)** | `aim_wiki.py` (+ `wiki_common.py`, `wiki_inventory.py`, `wiki_pointer.py`, `wiki_verify.py`) | `_ai-memory/skills/aim-wiki/scripts/` |
+| **Agent-instruction pointer** | Managed `## Project Wiki` section | Top-level `CLAUDE.md` and/or `AGENTS.md` |
+| **Run state** | `.last-update.json` (content-hash + `gitHead` + `updatedAt`) | `wiki/.last-update.json` (excluded from the content hash) |
+
+The engine is invoked via `run-with-env.sh` (the AI-memory run-with-env convention). Every subcommand accepts `--root PATH` (override the project root; defaults to the git toplevel, else the current directory) and `--json` (machine-readable output).
+
+## Grounding discipline
+
+Authoring is held to the same standard as the underlying source:
+
+- **Do not invent** files, modules, APIs, business rules, or behavior — ground every important claim in source files, existing docs, or inspected git evidence, with inline source references so a reader can verify.
+- **Discover efficiently** — inspect the tree, config/package files, entrypoints, and representative files per domain rather than reading everything; prefer `Grep`/`Glob` and targeted reads.
+- **Existing docs are primary source** — treat READMEs, `docs/`, and `SKILL.md` files as material to summarize and link, not duplicate; flag a doc that conflicts with current source rather than trusting it.
+- **Subagents are read-only** — a dispatched research/verifier subagent may inspect and summarize but never create, edit, move, or delete files, and never writes under `wiki/`.
+- **Security** — never read or document secret values, credentials, keys, tokens, or `.env` files (placeholders in `.env.example` are fine).
+
+Full page-authoring rules (entrypoint, page count, no thin pages, one canonical home per concept) live in `references/page-structure.md` and are read before authoring, not restated here.
+
+## Modes
+
+### `init` — create the wiki
+
+```bash
+bash "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh" \
+  "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/_ai-memory/skills/aim-wiki/scripts/aim_wiki.py" \
+  init [--force] [--json]
+```
+
+Guards an existing wiki — if `wiki/` already has authored content, `init` routes to `update` unless `--force` is passed to rebuild. Otherwise it builds a repo inventory (file counts by bucket: docs, entrypoints, config, tests, schema) and a git summary (branch + recent commits), which Claude Code reads as its grounding before authoring `wiki/_plan.md` (deleted before finishing), then `wiki/quickstart.md` and the linked section pages — at most ~8 pages on a first run unless the repo is clearly tiny.
+
+### `update` — incremental maintenance
+
+```bash
+bash "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh" \
+  "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/_ai-memory/skills/aim-wiki/scripts/aim_wiki.py" \
+  update [--json]
+```
+
+Reads the recorded state and computes the git-diff since the recorded `gitHead` (committed + uncommitted, wiki-managed paths excluded), plus whether the wiki's own content hash has changed since the last record. Claude Code builds a docs-impact plan (changed source → page → edit → why) and edits surgically — replacing a stale sentence rather than adding paragraphs, and never reformatting an accurate page. **A no-op is valid**: if nothing relevant changed, the correct action is to say so and stop. If no state file is found, `update` reports `no_state` (wiki exists, needs a `finalize --command init` baseline) or `not_initialized` (no wiki — run `init`) instead of guessing.
+
+### `status` — freshness only, no writes
+
+```bash
+bash "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh" \
+  "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/_ai-memory/skills/aim-wiki/scripts/aim_wiki.py" \
+  status [--json]
+```
+
+Reports `current`, `drifted`, or `unknown`: the last `updatedAt` and `gitHead`, how many source files have changed since (committed + uncommitted), and whether the wiki content was hand-edited since the last recorded run. `unknown` means the recorded `gitHead` no longer resolves (e.g. rewritten history) — the diff can't be computed, so `status` never reports `current` in that case. Never writes.
+
+### `verify` — correctness gate
+
+```bash
+bash "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh" \
+  "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/_ai-memory/skills/aim-wiki/scripts/aim_wiki.py" \
+  verify [--json]
+```
+
+Two layers, run after authoring or refreshing:
+
+1. **Deterministic dead-citation precheck** — the engine extracts every inline source citation from the wiki pages (markdown links and backtick-wrapped paths with a recognized source extension) and checks each resolves to a real file. A dead citation is immediate, unambiguous drift.
+2. **Read-only verifier subagent** — dispatched (via the `Task` tool) with the manifest, it cross-checks that each page's *claims* match its cited source — a citation can point at a real file yet still misdescribe it. It inspects and reports only, one pass, never edits.
+
+All discrepancies (dead citations + ungrounded/drifted claims) are surfaced in the review gate before acceptance — the in-session equivalent of a PR review.
+
+### `finalize --command init|update` — post-acceptance writes
+
+```bash
+bash "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/scripts/memory/run-with-env.sh" \
+  "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/_ai-memory/skills/aim-wiki/scripts/aim_wiki.py" \
+  finalize --command init [--json]
+```
+
+Runs only after the human accepts the authored/refreshed wiki and the verify pass. It upserts the `## Project Wiki` pointer (below) and writes the run-state (`updatedAt`, `command`, `gitHead`, content hash) to `wiki/.last-update.json`. If `wiki/` has no authored pages yet, `finalize` refuses and writes nothing.
+
+## The `## Project Wiki` pointer
+
+`finalize` is the only step that touches files outside `wiki/`, and it touches exactly one thing: a pointer section telling any coding agent the wiki exists.
+
+- **Placement**: upserted into the top-level `CLAUDE.md` and/or `AGENTS.md`, whichever already exist. If neither exists, a new `AGENTS.md` is created containing only the section. Only ever the top-level files — never a nested `CLAUDE.md`/`AGENTS.md`.
+- **Idempotency**: the section is delivered inside a managed marker pair, `<!-- BEGIN AI-MEMORY (managed aim-wiki) -->` … `<!-- END AI-MEMORY (managed aim-wiki) -->`. Idempotency keys on the marker pair, **never** on the human-readable `## Project Wiki` heading — so a user's own hand-written section with that same heading is never clobbered.
+- **Legacy migration**: a markerless `## Project Wiki` section is migrated to the marked form exactly once, and only when its body matches aim-wiki's own template verbatim — anything else is treated as user content and left untouched.
+- **Malformed markers**: any other marker state (stray, duplicate, or out-of-order BEGIN/END) is left unchanged; the engine prints a warning to stderr and writes nothing rather than risk clobbering content on an ambiguous state.
+- **Write safety**: on an actual content change, the existing file is copied to a timestamped `.backup.<timestamp>` first, then the new content is written via a temp file (`tempfile.mkstemp`) and `os.replace` (atomic) — a crash mid-write cannot truncate the original. When the managed block is already present and identical, nothing is written and no backup is made.
+
+## Staleness model
+
+Freshness is tracked two ways, both recorded in `wiki/.last-update.json` at `finalize` time:
+
+- **Source drift** — files changed (committed since the recorded `gitHead`, or currently uncommitted) that aren't part of the wiki's own managed paths. The wiki directory itself and the top-level `CLAUDE.md`/`AGENTS.md` pointer files are excluded from this signal, since editing the docs isn't the source changing out from under them.
+- **Wiki-edited-since-record** — a SHA-256 over every authored file under `wiki/` (sorted relative path + bytes; the state file and the temporary `_plan.md` are excluded) compared against the hash stamped at the last `finalize`. A mismatch means someone hand-edited the wiki without going through `finalize`.
+
+`status` combines both into `current` / `drifted` / `unknown`.
+
+## Limits (v1)
+
+- **Standalone, no Qdrant** — the wiki lives entirely in `wiki/` on disk; there is no memory-store integration in v1.
+- **Whole-file drift exclusion** — source-drift detection excludes the *entire* top-level `CLAUDE.md`/`AGENTS.md`, not just the injected pointer section. A substantive unrelated hand-edit elsewhere in one of those files will not register as drift. Pointer-section-scoped drift is a deferred v2 refinement.
+- **In-session only** — there is no headless or CI mode / GitHub Action in v1.
+- **No `aim-sot` composition** — doc-drift signals are not yet composed with the `aim-sot` skill's own drift tracking (see [`docs/AIM-SOT.md`](AIM-SOT.md)); these are separate systems today.
+- **Multi-project scoping** is guaranteed by the resolved project root: the wiki is written only under that project's `wiki/`, never across projects.

--- a/tests/test_aim_wiki_cli_modes.py
+++ b/tests/test_aim_wiki_cli_modes.py
@@ -252,6 +252,46 @@ def test_finalize_noop_reports_already_current(capsys, git_repo):
     assert "REFUSED" not in out
 
 
+def test_finalize_mixed_changed_and_refused(capsys, git_repo):
+    """Per-file accumulation: with one valid target (needs the pointer) and one
+    carrying malformed markers, `finalize` writes the valid file
+    (`pointer_files_changed`), refuses the malformed one (`pointer_files_refused`),
+    exits 2, and in text mode renders BOTH the changed line and the REFUSED line."""
+    root, _ = git_repo
+    r = str(root)
+    aim_wiki.main(["init", "--root", r])
+    (wc.wiki_dir(root) / "quickstart.md").write_text("# hi\n", encoding="utf-8")
+
+    # CLAUDE.md valid (no markers → pointer appended); AGENTS.md malformed
+    # (a stray BEGIN with no matching END).
+    claude = root / "CLAUDE.md"
+    agents = root / "AGENTS.md"
+    claude_original = "# rules\n"
+    agents_original = f"# agents\n\n{wp.BEGIN_MARKER}\ndangling — no end marker\n"
+    claude.write_text(claude_original, encoding="utf-8")
+    agents.write_text(agents_original, encoding="utf-8")
+
+    rc, data = _json(capsys, ["finalize", "--root", r, "--command", "init", "--json"])
+    assert rc == 2, "any refused file makes finalize exit non-zero"
+    assert data["pointer_files_changed"] == ["CLAUDE.md"], "valid target written"
+    assert data["pointer_files_refused"] == ["AGENTS.md"], "malformed target refused"
+    assert data["status"] == "recorded", "wiki run-state still recorded"
+    assert "## Project Wiki" in claude.read_text(), "pointer landed in the valid file"
+    assert agents.read_text() == agents_original, "malformed file left unchanged"
+    assert list(root.glob("AGENTS.md.backup.*")) == [], "no backup on the refused file"
+
+    # Text mode renders BOTH the changed line and the REFUSED line. Reset the valid
+    # file so this run re-exercises the mixed changed+refused render (the prior run
+    # already made CLAUDE.md a no-op).
+    claude.write_text(claude_original, encoding="utf-8")
+    rc, out = _run(capsys, ["finalize", "--root", r, "--command", "init"])
+    assert rc == 2
+    assert "CLAUDE.md" in out, "changed line names the valid file"
+    assert (
+        "REFUSED" in out and "AGENTS.md" in out
+    ), "REFUSED line names the malformed file"
+
+
 def test_verify_reports_dead_citation(capsys, git_repo):
     root, _ = git_repo
     r = str(root)

--- a/tests/test_aim_wiki_cli_modes.py
+++ b/tests/test_aim_wiki_cli_modes.py
@@ -1,0 +1,235 @@
+"""aim_wiki CLI: init / update / status / verify / finalize via main(), JSON path.
+
+Drives the real argv dispatch (--root override, --json) end-to-end on a tmp git
+repo so the mode wiring, guards, and state lifecycle are exercised together.
+"""
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = (
+    Path(__file__).resolve().parents[1]
+    / "_ai-memory"
+    / "skills"
+    / "aim-wiki"
+    / "scripts"
+)
+
+
+def _load(name: str):
+    """Load an aim-wiki skill script by bare module name (registered in
+    sys.modules) so sibling scripts that `import <name>` resolve correctly —
+    without adding scripts/ to sys.path (no sys.path namespace collision)."""
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+wc = _load("wiki_common")
+_load("wiki_inventory")
+_load("wiki_pointer")
+_load("wiki_verify")
+aim_wiki = _load("aim_wiki")
+
+
+@pytest.fixture(autouse=True)
+def _stub_project_id(monkeypatch):
+    """Keep CLI-mode tests off the real memory stack: resolve_project_id would
+    import ~/.ai-memory and can touch machine state outside tmp_path. Scoping is
+    guaranteed by the resolved root, not this id, so a stub is faithful."""
+    monkeypatch.setattr(wc, "resolve_project_id", lambda root, **_: "test-project")
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(root), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    """A tmp git repo with one initial commit. Returns (root, commit_fn)."""
+    root = tmp_path
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "t@example.com")
+    _git(root, "config", "user.name", "Test")
+    (root / "README.md").write_text("# Proj\n", encoding="utf-8")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "initial")
+
+    def commit(relpath: str, content: str, msg: str = "change") -> str:
+        p = root / relpath
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+        _git(root, "add", "-A")
+        _git(root, "commit", "-q", "-m", msg)
+        return _git(root, "rev-parse", "HEAD")
+
+    return root, commit
+
+
+def _run(capsys, argv):
+    capsys.readouterr()  # drain any prior (un-measured) main() output
+    rc = aim_wiki.main(argv)
+    out = capsys.readouterr().out
+    return rc, out
+
+
+def _json(capsys, argv):
+    rc, out = _run(capsys, argv)
+    return rc, json.loads(out)
+
+
+def test_init_ready_then_guard_then_force(capsys, git_repo):
+    root, _ = git_repo
+    r = str(root)
+
+    rc, data = _json(capsys, ["init", "--root", r, "--json"])
+    assert rc == 0 and data["status"] == "ready"
+    assert wc.wiki_dir(root).is_dir()
+    assert "inventory" in data and "git_summary" in data
+
+    # Author a page → wiki now has content.
+    (wc.wiki_dir(root) / "quickstart.md").write_text("# hi\n", encoding="utf-8")
+
+    # Bare init now routes to update (guard).
+    rc, data = _json(capsys, ["init", "--root", r, "--json"])
+    assert rc == 0 and data["status"] == "wiki_exists" and data["action"] == "update"
+
+    # --force overrides the guard.
+    rc, data = _json(capsys, ["init", "--root", r, "--force", "--json"])
+    assert rc == 0 and data["status"] == "ready" and data["forced"] is True
+
+
+def test_update_requires_state_then_ready(capsys, git_repo):
+    root, commit = git_repo
+    r = str(root)
+    aim_wiki.main(["init", "--root", r])
+    (wc.wiki_dir(root) / "quickstart.md").write_text("# hi\n", encoding="utf-8")
+
+    # No state yet → routed to finalize-init to establish a baseline.
+    rc, data = _json(capsys, ["update", "--root", r, "--json"])
+    assert rc == 0 and data["status"] == "no_state"
+
+    # Establish baseline, then change source → update reports the diff.
+    aim_wiki.main(["finalize", "--root", r, "--command", "init"])
+    commit("src/new.py", "x = 1\n", "add source")
+    rc, data = _json(capsys, ["update", "--root", r, "--json"])
+    assert rc == 0 and data["status"] == "ready"
+    assert "src/new.py" in data["changes"]["committed"]
+
+
+def test_status_lifecycle(capsys, git_repo):
+    root, commit = git_repo
+    r = str(root)
+
+    # Not initialized.
+    rc, data = _json(capsys, ["status", "--root", r, "--json"])
+    assert rc == 0 and data["status"] == "not_initialized"
+
+    # Init + author + finalize → current.
+    aim_wiki.main(["init", "--root", r])
+    (wc.wiki_dir(root) / "quickstart.md").write_text("# hi\n", encoding="utf-8")
+    aim_wiki.main(["finalize", "--root", r, "--command", "init"])
+    rc, data = _json(capsys, ["status", "--root", r, "--json"])
+    assert rc == 0 and data["status"] == "current"
+
+    # Source change → drifted.
+    commit("src/x.py", "1\n", "change")
+    rc, data = _json(capsys, ["status", "--root", r, "--json"])
+    assert data["status"] == "drifted" and data["source_changes_since"] >= 1
+
+
+def test_status_unresolvable_githead_not_current(capsys, git_repo):
+    """F-B: an unresolvable recorded gitHead must not report 'current'."""
+    root, _ = git_repo
+    r = str(root)
+    aim_wiki.main(["init", "--root", r])
+    (wc.wiki_dir(root) / "quickstart.md").write_text("# hi\n", encoding="utf-8")
+    aim_wiki.main(["finalize", "--root", r, "--command", "init"])
+
+    # Corrupt the recorded gitHead to a commit that no longer resolves.
+    sp = wc.state_path(root)
+    state = json.loads(sp.read_text())
+    state["gitHead"] = "0" * 40
+    sp.write_text(json.dumps(state), encoding="utf-8")
+
+    rc, data = _json(capsys, ["status", "--root", r, "--json"])
+    assert rc == 0
+    assert data["resolvable"] is False
+    assert data["status"] != "current", "unresolvable gitHead must not read as fresh"
+
+
+def test_finalize_guards_empty_wiki(capsys, git_repo):
+    """F-C: finalize on an empty wiki is guarded — no pointer, no state written."""
+    root, _ = git_repo
+    r = str(root)
+    aim_wiki.main(["init", "--root", r])  # scaffolds empty wiki/, authors nothing
+
+    rc, data = _json(capsys, ["finalize", "--root", r, "--command", "init", "--json"])
+    assert rc == 0 and data["status"] == "not_initialized"
+    assert not (root / "AGENTS.md").exists() and not (root / "CLAUDE.md").exists()
+    assert wc.read_state(root) is None, "no baseline state recorded on empty wiki"
+
+
+def test_finalize_writes_pointer_and_state(capsys, git_repo):
+    root, _ = git_repo
+    r = str(root)
+    aim_wiki.main(["init", "--root", r])
+    (wc.wiki_dir(root) / "quickstart.md").write_text("# hi\n", encoding="utf-8")
+
+    rc, data = _json(capsys, ["finalize", "--root", r, "--command", "init", "--json"])
+    assert rc == 0 and data["status"] == "recorded"
+    # Pointer landed in CLAUDE.md (README exists but CLAUDE/AGENTS do not → AGENTS.md).
+    assert data["pointer_files_changed"] == ["AGENTS.md"]
+    assert "## Project Wiki" in (root / "AGENTS.md").read_text()
+    # State persisted with a real gitHead + matching content hash.
+    state = wc.read_state(root)
+    assert state["command"] == "init"
+    assert state["gitHead"] == wc.git_head(root)
+    assert state["contentHash"] == wc.content_hash(root)
+
+
+def test_verify_reports_dead_citation(capsys, git_repo):
+    root, _ = git_repo
+    r = str(root)
+    aim_wiki.main(["init", "--root", r])
+    (wc.wiki_dir(root) / "quickstart.md").write_text(
+        "Entry `src/ghost.py` does not exist.\n", encoding="utf-8"
+    )
+
+    rc, data = _json(capsys, ["verify", "--root", r, "--json"])
+    assert rc == 0 and data["status"] == "dead_citations"
+    assert data["dead_count"] == 1
+    assert data["dead_citations"][0]["ref"] == "src/ghost.py"
+
+
+def test_verify_not_initialized(capsys, tmp_path):
+    rc, data = _json(capsys, ["verify", "--root", str(tmp_path), "--json"])
+    assert rc == 0 and data["status"] == "not_initialized"
+
+
+def test_text_output_smoke(capsys, git_repo):
+    """Text (non-JSON) path renders without error for every mode."""
+    root, _ = git_repo
+    r = str(root)
+    assert aim_wiki.main(["init", "--root", r]) == 0
+    (wc.wiki_dir(root) / "quickstart.md").write_text("# hi\n", encoding="utf-8")
+    assert aim_wiki.main(["finalize", "--root", r, "--command", "init"]) == 0
+    assert aim_wiki.main(["status", "--root", r]) == 0
+    assert aim_wiki.main(["update", "--root", r]) == 0
+    assert aim_wiki.main(["verify", "--root", r]) == 0
+    out = capsys.readouterr().out
+    assert "aim-wiki" in out

--- a/tests/test_aim_wiki_cli_modes.py
+++ b/tests/test_aim_wiki_cli_modes.py
@@ -36,7 +36,7 @@ def _load(name: str):
 
 wc = _load("wiki_common")
 _load("wiki_inventory")
-_load("wiki_pointer")
+wp = _load("wiki_pointer")
 _load("wiki_verify")
 aim_wiki = _load("aim_wiki")
 
@@ -200,6 +200,56 @@ def test_finalize_writes_pointer_and_state(capsys, git_repo):
     assert state["command"] == "init"
     assert state["gitHead"] == wc.git_head(root)
     assert state["contentHash"] == wc.content_hash(root)
+
+
+def test_finalize_refuses_malformed_pointer_markers(capsys, git_repo):
+    """Refusal observability: `finalize` against a CLAUDE.md with malformed
+    AI-memory markers surfaces the refusal distinctly from a no-op — a populated
+    `pointer_files_refused` (empty `pointer_files_changed`) in --json, a human
+    REFUSED line in text, exit 2, and the file left byte-for-byte unchanged."""
+    root, _ = git_repo
+    r = str(root)
+    aim_wiki.main(["init", "--root", r])
+    (wc.wiki_dir(root) / "quickstart.md").write_text("# hi\n", encoding="utf-8")
+
+    # Malformed: a stray BEGIN with no matching END.
+    claude = root / "CLAUDE.md"
+    original = f"# rules\n\n{wp.BEGIN_MARKER}\ndangling — no end marker\n"
+    claude.write_text(original, encoding="utf-8")
+
+    rc, data = _json(capsys, ["finalize", "--root", r, "--command", "init", "--json"])
+    assert rc == 2, "refused pointer write exits non-zero"
+    assert data["pointer_files_refused"] == ["CLAUDE.md"]
+    assert data["pointer_files_changed"] == [], "refusal is not a change"
+    assert data["status"] == "recorded", "wiki run-state is still recorded"
+    assert claude.read_text() == original, "malformed file left byte-for-byte unchanged"
+    assert list(root.glob("CLAUDE.md.backup.*")) == [], "no backup on refusal"
+
+    # Text path renders a REFUSED line, not 'already current'.
+    rc, out = _run(capsys, ["finalize", "--root", r, "--command", "init"])
+    assert rc == 2
+    assert "REFUSED" in out and "CLAUDE.md" in out
+    assert "already current" not in out
+
+
+def test_finalize_noop_reports_already_current(capsys, git_repo):
+    """No-op companion: once the pointer is present and identical, a re-finalize
+    is a true no-op — exit 0, empty changed/refused, and the text path still
+    reports `already current` (no false-refused regression)."""
+    root, _ = git_repo
+    r = str(root)
+    aim_wiki.main(["init", "--root", r])
+    (wc.wiki_dir(root) / "quickstart.md").write_text("# hi\n", encoding="utf-8")
+    aim_wiki.main(["finalize", "--root", r, "--command", "init"])  # writes pointer
+
+    rc, data = _json(capsys, ["finalize", "--root", r, "--command", "init", "--json"])
+    assert rc == 0
+    assert data["pointer_files_changed"] == [] and data["pointer_files_refused"] == []
+
+    rc, out = _run(capsys, ["finalize", "--root", r, "--command", "init"])
+    assert rc == 0
+    assert "already current" in out
+    assert "REFUSED" not in out
 
 
 def test_verify_reports_dead_citation(capsys, git_repo):

--- a/tests/test_aim_wiki_common_state_hash.py
+++ b/tests/test_aim_wiki_common_state_hash.py
@@ -1,0 +1,170 @@
+"""wiki_common: root resolution, content-hash (no-op detection), state roundtrip,
+and git-diff-since-last-run."""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = (
+    Path(__file__).resolve().parents[1]
+    / "_ai-memory"
+    / "skills"
+    / "aim-wiki"
+    / "scripts"
+)
+
+
+def _load(name: str):
+    """Load an aim-wiki skill script by bare module name (registered in
+    sys.modules) so sibling scripts that `import <name>` resolve correctly —
+    without adding scripts/ to sys.path (no sys.path namespace collision)."""
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+wc = _load("wiki_common")
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(root), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    """A tmp git repo with one initial commit. Returns (root, commit_fn)."""
+    root = tmp_path
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "t@example.com")
+    _git(root, "config", "user.name", "Test")
+    (root / "README.md").write_text("# Proj\n", encoding="utf-8")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "initial")
+
+    def commit(relpath: str, content: str, msg: str = "change") -> str:
+        p = root / relpath
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+        _git(root, "add", "-A")
+        _git(root, "commit", "-q", "-m", msg)
+        return _git(root, "rev-parse", "HEAD")
+
+    return root, commit
+
+
+def _page(root: Path, rel: str, text: str) -> None:
+    p = wc.wiki_dir(root) / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def test_resolve_root_override(tmp_path):
+    assert wc.resolve_root(str(tmp_path)) == tmp_path
+
+
+def test_wiki_has_content(tmp_path):
+    assert wc.wiki_has_content(tmp_path) is False
+    _page(tmp_path, "quickstart.md", "# hi\n")
+    assert wc.wiki_has_content(tmp_path) is True
+
+
+def test_content_hash_stable_and_sensitive(tmp_path):
+    _page(tmp_path, "quickstart.md", "# hi\n")
+    _page(tmp_path, "arch/overview.md", "body\n")
+    h1 = wc.content_hash(tmp_path)
+    assert h1 == wc.content_hash(tmp_path), "hash must be stable when nothing changes"
+    _page(tmp_path, "arch/overview.md", "body changed\n")
+    assert wc.content_hash(tmp_path) != h1, "hash must change when a page changes"
+
+
+def test_content_hash_excludes_state_and_plan(tmp_path):
+    _page(tmp_path, "quickstart.md", "# hi\n")
+    h1 = wc.content_hash(tmp_path)
+    # Writing the state file and a plan file must NOT change the content hash.
+    wc.state_path(tmp_path).write_text('{"x":1}', encoding="utf-8")
+    _page(tmp_path, wc.PLAN_FILENAME, "scratch\n")
+    assert wc.content_hash(tmp_path) == h1
+
+
+def test_state_roundtrip(tmp_path):
+    _page(tmp_path, "quickstart.md", "# hi\n")
+    assert wc.read_state(tmp_path) is None
+    state = wc.write_state(tmp_path, "init", "abc123")
+    assert state["command"] == "init"
+    assert state["gitHead"] == "abc123"
+    assert state["contentHash"] == wc.content_hash(tmp_path)
+    assert state["updatedAt"].endswith("Z")
+    read = wc.read_state(tmp_path)
+    assert read == state
+
+
+def test_read_state_none_on_bad_json(tmp_path):
+    wc.wiki_dir(tmp_path).mkdir(parents=True)
+    wc.state_path(tmp_path).write_text("{not json", encoding="utf-8")
+    assert wc.read_state(tmp_path) is None
+
+
+def test_git_changed_files(git_repo):
+    root, commit = git_repo
+    head0 = wc.git_head(root)
+    assert head0
+    commit("src/app.py", "print(1)\n", "add app")
+    commit("src/util.py", "x = 1\n", "add util")
+    changes = wc.git_changed_files(root, head0)
+    assert changes["resolvable"] is True
+    assert set(changes["committed"]) == {"src/app.py", "src/util.py"}
+    # Uncommitted edit shows up too.
+    (root / "src" / "app.py").write_text("print(2)\n", encoding="utf-8")
+    changes2 = wc.git_changed_files(root, head0)
+    assert "src/app.py" in changes2["uncommitted"]
+
+
+def test_git_changed_files_excludes_wiki_managed(git_repo):
+    """The wiki dir + pointer files must not register as SOURCE drift."""
+    root, commit = git_repo
+    head0 = wc.git_head(root)
+    commit("src/real.py", "x=1\n", "add source")  # committed source change
+    # Uncommitted wiki output + pointer must NOT count as source drift.
+    (root / "wiki").mkdir()
+    (root / "wiki" / "quickstart.md").write_text("# q\n", encoding="utf-8")
+    (root / "AGENTS.md").write_text("## Project Wiki\n", encoding="utf-8")
+    changes = wc.git_changed_files(root, head0)
+    assert "src/real.py" in changes["committed"]
+    both = changes["committed"] + changes["uncommitted"]
+    assert not any(p.startswith("wiki") for p in both)
+    assert "AGENTS.md" not in both
+
+
+def test_git_changed_files_non_ascii_unmangled(git_repo):
+    """F-D: non-ASCII paths must come back literal, not octal-quoted by git's
+    default core.quotePath (covers both the diff and status --porcelain parses)."""
+    root, commit = git_repo
+    base = wc.git_head(root)
+    commit("café.py", "x = 1\n", "add committed non-ascii")  # committed -> diff path
+    (root / "naïve.py").write_text("y = 2\n", encoding="utf-8")  # uncommitted -> status
+    changes = wc.git_changed_files(root, base)
+    assert "café.py" in changes["committed"]
+    assert "naïve.py" in changes["uncommitted"]
+
+
+def test_git_changed_files_unresolvable_head(git_repo):
+    root, _ = git_repo
+    changes = wc.git_changed_files(root, "deadbeef" * 5)
+    assert changes["resolvable"] is False
+    assert changes["committed"] == []
+
+
+def test_git_summary_non_repo(tmp_path):
+    assert "not a git repository" in wc.git_summary(tmp_path)

--- a/tests/test_aim_wiki_inventory.py
+++ b/tests/test_aim_wiki_inventory.py
@@ -1,0 +1,87 @@
+"""wiki_inventory: heuristic classification + exclude discipline."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_SCRIPTS = (
+    Path(__file__).resolve().parents[1]
+    / "_ai-memory"
+    / "skills"
+    / "aim-wiki"
+    / "scripts"
+)
+
+
+def _load(name: str):
+    """Load an aim-wiki skill script by bare module name (registered in
+    sys.modules) so sibling scripts that `import <name>` resolve correctly —
+    without adding scripts/ to sys.path (no sys.path namespace collision)."""
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+build_inventory = _load("wiki_inventory").build_inventory
+
+
+def _mk(root: Path, rel: str, text: str = "x\n") -> None:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def test_classification_buckets(tmp_path):
+    _mk(tmp_path, "README.md")
+    _mk(tmp_path, "docs/guide.md")
+    _mk(tmp_path, "pyproject.toml")
+    _mk(tmp_path, ".github/workflows/ci.yml")
+    _mk(tmp_path, "src/main.py")
+    _mk(tmp_path, "src/index.ts")
+    _mk(tmp_path, "tests/test_app.py")
+    _mk(tmp_path, "db/schema.sql")
+
+    inv = build_inventory(tmp_path)
+    assert "README.md" in inv["docs"]
+    assert "docs/guide.md" in inv["docs"]
+    assert "pyproject.toml" in inv["config"]
+    assert ".github/workflows/ci.yml" in inv["config"]
+    assert "src/main.py" in inv["entrypoints"]
+    assert "src/index.ts" in inv["entrypoints"]
+    assert "tests/test_app.py" in inv["tests"]
+    assert "db/schema.sql" in inv["schema"]
+
+
+def test_excludes_noise_dirs(tmp_path):
+    _mk(tmp_path, "src/main.py")
+    _mk(tmp_path, "node_modules/pkg/index.js")
+    _mk(tmp_path, ".git/config")
+    _mk(tmp_path, "dist/bundle.js")
+    _mk(tmp_path, "wiki/quickstart.md")  # the wiki itself is excluded
+
+    inv = build_inventory(tmp_path)
+    flat = (
+        inv["docs"] + inv["entrypoints"] + inv["config"] + inv["tests"] + inv["schema"]
+    )
+    joined = " ".join(flat)
+    assert "node_modules" not in joined
+    assert ".git/" not in joined
+    assert "dist/" not in joined
+    assert "wiki/" not in joined
+    assert "src/main.py" in inv["entrypoints"]
+
+
+def test_top_level_dirs_and_counts(tmp_path):
+    _mk(tmp_path, "src/main.py")
+    _mk(tmp_path, "docs/x.md")
+    _mk(tmp_path, "node_modules/p/i.js")
+    inv = build_inventory(tmp_path)
+    assert "src/" in inv["top_level_dirs"]
+    assert "docs/" in inv["top_level_dirs"]
+    assert "node_modules/" not in inv["top_level_dirs"]
+    assert inv["files_scanned"] >= 2
+    assert inv["truncated"] is False

--- a/tests/test_aim_wiki_pointer_injection.py
+++ b/tests/test_aim_wiki_pointer_injection.py
@@ -1,4 +1,9 @@
-"""wiki_pointer: placement rule, idempotency, surrounding-content preservation."""
+"""wiki_pointer: placement rule, marker-keyed idempotency, user-content safety.
+
+Idempotency keys on the managed marker pair (BP-171 OQ-3), never on the
+`## Project Wiki` heading — a user's own same-named section is never clobbered.
+Writes are backup-copy-first + atomic (tempfile + os.replace).
+"""
 
 import importlib.util
 import sys
@@ -28,15 +33,20 @@ def _load(name: str):
 
 _wiki_pointer = _load("wiki_pointer")
 POINTER_HEADING = _wiki_pointer.POINTER_HEADING
+POINTER_SECTION = _wiki_pointer.POINTER_SECTION
+BEGIN_MARKER = _wiki_pointer.BEGIN_MARKER
+END_MARKER = _wiki_pointer.END_MARKER
 upsert_pointer = _wiki_pointer.upsert_pointer
-upsert_section = _wiki_pointer.upsert_section
+splice_block = _wiki_pointer.splice_block
 
 
 def test_creates_agents_when_neither_exists(tmp_path):
     changed = upsert_pointer(tmp_path)
     assert changed == ["AGENTS.md"]
     assert not (tmp_path / "CLAUDE.md").exists()
-    assert POINTER_HEADING in (tmp_path / "AGENTS.md").read_text()
+    text = (tmp_path / "AGENTS.md").read_text()
+    assert POINTER_HEADING in text
+    assert BEGIN_MARKER in text and END_MARKER in text
 
 
 def test_updates_claude_when_present(tmp_path):
@@ -63,42 +73,140 @@ def test_updates_both_when_both_present(tmp_path):
 def test_idempotent_second_run_no_change(tmp_path):
     upsert_pointer(tmp_path)  # creates AGENTS.md
     changed = upsert_pointer(tmp_path)  # second run
-    assert changed == [], "re-running with an identical section must be a no-op"
+    assert changed == [], "re-running with an identical managed block must be a no-op"
 
 
-def test_replaces_existing_section_no_duplicate(tmp_path):
+# --- W1: managed-marker fences — user content is never clobbered ---
+
+
+def test_user_markerless_section_preserved(tmp_path):
+    """W1(a): a user-authored markerless `## Project Wiki` is NOT clobbered.
+
+    Its body differs from the aim-wiki template, so it is user content: left
+    untouched, and the managed block is added separately.
+    """
     claude = tmp_path / "CLAUDE.md"
-    claude.write_text(
-        "# top\n\n## Project Wiki\n\nOLD stale pointer text.\n\n## Other\n\nkeep me.\n",
-        encoding="utf-8",
-    )
+    user = "# top\n\n## Project Wiki\n\nMy own notes about our internal wiki.\n"
+    claude.write_text(user, encoding="utf-8")
     upsert_pointer(tmp_path)
     text = claude.read_text()
-    assert text.count(POINTER_HEADING) == 1, "must replace, not duplicate"
-    assert "OLD stale pointer text." not in text
-    assert "## Other" in text and "keep me." in text, "later section preserved"
-    assert "wiki/quickstart.md" in text
+    assert "My own notes about our internal wiki." in text, "user section preserved"
+    assert BEGIN_MARKER in text and END_MARKER in text, "managed block added"
+    assert text.count(POINTER_HEADING) == 2, "user heading + managed heading"
 
 
-def test_replace_preserves_following_h1(tmp_path):
-    """F-A: replacing the section must NOT swallow a following `# H1` heading.
-
-    The old terminator stopped only at `## ` H2 / EOF, so a `# Appendix` after the
-    Project Wiki section was consumed and deleted on replace (data-loss)."""
-    claude = tmp_path / "CLAUDE.md"
-    claude.write_text(
-        "# Top\n\n## Project Wiki\n\nOLD pointer text.\n\n# Appendix\n\nkeep me.\n",
+def test_replace_in_place_between_markers(tmp_path):
+    """W1(b): a stale managed block is replaced in place; bytes outside the
+    markers are preserved, and no duplicate markers appear."""
+    agents = tmp_path / "AGENTS.md"
+    agents.write_text(
+        f"# a\n\nkeep before.\n\n{BEGIN_MARKER}\nstale managed body\n{END_MARKER}\n"
+        f"\nkeep after.\n",
         encoding="utf-8",
     )
+    changed = upsert_pointer(tmp_path)
+    assert changed == ["AGENTS.md"]
+    text = agents.read_text()
+    assert text.count(BEGIN_MARKER) == 1 and text.count(END_MARKER) == 1
+    assert "stale managed body" not in text, "managed body replaced"
+    assert POINTER_HEADING in text and "wiki/quickstart.md" in text
+    assert "keep before." in text and "keep after." in text, "outside bytes kept"
+
+
+def test_no_duplicate_across_reruns(tmp_path):
+    """W1(b): re-running many times never duplicates the managed block."""
+    upsert_pointer(tmp_path)  # create AGENTS.md with block
+    upsert_pointer(tmp_path)
+    upsert_pointer(tmp_path)
+    text = (tmp_path / "AGENTS.md").read_text()
+    assert text.count(BEGIN_MARKER) == 1
+    assert text.count(END_MARKER) == 1
+    assert text.count(POINTER_HEADING) == 1
+
+
+def test_legacy_markerless_migrates_once(tmp_path):
+    """W1(c): a legacy markerless section whose body matches the template is
+    migrated once to the marked form (no duplicate); a following H1 survives."""
+    claude = tmp_path / "CLAUDE.md"
+    legacy = "# Top\n\n" + POINTER_SECTION.rstrip("\n") + "\n\n# Appendix\n\nkeep me.\n"
+    claude.write_text(legacy, encoding="utf-8")
     upsert_pointer(tmp_path)
     text = claude.read_text()
-    assert text.count(POINTER_HEADING) == 1, "must replace, not duplicate"
-    assert "OLD pointer text." not in text
+    assert BEGIN_MARKER in text and END_MARKER in text, "migrated to marked form"
+    assert text.count(POINTER_HEADING) == 1, "migrated in place, not appended"
     assert "# Appendix" in text and "keep me." in text, "following H1 preserved"
+    # markers now present → subsequent run is a true no-op
+    assert upsert_pointer(tmp_path) == []
 
 
-def test_upsert_section_appends_with_separation():
-    out = upsert_section("# title\n\nbody\n")
+def test_non_matching_section_not_migrated(tmp_path):
+    """W1(c): a markerless section whose body differs from the template is user
+    content — NOT migrated; the managed block is appended separately."""
+    claude = tmp_path / "CLAUDE.md"
+    claude.write_text(
+        "# Top\n\n## Project Wiki\n\nUser's own different wiki text.\n",
+        encoding="utf-8",
+    )
+    upsert_pointer(tmp_path)
+    text = claude.read_text()
+    assert "User's own different wiki text." in text, "user body preserved"
+    assert BEGIN_MARKER in text, "managed block appended separately"
+    assert text.count(POINTER_HEADING) == 2
+
+
+def test_malformed_markers_left_unchanged(tmp_path):
+    """W1: an ambiguous marker state (stray BEGIN) is refused — file unchanged,
+    no write, empty return list."""
+    agents = tmp_path / "AGENTS.md"
+    original = f"# a\n\n{BEGIN_MARKER}\ndangling — no end marker\n"
+    agents.write_text(original, encoding="utf-8")
+    changed = upsert_pointer(tmp_path)
+    assert changed == [], "malformed markers → no change"
+    assert agents.read_text() == original, "file left byte-for-byte unchanged"
+
+
+# --- W2: atomic write + timestamped backup ---
+
+
+def test_backup_created_on_change_not_on_noop(tmp_path):
+    """W2(d): a timestamped backup is produced on change, but NOT on a no-op."""
+    claude = tmp_path / "CLAUDE.md"
+    claude.write_text("# rules\n", encoding="utf-8")
+    upsert_pointer(tmp_path)  # change → one backup
+    assert len(list(tmp_path.glob("CLAUDE.md.backup.*"))) == 1, "backup on change"
+    upsert_pointer(tmp_path)  # no-op → no new backup
+    assert len(list(tmp_path.glob("CLAUDE.md.backup.*"))) == 1, "no backup on no-op"
+
+
+def test_no_backup_when_creating_new_file(tmp_path):
+    """W2: creating a brand-new AGENTS.md backs up nothing (nothing existed)."""
+    upsert_pointer(tmp_path)
+    assert list(tmp_path.glob("AGENTS.md.backup.*")) == []
+
+
+def test_write_is_atomic_via_os_replace(tmp_path, monkeypatch):
+    """W2(e): the write is routed through os.replace (atomic) and leaves no
+    temp files behind."""
+    calls = []
+    real_replace = _wiki_pointer.os.replace
+
+    def spy(src, dst):
+        calls.append((src, dst))
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(_wiki_pointer.os, "replace", spy)
+    upsert_pointer(tmp_path)  # creates AGENTS.md
+    assert calls, "write routed through os.replace"
+    assert any(str(dst).endswith("AGENTS.md") for _src, dst in calls)
+    assert list(tmp_path.glob(".AGENTS.md_*.tmp")) == [], "no leftover temp files"
+
+
+# --- pure splice_block behavior ---
+
+
+def test_splice_block_appends_with_separation():
+    out = splice_block("# title\n\nbody\n")
     assert "body" in out
-    assert out.rstrip().endswith("run an update when your changes make a page stale.")
-    assert "\n\n## Project Wiki" in out
+    assert "\n\n" + BEGIN_MARKER in out, "blank line separates existing content"
+    assert out.endswith(END_MARKER + "\n")
+    assert POINTER_HEADING in out

--- a/tests/test_aim_wiki_pointer_injection.py
+++ b/tests/test_aim_wiki_pointer_injection.py
@@ -9,6 +9,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
 _SCRIPTS = (
     Path(__file__).resolve().parents[1]
     / "_ai-memory"
@@ -38,11 +40,12 @@ BEGIN_MARKER = _wiki_pointer.BEGIN_MARKER
 END_MARKER = _wiki_pointer.END_MARKER
 upsert_pointer = _wiki_pointer.upsert_pointer
 splice_block = _wiki_pointer.splice_block
+MalformedMarkersError = _wiki_pointer.MalformedMarkersError
 
 
 def test_creates_agents_when_neither_exists(tmp_path):
-    changed = upsert_pointer(tmp_path)
-    assert changed == ["AGENTS.md"]
+    result = upsert_pointer(tmp_path)
+    assert result.changed == ["AGENTS.md"] and result.refused == []
     assert not (tmp_path / "CLAUDE.md").exists()
     text = (tmp_path / "AGENTS.md").read_text()
     assert POINTER_HEADING in text
@@ -53,8 +56,8 @@ def test_updates_claude_when_present(tmp_path):
     (tmp_path / "CLAUDE.md").write_text(
         "# House rules\n\nBe surgical.\n", encoding="utf-8"
     )
-    changed = upsert_pointer(tmp_path)
-    assert changed == ["CLAUDE.md"]
+    result = upsert_pointer(tmp_path)
+    assert result.changed == ["CLAUDE.md"]
     text = (tmp_path / "CLAUDE.md").read_text()
     assert "Be surgical." in text, "surrounding content preserved"
     assert POINTER_HEADING in text
@@ -66,14 +69,16 @@ def test_updates_claude_when_present(tmp_path):
 def test_updates_both_when_both_present(tmp_path):
     (tmp_path / "CLAUDE.md").write_text("# c\n", encoding="utf-8")
     (tmp_path / "AGENTS.md").write_text("# a\n", encoding="utf-8")
-    changed = upsert_pointer(tmp_path)
-    assert set(changed) == {"CLAUDE.md", "AGENTS.md"}
+    result = upsert_pointer(tmp_path)
+    assert set(result.changed) == {"CLAUDE.md", "AGENTS.md"}
 
 
 def test_idempotent_second_run_no_change(tmp_path):
     upsert_pointer(tmp_path)  # creates AGENTS.md
-    changed = upsert_pointer(tmp_path)  # second run
-    assert changed == [], "re-running with an identical managed block must be a no-op"
+    result = upsert_pointer(tmp_path)  # second run
+    assert (
+        result.changed == [] and result.refused == []
+    ), "re-running with an identical managed block must be a no-op"
 
 
 # --- W1: managed-marker fences — user content is never clobbered ---
@@ -104,8 +109,8 @@ def test_replace_in_place_between_markers(tmp_path):
         f"\nkeep after.\n",
         encoding="utf-8",
     )
-    changed = upsert_pointer(tmp_path)
-    assert changed == ["AGENTS.md"]
+    result = upsert_pointer(tmp_path)
+    assert result.changed == ["AGENTS.md"]
     text = agents.read_text()
     assert text.count(BEGIN_MARKER) == 1 and text.count(END_MARKER) == 1
     assert "stale managed body" not in text, "managed body replaced"
@@ -136,7 +141,7 @@ def test_legacy_markerless_migrates_once(tmp_path):
     assert text.count(POINTER_HEADING) == 1, "migrated in place, not appended"
     assert "# Appendix" in text and "keep me." in text, "following H1 preserved"
     # markers now present → subsequent run is a true no-op
-    assert upsert_pointer(tmp_path) == []
+    assert upsert_pointer(tmp_path).changed == []
 
 
 def test_non_matching_section_not_migrated(tmp_path):
@@ -154,15 +159,69 @@ def test_non_matching_section_not_migrated(tmp_path):
     assert text.count(POINTER_HEADING) == 2
 
 
-def test_malformed_markers_left_unchanged(tmp_path):
-    """W1: an ambiguous marker state (stray BEGIN) is refused — file unchanged,
-    no write, empty return list."""
+def test_one_version_stale_legacy_body_not_migrated(tmp_path):
+    """W1(c) template-evolution footgun: `_is_legacy_managed_section` requires an
+    EXACT match to the CURRENT template, so a markerless section carrying a
+    one-version-behind aim-wiki body is treated as user content — NOT migrated
+    in place. The managed block is appended separately (two `## Project Wiki`
+    headings). Documents that changing POINTER_SECTION strands pre-existing
+    markerless sections authored by an older skill version."""
+    # A plausible prior-version body: same heading, but the trust-but-verify
+    # closing paragraph differs by one word from the current template.
+    stale_body = POINTER_SECTION.strip().replace(
+        "confirm any specific file", "verify any specific file"
+    )
+    assert stale_body != POINTER_SECTION.strip(), "fixture must differ from current"
+    claude = tmp_path / "CLAUDE.md"
+    claude.write_text("# Top\n\n" + stale_body + "\n", encoding="utf-8")
+    upsert_pointer(tmp_path)
+    text = claude.read_text()
+    assert "verify any specific file" in text, "stale user body preserved verbatim"
+    assert BEGIN_MARKER in text and END_MARKER in text, "managed block appended"
+    assert text.count(POINTER_HEADING) == 2, "not migrated — appended alongside"
+
+
+@pytest.mark.parametrize(
+    "label, body",
+    [
+        ("stray_begin", f"# a\n\n{BEGIN_MARKER}\ndangling — no end marker\n"),
+        (
+            "duplicate",
+            f"# a\n\n{BEGIN_MARKER}\none\n{END_MARKER}\n\n"
+            f"{BEGIN_MARKER}\ntwo\n{END_MARKER}\n",
+        ),
+        ("out_of_order", f"# a\n\n{END_MARKER}\nbody\n{BEGIN_MARKER}\n"),
+    ],
+)
+def test_malformed_markers_refused_and_unchanged(tmp_path, label, body):
+    """W1 + refusal observability: an ambiguous marker state (stray, duplicate,
+    or out-of-order) is refused — the file is left byte-for-byte unchanged (no
+    write, no backup) AND the refusal is signaled distinctly from a true no-op:
+    `refused` names the file while `changed` stays empty."""
     agents = tmp_path / "AGENTS.md"
-    original = f"# a\n\n{BEGIN_MARKER}\ndangling — no end marker\n"
-    agents.write_text(original, encoding="utf-8")
-    changed = upsert_pointer(tmp_path)
-    assert changed == [], "malformed markers → no change"
-    assert agents.read_text() == original, "file left byte-for-byte unchanged"
+    agents.write_text(body, encoding="utf-8")
+    result = upsert_pointer(tmp_path)
+    assert result.changed == [], f"{label}: malformed markers → nothing changed"
+    assert result.refused == ["AGENTS.md"], f"{label}: refusal signaled distinctly"
+    assert agents.read_text() == body, f"{label}: file left byte-for-byte unchanged"
+    assert (
+        list(tmp_path.glob("AGENTS.md.backup.*")) == []
+    ), f"{label}: no backup written"
+    assert list(tmp_path.glob(".AGENTS.md_*.tmp")) == [], f"{label}: no temp leftover"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        f"# a\n\n{BEGIN_MARKER}\ndangling\n",  # stray BEGIN
+        f"# a\n\n{END_MARKER}\nbody\n{BEGIN_MARKER}\n",  # END before BEGIN
+    ],
+)
+def test_splice_block_raises_on_malformed(body):
+    """splice_block is a pure refusal gate: it raises MalformedMarkersError on
+    an unsafe marker state rather than silently returning the text unchanged."""
+    with pytest.raises(MalformedMarkersError):
+        splice_block(body)
 
 
 # --- W2: atomic write + timestamped backup ---

--- a/tests/test_aim_wiki_pointer_injection.py
+++ b/tests/test_aim_wiki_pointer_injection.py
@@ -1,0 +1,104 @@
+"""wiki_pointer: placement rule, idempotency, surrounding-content preservation."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_SCRIPTS = (
+    Path(__file__).resolve().parents[1]
+    / "_ai-memory"
+    / "skills"
+    / "aim-wiki"
+    / "scripts"
+)
+
+
+def _load(name: str):
+    """Load an aim-wiki skill script by bare module name (registered in
+    sys.modules) so sibling scripts that `import <name>` resolve correctly —
+    without adding scripts/ to sys.path (no sys.path namespace collision)."""
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_wiki_pointer = _load("wiki_pointer")
+POINTER_HEADING = _wiki_pointer.POINTER_HEADING
+upsert_pointer = _wiki_pointer.upsert_pointer
+upsert_section = _wiki_pointer.upsert_section
+
+
+def test_creates_agents_when_neither_exists(tmp_path):
+    changed = upsert_pointer(tmp_path)
+    assert changed == ["AGENTS.md"]
+    assert not (tmp_path / "CLAUDE.md").exists()
+    assert POINTER_HEADING in (tmp_path / "AGENTS.md").read_text()
+
+
+def test_updates_claude_when_present(tmp_path):
+    (tmp_path / "CLAUDE.md").write_text(
+        "# House rules\n\nBe surgical.\n", encoding="utf-8"
+    )
+    changed = upsert_pointer(tmp_path)
+    assert changed == ["CLAUDE.md"]
+    text = (tmp_path / "CLAUDE.md").read_text()
+    assert "Be surgical." in text, "surrounding content preserved"
+    assert POINTER_HEADING in text
+    assert not (
+        tmp_path / "AGENTS.md"
+    ).exists(), "AGENTS.md not created when CLAUDE.md exists"
+
+
+def test_updates_both_when_both_present(tmp_path):
+    (tmp_path / "CLAUDE.md").write_text("# c\n", encoding="utf-8")
+    (tmp_path / "AGENTS.md").write_text("# a\n", encoding="utf-8")
+    changed = upsert_pointer(tmp_path)
+    assert set(changed) == {"CLAUDE.md", "AGENTS.md"}
+
+
+def test_idempotent_second_run_no_change(tmp_path):
+    upsert_pointer(tmp_path)  # creates AGENTS.md
+    changed = upsert_pointer(tmp_path)  # second run
+    assert changed == [], "re-running with an identical section must be a no-op"
+
+
+def test_replaces_existing_section_no_duplicate(tmp_path):
+    claude = tmp_path / "CLAUDE.md"
+    claude.write_text(
+        "# top\n\n## Project Wiki\n\nOLD stale pointer text.\n\n## Other\n\nkeep me.\n",
+        encoding="utf-8",
+    )
+    upsert_pointer(tmp_path)
+    text = claude.read_text()
+    assert text.count(POINTER_HEADING) == 1, "must replace, not duplicate"
+    assert "OLD stale pointer text." not in text
+    assert "## Other" in text and "keep me." in text, "later section preserved"
+    assert "wiki/quickstart.md" in text
+
+
+def test_replace_preserves_following_h1(tmp_path):
+    """F-A: replacing the section must NOT swallow a following `# H1` heading.
+
+    The old terminator stopped only at `## ` H2 / EOF, so a `# Appendix` after the
+    Project Wiki section was consumed and deleted on replace (data-loss)."""
+    claude = tmp_path / "CLAUDE.md"
+    claude.write_text(
+        "# Top\n\n## Project Wiki\n\nOLD pointer text.\n\n# Appendix\n\nkeep me.\n",
+        encoding="utf-8",
+    )
+    upsert_pointer(tmp_path)
+    text = claude.read_text()
+    assert text.count(POINTER_HEADING) == 1, "must replace, not duplicate"
+    assert "OLD pointer text." not in text
+    assert "# Appendix" in text and "keep me." in text, "following H1 preserved"
+
+
+def test_upsert_section_appends_with_separation():
+    out = upsert_section("# title\n\nbody\n")
+    assert "body" in out
+    assert out.rstrip().endswith("run an update when your changes make a page stale.")
+    assert "\n\n## Project Wiki" in out

--- a/tests/test_aim_wiki_verify_manifest.py
+++ b/tests/test_aim_wiki_verify_manifest.py
@@ -1,0 +1,134 @@
+"""wiki_verify: citation extraction + dead-path precheck (verifier plumbing)."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_SCRIPTS = (
+    Path(__file__).resolve().parents[1]
+    / "_ai-memory"
+    / "skills"
+    / "aim-wiki"
+    / "scripts"
+)
+
+
+def _load(name: str):
+    """Load an aim-wiki skill script by bare module name (registered in
+    sys.modules) so sibling scripts that `import <name>` resolve correctly —
+    without adding scripts/ to sys.path (no sys.path namespace collision)."""
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_load("wiki_common")  # wiki_verify imports it by bare name — must land first
+build_manifest = _load("wiki_verify").build_manifest
+
+
+def _page(root: Path, rel: str, text: str) -> None:
+    p = root / "wiki" / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def test_live_and_dead_citations(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print(1)\n", encoding="utf-8")
+    _page(
+        tmp_path,
+        "quickstart.md",
+        "The entrypoint is `src/app.py`. Missing: `src/gone.py`.\n"
+        "External [docs](https://example.com) ignored.\n"
+        "Nav to [arch](architecture/overview.md) ignored.\n",
+    )
+    _page(tmp_path, "architecture/overview.md", "See `src/app.py:12` for detail.\n")
+
+    m = build_manifest(tmp_path)
+    assert m["page_count"] == 2
+    dead_refs = {(d["page"], d["ref"]) for d in m["dead_citations"]}
+    assert ("wiki/quickstart.md", "src/gone.py") in dead_refs
+    assert m["dead_count"] == 1
+    # Live citation resolves (and :line suffix is stripped before resolving).
+    all_refs = {c["ref"] for p in m["pages"] for c in p["citations"]}
+    assert "src/app.py" in all_refs
+    # External links and intra-wiki nav are not treated as source citations.
+    assert not any(
+        c["ref"].startswith(("http://", "https://"))
+        for p in m["pages"]
+        for c in p["citations"]
+    )
+    assert not any(
+        c["ref"] == "architecture/overview.md"
+        for p in m["pages"]
+        for c in p["citations"]
+    )
+
+
+def test_page_relative_citation_resolves(tmp_path):
+    (tmp_path / "README.md").write_text("# proj\n", encoding="utf-8")
+    _page(tmp_path, "quickstart.md", "Root readme: [readme](../README.md)\n")
+    m = build_manifest(tmp_path)
+    assert m["dead_count"] == 0, "../README.md must resolve page-relative to repo root"
+    assert m["citation_count"] == 1
+
+
+def test_plan_file_skipped(tmp_path):
+    _page(tmp_path, "quickstart.md", "ok\n")
+    _page(tmp_path, "_plan.md", "cite `src/nope.py`\n")
+    m = build_manifest(tmp_path)
+    assert m["page_count"] == 1, "_plan.md excluded from the manifest"
+    assert m["dead_count"] == 0
+
+
+def test_prose_dotted_token_not_flagged(tmp_path):
+    """F-E: bare dotted prose (`array.map`) is not a source citation; a real
+    slash path (`src/gone.py`) still is."""
+    _page(
+        tmp_path,
+        "quickstart.md",
+        "Use `array.map` and `response` freely. Missing file `src/gone.py`.\n",
+    )
+    m = build_manifest(tmp_path)
+    refs = {c["ref"] for p in m["pages"] for c in p["citations"]}
+    assert "array.map" not in refs, "prose dotted token must not be a citation"
+    assert "response" not in refs
+    assert "src/gone.py" in refs, "a real slash path is still a citation"
+    assert m["dead_count"] == 1
+
+
+def test_slash_prose_not_flagged(tmp_path):
+    """F-E-R2: backtick slash-prose (`TCP/IP`, `CI/CD`, `and/or`, `client/server`)
+    is not a source citation; a slash path whose basename has a source extension
+    still is (`docs/guide.md` live, `src/gone.py` dead)."""
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "guide.md").write_text("# guide\n", encoding="utf-8")
+    _page(
+        tmp_path,
+        "quickstart.md",
+        "Networking uses `TCP/IP`, `CI/CD`, `and/or`, `client/server`.\n"
+        "See `docs/guide.md`. Missing file `src/gone.py`.\n",
+    )
+    m = build_manifest(tmp_path)
+    refs = {c["ref"] for p in m["pages"] for c in p["citations"]}
+    for prose in ("TCP/IP", "CI/CD", "and/or", "client/server"):
+        assert prose not in refs, f"{prose} slash-prose must not be a citation"
+    assert "docs/guide.md" in refs, "slash path with source-ext basename is a citation"
+    assert "src/gone.py" in refs, "nonexistent slash source path still flagged dead"
+    assert m["dead_count"] == 1, "only src/gone.py is dead"
+
+
+def test_empty_wiki(tmp_path):
+    (tmp_path / "wiki").mkdir()
+    m = build_manifest(tmp_path)
+    assert m == {
+        "pages": [],
+        "dead_citations": [],
+        "page_count": 0,
+        "citation_count": 0,
+        "dead_count": 0,
+    }


### PR DESCRIPTION
## Summary
Adds `aim-wiki`, a skill that creates and maintains an up-to-date wiki of the
user's project, in-session. Works on any project — new or existing.

## What it does
- init — generate the wiki from the current repo (existing codebases: inventory
  + git-history synthesis, maps over any existing docs)
- update — surgical, git-diff-driven refresh; no-op when nothing relevant changed
- status — freshness/drift report
- Grounds every claim in source; a read-only verifier pass flags ungrounded
  claims before acceptance
- Injects a `## Project Wiki` pointer into CLAUDE.md/AGENTS.md
- Multi-project scoped; no external LLM/provider config (runs in-session)

## Structure
- `_ai-memory/skills/aim-wiki/{SKILL.md, scripts/, references/}`
- Tests: `tests/test_aim_wiki_*.py` (36)

## Notes
- Known v1 limitation: source-drift excludes the whole top-level CLAUDE.md/AGENTS.md
  (pointer-section-scoped drift is a future refinement).
- Deferred (designed-for, not built): memory-store integration of wiki pages,
  headless/CI mode + GitHub Action.

Concept adapted from langchain-ai/openwiki (MIT).
