### PR TITLE
fix(aim-wiki): backtick dir-citation check + full-path citation rule

### DIFF
--- a/_ai-memory/skills/aim-wiki/references/page-structure.md
+++ b/_ai-memory/skills/aim-wiki/references/page-structure.md
@@ -54,6 +54,11 @@ to these rules.
 - Include inline source references (e.g. `` `src/app.py` `` or a link to the file)
   where they help a reader verify or continue exploring. These citations are what
   the `verify` manifest and the read-only verifier subagent check.
+- **Citations must be full paths** — repo-root-relative (`` `src/app.py` ``) or a
+  valid page-relative link (`` [readme](../README.md) ``) — **never a bare
+  filename** (`` `app.py` ``). The verifier only resolves those two forms; a bare
+  basename cannot be matched to a real file and will show as a dead citation even
+  when the file exists elsewhere in the repo.
 - Prefer current source over stale docs. If existing docs conflict with the code or
   git history, flag the likely-stale doc and prefer the source evidence.
 - Explain **why** important code exists, not only what files contain. Use git

--- a/_ai-memory/skills/aim-wiki/scripts/wiki_verify.py
+++ b/_ai-memory/skills/aim-wiki/scripts/wiki_verify.py
@@ -88,6 +88,12 @@ def _looks_like_source(ref: str) -> bool:
     return bool(dot) and ext.lower() in _SOURCE_EXTS
 
 
+def _looks_like_dir_ref(ref: str) -> bool:
+    """True when a backtick token is a directory citation: `/`-terminated and
+    more than just the bare root slash (e.g. `src/handlers/`)."""
+    return ref.endswith("/") and len(ref) > 1
+
+
 def _is_external(target: str) -> bool:
     return target.startswith(("http://", "https://", "mailto:", "#"))
 
@@ -113,7 +119,7 @@ def _extract_citations(page: Path, wiki_root: Path) -> list[str]:
         refs.add(norm)
     for m in _CODE_PATH_RE.finditer(text):
         norm = _normalize(m.group(1))
-        if _looks_like_source(norm):
+        if _looks_like_source(norm) or _looks_like_dir_ref(norm):
             refs.add(norm)
     return sorted(refs)
 

--- a/tests/test_aim_wiki_verify_manifest.py
+++ b/tests/test_aim_wiki_verify_manifest.py
@@ -122,6 +122,35 @@ def test_slash_prose_not_flagged(tmp_path):
     assert m["dead_count"] == 1, "only src/gone.py is dead"
 
 
+def test_bare_basename_citation_flags_dead(tmp_path):
+    """W2: a bare-basename backtick citation (no path) cannot resolve even when
+    the file exists elsewhere in the repo — only root-relative / page-relative
+    forms are supported."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "storage.py").write_text("pass\n", encoding="utf-8")
+    _page(tmp_path, "quickstart.md", "See `storage.py` for the store.\n")
+    m = build_manifest(tmp_path)
+    dead_refs = {(d["page"], d["ref"]) for d in m["dead_citations"]}
+    assert ("wiki/quickstart.md", "storage.py") in dead_refs
+    assert m["dead_count"] == 1
+
+
+def test_dir_citation_resolves_and_flags(tmp_path):
+    """W5: a `/`-terminated backtick citation is checked for directory
+    existence — a real directory resolves live, a missing one is dead."""
+    (tmp_path / "src" / "handlers").mkdir(parents=True)
+    _page(
+        tmp_path,
+        "quickstart.md",
+        "Handlers live in `src/handlers/`. Missing: `src/absent/`.\n",
+    )
+    m = build_manifest(tmp_path)
+    refs = {c["ref"]: c["exists"] for p in m["pages"] for c in p["citations"]}
+    assert refs["src/handlers/"] is True
+    assert refs["src/absent/"] is False
+    assert m["dead_count"] == 1
+
+
 def test_empty_wiki(tmp_path):
     (tmp_path / "wiki").mkdir()
     m = build_manifest(tmp_path)


### PR DESCRIPTION
## Summary
- `wiki_verify.py`: a `/`-terminated backtick citation (e.g. `` `src/handlers/` ``) was silently skipped by the dead-citation precheck because it has no file extension. Add `_looks_like_dir_ref` so directory-style backtick citations are checked for existence too, consistent with how markdown-link citations are already checked. Scoped to backtick citations only — markdown-link citations already resolve directories correctly.
- `references/page-structure.md`: the citation resolver only supports repo-root-relative paths or page-relative links — a bare filename (e.g. `` `storage.py` ``) can never resolve, even when the file exists elsewhere in the repo, producing a false "dead citation". Add an explicit authoring rule (with example) stating citations must be full paths, never a bare filename.

## Test plan
- [x] `pytest tests/test_aim_wiki_verify_manifest.py -q` — 8/8 passed (6 existing + 2 new: bare-basename-still-dead, dir-citation-resolves-and-flags)
- [x] `black --check`, `ruff check`, `mypy`, `isort --check-only` clean on touched files