### PR TITLE
Data-safety: read-merge Gemini config + shut down embedding executor at teardown (TD-635, TD-710-pt2)

### DIFF
--- a/docker/embedding/main.py
+++ b/docker/embedding/main.py
@@ -690,6 +690,11 @@ async def _lifespan(_app):
         task.cancel()
         with suppress(asyncio.CancelledError):
             await task
+        # TD-710: shut the inference executor down explicitly at teardown rather
+        # than leaving it to process-exit reaping. wait=False + cancel_futures
+        # mirrors the controller-task cancel above (stop promptly, never block
+        # teardown); any in-flight inference threads finish as the process exits.
+        _inference_executor.shutdown(wait=False, cancel_futures=True)
 
 
 app = FastAPI(

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3757,108 +3757,192 @@ write_gemini_config() {
         cp "$guidance_src" "$project_path/AI-MEMORY.md"
         log_success "Deployed agent-guidance file to $project_path/AI-MEMORY.md"
     fi
-    # Ensure AI-MEMORY.md is registered in context.fileName when an existing
-    # settings.json would otherwise be skipped (append-preserve: never drops GEMINI.md
-    # or user entries; non-str/non-list type guard retained).
-    if [[ -f "$config_file" ]]; then
-        python3 -c "
-import json, sys
-config_path = sys.argv[1]
-try:
-    with open(config_path) as f:
-        cfg = json.load(f)
-except (ValueError, OSError):
-    cfg = {}
-ctx = cfg.setdefault('context', {})
-existing = ctx.get('fileName')
-if existing is None:
-    names = ['GEMINI.md']
-elif isinstance(existing, str):
-    names = [existing]
-elif isinstance(existing, list):
-    names = list(existing)
-else:
-    names = ['GEMINI.md']
-if 'AI-MEMORY.md' not in names:
-    names.append('AI-MEMORY.md')
-    ctx['fileName'] = names
-    with open(config_path, 'w') as f:
-        json.dump(cfg, f, indent=2)
-        f.write('\n')
-" "$config_file"
-    fi
-
-    if [[ -f "$config_file" ]] && grep -q "AI_MEMORY_INSTALL_DIR" "$config_file" 2>/dev/null; then
-        if [[ "$force" != "true" ]]; then
-            log_warning "Gemini config already contains ai-memory hooks — skipping (use FORCE_IDE=true to overwrite)"
-            return 0
-        fi
-    fi
-
     mkdir -p "$project_path/.gemini"
     local py="$install_dir/.venv/bin/python"
     local ad="$install_dir/src/memory/adapters"
 
+    # TD-600 skip-path: when the config already carries ai-memory hooks and this is
+    # not a forced re-install, register context.fileName ONLY (leave env/hooks as the
+    # user has them). Otherwise do the full read-merge. The single python path below
+    # handles both modes; the mode is decided here so the skip-path can still short
+    # -circuit the command-file copy + success log.
+    local mode="full"
+    if [[ -f "$config_file" ]] && grep -q "AI_MEMORY_INSTALL_DIR" "$config_file" 2>/dev/null; then
+        if [[ "$force" != "true" ]]; then
+            mode="register-only"
+        fi
+    fi
+
+    # TD-635: single safe path — read existing (guarded) -> pristine timestamped
+    # backup FIRST (before any mutation) -> merge -> atomic write (tempfile in the
+    # same dir + os.replace). Mirrors scripts/merge_settings.py discipline. Every
+    # access is isinstance-guarded so malformed / non-dict input degrades to safe
+    # defaults and NEVER aborts the installer (no un-guarded access under set -e).
     python3 -c "
-import json, os, sys
-install_dir, project_id, py, ad = sys.argv[1:5]
-config_path = sys.argv[5]
+import json, os, shutil, sys, tempfile
+from datetime import datetime
+
+install_dir, project_id, py, ad, config_path, mode = sys.argv[1:7]
 _sot_on = os.environ.get('AI_MEMORY_SOT_HOOKS', 'on').lower() != 'off'
-config = {
-    'env': {
-        'AI_MEMORY_INSTALL_DIR': install_dir,
-        'AI_MEMORY_PROJECT_ID': project_id,
-        'QDRANT_HOST': 'localhost',
-        'QDRANT_PORT': '26350',
-        'QDRANT_GRPC_PORT': '26351',
-        'EMBEDDING_HOST': '127.0.0.1',
-        'EMBEDDING_PORT': '28080',
-        'SIMILARITY_THRESHOLD': '0.4',
-        'LOG_LEVEL': 'INFO'
-    },
-    'hooks': {
-        'SessionStart': [{'matcher': '.*', 'hooks': [{'type': 'command', 'command': f'\"{py}\" \"{ad}/gemini/session_start.py\"', 'timeout': 30000}]}],
-        'AfterTool': [
-            {'matcher': 'edit_file|write_file|create_file', 'hooks': [{'type': 'command', 'command': f'\"{py}\" \"{ad}/gemini/after_tool_capture.py\"', 'timeout': 5000}]},
-            {'matcher': 'run_shell_command', 'hooks': [
-                {'type': 'command', 'command': f'\"{py}\" \"{ad}/gemini/error_detection.py\"', 'timeout': 5000},
-                {'type': 'command', 'command': f'\"{py}\" \"{ad}/gemini/error_pattern_capture.py\"', 'timeout': 5000}
-            ]},
-            {'matcher': 'mcp_.*', 'hooks': [{'type': 'command', 'command': f'\"{py}\" \"{ad}/gemini/after_tool_capture.py\"', 'timeout': 5000}]}
-        ],
-        'PreCompress': [{'matcher': '.*', 'hooks': [{'type': 'command', 'command': f'\"{py}\" \"{ad}/gemini/pre_compress.py\"', 'timeout': 60000}]}]
-    }
+
+
+def load_config(path):
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (ValueError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def context_and_names(config):
+    context = config.get('context')
+    if not isinstance(context, dict):
+        context = {}
+    existing = context.get('fileName')
+    if isinstance(existing, str):
+        names = [existing]
+    elif isinstance(existing, list):
+        names = list(existing)
+    else:
+        # None or non-str/non-list (int, bool, dict) -> treat as absent. Setting
+        # context.fileName disables Gemini's implicit GEMINI.md default, so list it
+        # explicitly alongside ours when the user has no usable prior setting.
+        names = ['GEMINI.md']
+    return context, names
+
+
+def hook_commands(wrapper):
+    cmds = set()
+    if isinstance(wrapper, dict):
+        if 'command' in wrapper:
+            cmds.add(wrapper['command'])
+        subs = wrapper.get('hooks')
+        if isinstance(subs, list):
+            for h in subs:
+                if isinstance(h, dict) and 'command' in h:
+                    cmds.add(h['command'])
+    return cmds
+
+
+def wrapper_key(wrapper):
+    # Identity of a hook wrapper for dedupe = (matcher, its command set). Keying on
+    # commands alone is WRONG for Gemini: distinct matchers legitimately share a
+    # command (e.g. the 'edit_file|...' and 'mcp_.*' AfterTool wrappers both run
+    # after_tool_capture.py) — command-only dedupe would silently drop one.
+    matcher = wrapper.get('matcher') if isinstance(wrapper, dict) else None
+    return (matcher, frozenset(hook_commands(wrapper)))
+
+
+def merge_hooks(existing, new):
+    # Deep-merge per hook event: list-append + dedupe by (matcher, command set),
+    # preserving user-authored (non-AI-Memory) Gemini hooks. Append a new wrapper
+    # only when its (matcher, commands) identity is not already present. Idempotent:
+    # a re-install's identical wrappers dedupe to a byte-identical result.
+    if not isinstance(existing, dict):
+        existing = {}
+    result = dict(existing)
+    for event, new_wrappers in new.items():
+        current = result.get(event)
+        if not isinstance(current, list):
+            current = []
+        merged = list(current)
+        seen = {wrapper_key(w) for w in current}
+        for w in new_wrappers:
+            key = wrapper_key(w)
+            if key not in seen:
+                merged.append(w)
+                seen.add(key)
+        result[event] = merged
+    return result
+
+
+def atomic_write(path, data):
+    # Pristine backup FIRST (copy, not rename), then atomic tempfile + os.replace.
+    if os.path.exists(path):
+        backup = path + '.backup.' + datetime.now().strftime('%Y%m%d_%H%M%S_%f')
+        shutil.copy2(path, backup)
+    d = os.path.dirname(path) or '.'
+    fd, tmp = tempfile.mkstemp(dir=d, prefix='.settings_', suffix='.tmp')
+    try:
+        with os.fdopen(fd, 'w') as f:
+            json.dump(data, f, indent=2)
+            f.write('\n')
+        os.replace(tmp, path)
+    except Exception:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
+
+
+config = load_config(config_path)
+context, names = context_and_names(config)
+
+if mode == 'register-only':
+    # Register context.fileName only; leave env/hooks exactly as the user has them.
+    # Skip the write entirely when already registered so an idempotent re-install
+    # leaves the file (and its backups) untouched.
+    if 'AI-MEMORY.md' in names:
+        sys.exit(0)
+    names.append('AI-MEMORY.md')
+    context['fileName'] = names
+    config['context'] = context
+    atomic_write(config_path, config)
+    sys.exit(0)
+
+# Full mode: read-merge env + deep-merge hooks + register context.fileName, while
+# preserving user-authored top-level keys (theme, mcpServers, ...) and user env
+# sub-keys.
+env = config.get('env')
+if not isinstance(env, dict):
+    env = {}
+for k, v in {
+    'AI_MEMORY_INSTALL_DIR': install_dir,
+    'AI_MEMORY_PROJECT_ID': project_id,
+    'QDRANT_HOST': 'localhost',
+    'QDRANT_PORT': '26350',
+    'QDRANT_GRPC_PORT': '26351',
+    'EMBEDDING_HOST': '127.0.0.1',
+    'EMBEDDING_PORT': '28080',
+    'SIMILARITY_THRESHOLD': '0.4',
+    'LOG_LEVEL': 'INFO',
+}.items():
+    env.setdefault(k, v)
+env['AI_MEMORY_INSTALL_DIR'] = install_dir
+env['AI_MEMORY_PROJECT_ID'] = project_id
+config['env'] = env
+
+ai_hooks = {
+    'SessionStart': [{'matcher': '.*', 'hooks': [{'type': 'command', 'command': f'\"{py}\" \"{ad}/gemini/session_start.py\"', 'timeout': 30000}]}],
+    'AfterTool': [
+        {'matcher': 'edit_file|write_file|create_file', 'hooks': [{'type': 'command', 'command': f'\"{py}\" \"{ad}/gemini/after_tool_capture.py\"', 'timeout': 5000}]},
+        {'matcher': 'run_shell_command', 'hooks': [
+            {'type': 'command', 'command': f'\"{py}\" \"{ad}/gemini/error_detection.py\"', 'timeout': 5000},
+            {'type': 'command', 'command': f'\"{py}\" \"{ad}/gemini/error_pattern_capture.py\"', 'timeout': 5000}
+        ]},
+        {'matcher': 'mcp_.*', 'hooks': [{'type': 'command', 'command': f'\"{py}\" \"{ad}/gemini/after_tool_capture.py\"', 'timeout': 5000}]}
+    ],
+    'PreCompress': [{'matcher': '.*', 'hooks': [{'type': 'command', 'command': f'\"{py}\" \"{ad}/gemini/pre_compress.py\"', 'timeout': 60000}]}]
 }
 if _sot_on:
-    config['hooks']['SessionStart'].append({'matcher': '.*', 'hooks': [{'type': 'command', 'command': f'\"{py}\" \"{ad}/gemini/sot_digest_session_start.py\"', 'timeout': 30000}]})
-    config['hooks']['PreCompress'].append({'matcher': '.*', 'hooks': [{'type': 'command', 'command': f'\"{py}\" \"{ad}/gemini/sot_drift.py\"', 'timeout': 30000}]})
-# TD-600: register the AI-Memory-owned guidance file in context.fileName so it
-# auto-loads with every prompt, WITHOUT dropping GEMINI.md or any user entries.
-# Setting context.fileName disables Gemini's implicit GEMINI.md default, so when
-# the user has no prior setting we must list GEMINI.md explicitly alongside ours.
-existing_names = None
-if os.path.exists(config_path):
-    try:
-        with open(config_path) as f:
-            existing_names = json.load(f).get('context', {}).get('fileName')
-    except (ValueError, OSError):
-        existing_names = None
-if existing_names is None:
-    names = ['GEMINI.md']
-elif isinstance(existing_names, str):
-    names = [existing_names]
-elif isinstance(existing_names, list):
-    names = list(existing_names)
-else:
-    # Non-string, non-list value (e.g. integer, boolean) — treat as absent.
-    names = ['GEMINI.md']
+    ai_hooks['SessionStart'].append({'matcher': '.*', 'hooks': [{'type': 'command', 'command': f'\"{py}\" \"{ad}/gemini/sot_digest_session_start.py\"', 'timeout': 30000}]})
+    ai_hooks['PreCompress'].append({'matcher': '.*', 'hooks': [{'type': 'command', 'command': f'\"{py}\" \"{ad}/gemini/sot_drift.py\"', 'timeout': 30000}]})
+config['hooks'] = merge_hooks(config.get('hooks'), ai_hooks)
+
 if 'AI-MEMORY.md' not in names:
     names.append('AI-MEMORY.md')
-config['context'] = {'fileName': names}
-with open(config_path, 'w') as f:
-    json.dump(config, f, indent=2)
-    f.write('\n')
-" "$install_dir" "$project_id" "$py" "$ad" "$config_file"
+context['fileName'] = names
+config['context'] = context
+
+atomic_write(config_path, config)
+" "$install_dir" "$project_id" "$py" "$ad" "$config_file" "$mode"
+
+    if [[ "$mode" == "register-only" ]]; then
+        log_warning "Gemini config already contains ai-memory hooks — skipping (use FORCE_IDE=true to overwrite)"
+        return 0
+    fi
 
     mkdir -p "$project_path/.gemini/commands"
     cp "$install_dir/src/memory/adapters/templates/gemini/"*.toml "$project_path/.gemini/commands/" 2>/dev/null || true

--- a/tests/test_embedding_service.py
+++ b/tests/test_embedding_service.py
@@ -1074,3 +1074,19 @@ def test_health_model_none_returns_503():
     resp = client.get("/health")
     assert resp.status_code == 503
     assert resp.json()["status"] == "loading"
+
+
+def test_lifespan_teardown_shuts_down_inference_executor():
+    """TD-710: the FastAPI lifespan teardown shuts the inference executor down
+    explicitly (rather than leaving it to process-exit reaping). The request path
+    is unaffected — the executor runs work while the app is live; only after
+    teardown are new submissions rejected."""
+    service = _load_service(2)
+
+    # Request path unaffected: the executor runs work while the app is live.
+    with TestClient(service.app):
+        assert service._inference_executor.submit(lambda: 1).result(timeout=5) == 1
+
+    # After teardown the executor is shut down: new submissions are rejected.
+    with pytest.raises(RuntimeError):
+        service._inference_executor.submit(lambda: 1)

--- a/tests/test_install_multicli_agent_guidance.py
+++ b/tests/test_install_multicli_agent_guidance.py
@@ -175,6 +175,294 @@ class TestGeminiGuidance:
         # Existing entry preserved.
         assert "GEMINI.md" in names
 
+    def test_zero_clobber_user_top_level_keys(
+        self, install_sh_no_main, install_dir, tmp_path
+    ):
+        """TD-635: a pre-existing settings.json with user top-level keys (theme,
+        mcpServers, ...) survives install byte-equivalent except the AI-Memory-owned
+        keys (env, hooks, context); a timestamped backup is written first."""
+        project = tmp_path / "proj"
+        (project / ".gemini").mkdir(parents=True)
+        user_settings = {
+            "theme": "GitHub",
+            "mcpServers": {"my-server": {"command": "node", "args": ["srv.js"]}},
+            "model": {"name": "gemini-2.5-pro"},
+            "env": {"MY_CUSTOM_VAR": "keep-me", "LOG_LEVEL": "DEBUG"},
+        }
+        (project / ".gemini" / "settings.json").write_text(
+            json.dumps(user_settings), encoding="utf-8"
+        )
+
+        result = _call(install_sh_no_main, "write_gemini_config", project, install_dir)
+        assert result.returncode == 0, result.stderr
+
+        after = json.loads((project / ".gemini" / "settings.json").read_text())
+        # User top-level keys survive byte-equivalent (compare everything except
+        # the AI-Memory-owned keys the installer sets/updates).
+        owned = {"env", "hooks", "context"}
+        before_rest = {k: v for k, v in user_settings.items() if k not in owned}
+        after_rest = {k: v for k, v in after.items() if k not in owned}
+        assert after_rest == before_rest
+        # AI-Memory-owned keys are set.
+        assert after["env"]["AI_MEMORY_INSTALL_DIR"] == str(install_dir)
+        assert after["env"]["AI_MEMORY_PROJECT_ID"] == "test-project"
+        assert "SessionStart" in after["hooks"]
+        assert "AI-MEMORY.md" in after["context"]["fileName"]
+        # User env entries preserved (custom var kept; user LOG_LEVEL not overwritten).
+        assert after["env"]["MY_CUSTOM_VAR"] == "keep-me"
+        assert after["env"]["LOG_LEVEL"] == "DEBUG"
+        # Timestamped backup written before the atomic rewrite.
+        assert list((project / ".gemini").glob("settings.json.backup.*"))
+
+    def test_reinstall_idempotent_settings_byte_equivalent(
+        self, install_sh_no_main, install_dir, tmp_path
+    ):
+        """TD-635: a forced re-install produces byte-identical settings.json."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        _call(install_sh_no_main, "write_gemini_config", project, install_dir)
+        first = (project / ".gemini" / "settings.json").read_bytes()
+        result = _call(
+            install_sh_no_main,
+            "write_gemini_config",
+            project,
+            install_dir,
+            force="true",
+        )
+        assert result.returncode == 0, result.stderr
+        second = (project / ".gemini" / "settings.json").read_bytes()
+        assert second == first
+
+    def test_malformed_json_no_crash_and_backup_is_pristine(
+        self, install_sh_no_main, install_dir, tmp_path
+    ):
+        """TD-635: malformed settings.json must NOT abort the installer, and the
+        timestamped backup must preserve the ORIGINAL (pristine) content so the
+        user's keys are recoverable."""
+        project = tmp_path / "proj"
+        (project / ".gemini").mkdir(parents=True)
+        settings = project / ".gemini" / "settings.json"
+        # Invalid JSON (trailing comma) that still textually carries user keys.
+        malformed = '{"theme": "Dracula", "mcpServers": {"srv": {"command": "node"}},}'
+        settings.write_text(malformed, encoding="utf-8")
+        original = settings.read_bytes()
+
+        result = _call(install_sh_no_main, "write_gemini_config", project, install_dir)
+        # Installer does not crash on malformed input.
+        assert result.returncode == 0, result.stderr
+        # settings.json was rewritten to a valid AI-Memory config.
+        rewritten = json.loads(settings.read_text())
+        assert "AI-MEMORY.md" in rewritten["context"]["fileName"]
+        # A pristine backup preserves the ORIGINAL content byte-for-byte, so the
+        # user's theme/mcpServers remain recoverable.
+        backups = list((project / ".gemini").glob("settings.json.backup.*"))
+        assert len(backups) == 1
+        assert backups[0].read_bytes() == original
+        assert "theme" in backups[0].read_text()
+        assert "mcpServers" in backups[0].read_text()
+
+    def test_top_level_non_dict_json_no_crash(
+        self, install_sh_no_main, install_dir, tmp_path
+    ):
+        """TD-635: a top-level non-dict JSON document (e.g. an array) must not raise
+        under set -euo pipefail — it degrades to a safe default."""
+        project = tmp_path / "proj"
+        (project / ".gemini").mkdir(parents=True)
+        settings = project / ".gemini" / "settings.json"
+        settings.write_text("[1, 2, 3]", encoding="utf-8")
+        original = settings.read_bytes()
+
+        result = _call(install_sh_no_main, "write_gemini_config", project, install_dir)
+        assert result.returncode == 0, result.stderr
+        rewritten = json.loads(settings.read_text())
+        assert isinstance(rewritten, dict)
+        assert "AI-MEMORY.md" in rewritten["context"]["fileName"]
+        # Original array preserved in the pristine backup.
+        backups = list((project / ".gemini").glob("settings.json.backup.*"))
+        assert len(backups) == 1
+        assert backups[0].read_bytes() == original
+
+    def test_context_present_but_non_dict_no_crash(
+        self, install_sh_no_main, install_dir, tmp_path
+    ):
+        """TD-635: a `context` key whose value is not a dict must not raise; it
+        degrades to the default fileName registration."""
+        project = tmp_path / "proj"
+        (project / ".gemini").mkdir(parents=True)
+        settings = project / ".gemini" / "settings.json"
+        settings.write_text(
+            json.dumps({"theme": "Solarized", "context": 5}), encoding="utf-8"
+        )
+
+        result = _call(install_sh_no_main, "write_gemini_config", project, install_dir)
+        assert result.returncode == 0, result.stderr
+        rewritten = json.loads(settings.read_text())
+        # User top-level key preserved; context.fileName registered with defaults.
+        assert rewritten["theme"] == "Solarized"
+        assert rewritten["context"]["fileName"] == ["GEMINI.md", "AI-MEMORY.md"]
+
+    def test_reinstall_idempotent_from_user_file(
+        self, install_sh_no_main, install_dir, tmp_path
+    ):
+        """TD-635: re-install starting FROM a pre-existing user file (not an empty
+        project) is byte-equivalent and the user's top-level keys survive."""
+        project = tmp_path / "proj"
+        (project / ".gemini").mkdir(parents=True)
+        settings = project / ".gemini" / "settings.json"
+        settings.write_text(
+            json.dumps({"theme": "GitHub", "mcpServers": {"s": {"command": "x"}}}),
+            encoding="utf-8",
+        )
+
+        _call(install_sh_no_main, "write_gemini_config", project, install_dir)
+        first = settings.read_bytes()
+        # Forced re-install must reproduce byte-identical settings.json.
+        result = _call(
+            install_sh_no_main,
+            "write_gemini_config",
+            project,
+            install_dir,
+            force="true",
+        )
+        assert result.returncode == 0, result.stderr
+        second = settings.read_bytes()
+        assert second == first
+        after = json.loads(second)
+        assert after["theme"] == "GitHub"
+        assert after["mcpServers"] == {"s": {"command": "x"}}
+
+    def test_deep_merge_preserves_user_authored_hook(
+        self, install_sh_no_main, install_dir, tmp_path
+    ):
+        """TD-635 fix ②: a user-authored Gemini hook survives the install — hooks are
+        deep-merged (list-append + dedupe-by-command), not wholesale-replaced."""
+        project = tmp_path / "proj"
+        (project / ".gemini").mkdir(parents=True)
+        settings = project / ".gemini" / "settings.json"
+        settings.write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "SessionStart": [
+                            {
+                                "matcher": "custom",
+                                "hooks": [
+                                    {"type": "command", "command": "echo user-hook"}
+                                ],
+                            }
+                        ]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = _call(install_sh_no_main, "write_gemini_config", project, install_dir)
+        assert result.returncode == 0, result.stderr
+        hooks = json.loads(settings.read_text())["hooks"]
+        commands = json.dumps(hooks)
+        # User hook preserved.
+        assert "echo user-hook" in commands
+        # AI-Memory hook appended alongside it (not replacing it).
+        assert "gemini/session_start.py" in commands
+
+    def test_all_after_tool_matchers_present_after_clean_install(
+        self, install_sh_no_main, install_dir, tmp_path
+    ):
+        """All three AfterTool wrappers survive a clean install. Regression guard:
+        the 'edit_file|write_file|create_file' and 'mcp_.*' wrappers share the
+        after_tool_capture.py command, so command-only dedupe silently dropped the
+        mcp_.* wrapper (Gemini stopped capturing memory on MCP tool calls)."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        result = _call(install_sh_no_main, "write_gemini_config", project, install_dir)
+        assert result.returncode == 0, result.stderr
+
+        after_tool = json.loads((project / ".gemini" / "settings.json").read_text())[
+            "hooks"
+        ]["AfterTool"]
+        matchers = [w["matcher"] for w in after_tool]
+        assert "edit_file|write_file|create_file" in matchers
+        assert "run_shell_command" in matchers
+        assert "mcp_.*" in matchers
+        # Byte-idempotent on a forced reinstall (dedupe keeps all three, no dupes).
+        result = _call(
+            install_sh_no_main,
+            "write_gemini_config",
+            project,
+            install_dir,
+            force="true",
+        )
+        assert result.returncode == 0, result.stderr
+        after_tool_2 = json.loads((project / ".gemini" / "settings.json").read_text())[
+            "hooks"
+        ]["AfterTool"]
+        assert [w["matcher"] for w in after_tool_2] == matchers
+
+    def test_register_only_leaves_env_and_hooks_untouched(
+        self, install_sh_no_main, install_dir, tmp_path
+    ):
+        """Skip-path (existing ai-memory hooks, no force): register context.fileName
+        ONLY — env and hooks content is left exactly as the user has it."""
+        project = tmp_path / "proj"
+        (project / ".gemini").mkdir(parents=True)
+        settings = project / ".gemini" / "settings.json"
+        existing = {
+            "theme": "Nord",
+            "env": {
+                "AI_MEMORY_INSTALL_DIR": "/old/install",
+                "AI_MEMORY_PROJECT_ID": "old-proj",
+                "CUSTOM": "keep-me",
+            },
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "matcher": "custom",
+                        "hooks": [{"type": "command", "command": "echo mine"}],
+                    }
+                ]
+            },
+            "context": {"fileName": ["GEMINI.md"]},
+        }
+        settings.write_text(json.dumps(existing), encoding="utf-8")
+
+        result = _call(install_sh_no_main, "write_gemini_config", project, install_dir)
+        assert result.returncode == 0, result.stderr
+
+        after = json.loads(settings.read_text())
+        # env + hooks content untouched (no AI-Memory injection, old values kept).
+        assert after["env"] == existing["env"]
+        assert after["hooks"] == existing["hooks"]
+        assert after["theme"] == "Nord"
+        # Only context.fileName was updated.
+        assert after["context"]["fileName"] == ["GEMINI.md", "AI-MEMORY.md"]
+
+    def test_register_only_repeat_is_noop_with_no_new_backup(
+        self, install_sh_no_main, install_dir, tmp_path
+    ):
+        """A second skip-path call once AI-MEMORY.md is already registered is a true
+        no-op: the file is byte-identical and no new backup is written."""
+        project = tmp_path / "proj"
+        (project / ".gemini").mkdir(parents=True)
+        settings = project / ".gemini" / "settings.json"
+        settings.write_text(
+            json.dumps(
+                {
+                    "env": {"AI_MEMORY_INSTALL_DIR": "/old"},
+                    "hooks": {},
+                    "context": {"fileName": ["GEMINI.md", "AI-MEMORY.md"]},
+                }
+            ),
+            encoding="utf-8",
+        )
+        before = settings.read_bytes()
+
+        result = _call(install_sh_no_main, "write_gemini_config", project, install_dir)
+        assert result.returncode == 0, result.stderr
+        # No write happened (already registered) → byte-identical, zero backups.
+        assert settings.read_bytes() == before
+        assert list((project / ".gemini").glob("settings.json.backup.*")) == []
+
 
 # --------------------------------------------------------------------------- #
 # Cursor


### PR DESCRIPTION
## Summary
Two independent user-data-safety fixes — the Gemini installer config-write and the embedding service teardown. No change to normal request/capture behavior.

## TD-635 — read-merge `.gemini/settings.json`
`write_gemini_config` rebuilt the Gemini settings file from scratch on every install / `--force`, destroying user-authored top-level keys (`theme`, `mcpServers`, model prefs) and user env entries. It now **read-merges**:
- preserves unknown top-level keys and user env / hook / context entries; only sets/updates the AI-Memory-owned keys;
- takes a **pristine timestamped backup before any mutation**, then writes **atomically** (tempfile + `os.replace`);
- **deep-merges hooks** (per event, dedupe by matcher + command set) so user-authored hooks survive and AI wrappers are neither dropped nor duplicated;
- guards malformed / non-dict input so it degrades to safe defaults instead of aborting the install;
- idempotent; creates the file when absent.

Mirrors the non-destructive discipline of `scripts/merge_settings.py`.

## TD-710 (part 2) — executor teardown
The embedding inference `ThreadPoolExecutor` is now explicitly shut down (`wait=False, cancel_futures=True`) at FastAPI lifespan teardown instead of relying on process-exit reaping. Request path unchanged.

## Tests
User top-level keys survive byte-equivalent; the backup is the pristine original; malformed / non-dict / array input does not crash; re-install idempotency (including from a pre-existing user file); hook deep-merge preserves user + all AI wrappers (incl. the `mcp_.*` matcher); register-only path leaves env/hooks untouched; and the lifespan teardown shutdown.

Baseline: `main @ 29d4f58` (v2.8.3). Opened as **draft** — holding for maintainer review and merge.
