### PR TITLE
fix(retry-queue): durable, project-scoped failed-store retry with in-stack drain daemon

### DIFF
--- a/.claude/hooks/scripts/error_store_async.py
+++ b/.claude/hooks/scripts/error_store_async.py
@@ -174,20 +174,23 @@ def _build_recoverable_payload(error_context: dict[str, Any]) -> dict[str, Any]:
     The raw ``error_context`` is not a recognised memory-data record, so the
     queue guard would reject it and the outage-time capture would be lost. This
     reconstructs the same record the main (Qdrant-up) store path would have
-    written — formatted content, the ``error_pattern`` type, the resolved
-    group_id, and the session_id — so the entry drains via the format-1
-    ("content" key) handler. group_id mirrors the main path's
-    ``resolve_project_id`` resolution, falling back to "unknown" (the same
-    sentinel process_retry_queue uses) if detection fails.
+    written — formatted content, the ``error_pattern`` type, a valid
+    ``source_hook`` (this capture runs via the PostToolUse hook), and the
+    session_id — so the entry drains via the format-1 ("content" key) handler.
+
+    ``group_id`` is deliberately NOT resolved here: the raw ``cwd`` is carried
+    on the entry instead, and the failed-store producer boundary
+    (``queue_operation`` -> ``_prepare_failed_store_entry`` in
+    ``src/memory/queue.py``) resolves it ONCE, canonically, in the producer's
+    live context. If resolution genuinely fails, that boundary rejects the
+    entry (drop + log) rather than enqueuing it under a fabricated "unknown"
+    catch-all (BUG-523; Will PM #380 — no catch-all group_ids).
     """
-    try:
-        group_id = resolve_project_id(error_context.get("cwd", ""))
-    except ValueError:
-        group_id = "unknown"
     return {
         "content": format_error_content(error_context),
         "type": "error_pattern",
-        "group_id": group_id,
+        "cwd": error_context.get("cwd", ""),
+        "source_hook": "PostToolUse",
         "session_id": error_context.get("session_id", ""),
     }
 

--- a/.claude/hooks/scripts/manual_save_memory.py
+++ b/.claude/hooks/scripts/manual_save_memory.py
@@ -258,7 +258,7 @@ This session summary was manually saved by the user using /save-memory command.
             "content": summary_content,
             "group_id": project_name,
             "memory_type": "session",
-            "source_hook": "ManualSave",
+            "source_hook": "manual",
             "session_id": session_id,
             "importance": "normal",
         }

--- a/.claude/hooks/scripts/manual_save_memory.py
+++ b/.claude/hooks/scripts/manual_save_memory.py
@@ -168,7 +168,7 @@ This session summary was manually saved by the user using /save-memory command.
             "content_hash": content_hash,
             "group_id": project_name,
             "type": "session",
-            "source_hook": "ManualSave",
+            "source_hook": "manual",
             "session_id": session_id,
             "timestamp": timestamp,
             "embedding_status": embedding_status,

--- a/.claude/hooks/scripts/session_start.py
+++ b/.claude/hooks/scripts/session_start.py
@@ -420,6 +420,33 @@ def cleanup_dedup_lock(lock_path: str) -> None:
         pass
 
 
+def _spawn_opportunistic_drain() -> None:
+    """Fire-and-forget an immediate retry-queue drain on session start (BP-181).
+
+    Complements the in-stack daemon so a resumed session doesn't wait for the
+    next interval tick. Fully non-blocking and best-effort — it NEVER delays or
+    crashes session start. The drain CLI holds the shared drain lock, so this
+    never runs concurrently with the daemon.
+    """
+    try:
+        import subprocess
+
+        drain_script = os.path.join(
+            INSTALL_DIR, "scripts", "memory", "process_retry_queue.py"
+        )
+        if not os.path.exists(drain_script):
+            return
+        subprocess.Popen(
+            [sys.executable, drain_script],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except Exception:
+        pass  # Never block or crash session start (FR30, NFR-R1).
+
+
 def main():
     """Retrieve and output relevant memories for Claude context.
 
@@ -427,6 +454,9 @@ def main():
     CRITICAL: Always exit 0 - never block Claude startup (FR30, NFR-R1).
     """
     start_time = time.perf_counter()
+
+    # Opportunistic, non-blocking retry-queue drain (BP-181) — never blocks start.
+    _spawn_opportunistic_drain()
 
     with track_hook_duration("SessionStart"):
         try:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -513,6 +513,82 @@ services:
       retries: 3
       start_period: 60s  # F2/F9: Allow time for Python startup, logger init, and first health file creation (typically <5s, buffer for slow systems)
 
+  # BUG-522 / BP-181: in-stack retry-queue drain daemon. Replaces the WSL2 host
+  # cron (which recovered ≈0 because the distro idles out with no terminal open).
+  # Reuses Dockerfile.worker (bakes scripts/) with a command override; drains on
+  # a fixed interval, re-storing each entry under its own persisted group_id.
+  retry-queue-drain:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.worker
+    container_name: ${AI_MEMORY_CONTAINER_PREFIX:-ai-memory}-retry-queue-drain
+    labels:
+      <<: *ai-memory-labels
+      ai-memory.service: "retry-queue-drain"
+    <<: *python-service-defaults
+    command: ["python3", "scripts/memory/retry_drain_scheduler.py"]
+    environment:
+      # Service-specific overrides — all other config comes from env_file: (BP-152 §3.2/3.3)
+      - QDRANT_HOST=qdrant                            # container-internal hostname
+      - QDRANT_PORT=6333                              # container-internal port
+      - EMBEDDING_HOST=embedding                      # container-internal hostname
+      - EMBEDDING_PORT=8080                           # container-internal port
+      - PUSHGATEWAY_URL=pushgateway:9091              # container-internal URL
+      - LANGFUSE_BASE_URL=http://langfuse-web:3000    # container-internal URL
+      # BUG-150: LANGFUSE_TRACING_ENABLED mirrors LANGFUSE_ENABLED — Docker-only alias.
+      - LANGFUSE_TRACING_ENABLED=${LANGFUSE_ENABLED:-false}
+      - AI_MEMORY_INSTALL_DIR=/app                    # container path override
+      - AI_MEMORY_QUEUE_DIR=/app/queue                # container path override
+      - RETRY_DRAIN_INTERVAL_SECONDS=${RETRY_DRAIN_INTERVAL_SECONDS:-900}  # BP-181: ~15-min cadence
+      - PUSHGATEWAY_ENABLED=${MONITORING_ENABLED:-false}
+    volumes:
+      - ../src:/app/src:ro
+      - ../scripts:/app/scripts:ro
+      # Writable: the drain dequeues recovered entries and appends to the DLQ.
+      - ${AI_MEMORY_QUEUE_DIR:-~/.ai-memory/queue}:/app/queue
+      # Shared trace buffer for store span emission (matches classifier-worker)
+      - ${AI_MEMORY_INSTALL_DIR:-~/.ai-memory}/trace_buffer:/app/trace_buffer
+    depends_on:
+      qdrant:
+        condition: service_healthy
+      embedding:
+        condition: service_healthy
+    # Run as host user for queue file access (bind mount permissions)
+    user: "${UID:-1000}:${GID:-1000}"
+    stop_grace_period: 30s
+    restart: unless-stopped  # Dependable heartbeat across reboots/crashes (BP-181). Matches anchor; explicit for the DONE-WHEN gate.
+    # Security hardening (2026 best practices) — matches classifier-worker
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=50m
+    networks:
+      - default
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: '1.0'
+        reservations:
+          memory: 256M
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    healthcheck:
+      # File-based heartbeat — daemon touches the health file on startup and after
+      # each successful drain cycle. Check: exists AND modified within last 3600s
+      # (accommodates the 900s interval plus buffer, without a false failure).
+      test: ["CMD-SHELL", "python3 -c \"import os,sys,time; f='/tmp/retry-queue-drain.health'; sys.exit(0 if os.path.exists(f) and time.time()-os.path.getmtime(f)<3600 else 1)\""]
+      interval: 60s
+      timeout: 5s
+      retries: 3
+      start_period: 60s  # Python startup + first health-file write (typically <5s)
+
   github-sync:
     build:
       context: ..

--- a/scripts/memory/backfill_retry_queue_snapshot.py
+++ b/scripts/memory/backfill_retry_queue_snapshot.py
@@ -183,17 +183,14 @@ def backfill(snapshot_dir: Path, dry_run: bool, limit: int | None) -> dict:
 
 
 def main() -> int:
-    default_snapshot = (
-        "/mnt/e/projects/dev-ai-memory/oversight/tasks/pm386-lane-c/"
-        "queue-snapshot-2026-07-09"
-    )
     parser = argparse.ArgumentParser(
         description="Backfill preserved retry-queue snapshot entries (BUG-521/522)."
     )
     parser.add_argument(
         "--snapshot-dir",
-        default=default_snapshot,
-        help=f"Directory holding the snapshot .jsonl files (default: {default_snapshot})",
+        required=True,
+        help="Directory holding the snapshot .jsonl files (no default — no "
+        "hardcoded machine-specific path)",
     )
     parser.add_argument(
         "--execute",
@@ -213,6 +210,15 @@ def main() -> int:
 
     dry_run = not args.execute
     snapshot_dir = Path(args.snapshot_dir)
+
+    if args.execute:
+        confirm = input(
+            "W-02: this WRITES to Qdrant. Are you sure you want to execute "
+            "the backfill? (yes/no): "
+        )
+        if confirm.lower() != "yes":
+            print("Aborted")
+            return 1
 
     mode = (
         "DRY RUN (no Qdrant writes)"

--- a/scripts/memory/backfill_retry_queue_snapshot.py
+++ b/scripts/memory/backfill_retry_queue_snapshot.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Backfill preserved retry-queue snapshot entries under their persisted scope.
+
+One-off migration for the PM #386 snapshot (BUG-521 / BUG-522). Re-stores each
+recoverable entry from the preserved ``pending_queue.jsonl`` / ``retry_queue_dlq.jsonl``
+through the SAME fixed drain path (``process_retry_queue.process_entry``) so the
+result is identical to what the fixed daemon would produce.
+
+Scope resolution (BP-180):
+- Entries that already carry a persisted ``group_id`` are re-stored under it,
+  untouched.
+- Legacy ``hook_input`` entries (captured before the persist fix) carry only a
+  ``cwd``. This backfill re-derives their ``group_id`` from that persisted cwd
+  ONCE, OFFLINE, and stamps it onto the entry before draining. This deliberate,
+  reviewable, one-time re-derivation is the BP-180 legacy carve-out — it is NOT
+  the drain-time cwd re-resolution BUG-522 forbids (the daemon never does this).
+- Entries with neither a persisted group_id nor a resolvable cwd, and non-memory
+  records (e.g. raw command/output dicts in the DLQ), are reported as skipped —
+  never stored under a catch-all.
+
+SAFETY (W-02): the default is ``--dry-run`` (no Qdrant writes). Storing for real
+requires the explicit ``--execute`` flag, which is a Will-gated database write and
+MUST NOT be run without his go-ahead. Dry-run prints exactly what would be stored,
+per group, with zero Qdrant calls.
+
+Usage:
+    # Dry run (default, safe): show what WOULD be re-stored, per group
+    python scripts/memory/backfill_retry_queue_snapshot.py --snapshot-dir <dir>
+
+    # Execute (W-02 — requires Will's go-ahead; do NOT run otherwise)
+    python scripts/memory/backfill_retry_queue_snapshot.py --snapshot-dir <dir> --execute
+
+Reference: BP-180, BUG-521, BUG-522, PM #386.
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import Counter
+from pathlib import Path
+
+# Setup Python path (mirrors process_retry_queue.py)
+INSTALL_DIR = os.environ.get(
+    "AI_MEMORY_INSTALL_DIR", os.path.expanduser("~/.ai-memory")
+)
+sys.path.insert(0, os.path.join(INSTALL_DIR, "src"))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from process_retry_queue import process_entry  # noqa: E402
+
+_SNAPSHOT_FILES = ("pending_queue.jsonl", "retry_queue_dlq.jsonl")
+
+
+def _stamp_legacy_scope(entry: dict) -> tuple[dict, str | None]:
+    """Ensure *entry*'s memory_data carries a persisted group_id + source_hook.
+
+    Returns (entry, reason_skipped). reason_skipped is None when the entry is
+    ready to drain; otherwise a short human-readable reason.
+
+    For legacy ``hook_input`` entries that lack a persisted group_id, resolves it
+    ONCE offline from the persisted cwd (BP-180 legacy carve-out). Entries that
+    are not a recognised memory record, or whose scope cannot be resolved, are
+    left for the caller to report as skipped.
+    """
+    memory_data = entry.get("memory_data", {})
+    if not isinstance(memory_data, dict):
+        return entry, "non-memory record (memory_data is not a dict)"
+
+    # Legacy hook_input: re-derive group_id from the persisted cwd, offline.
+    if "hook_input" in memory_data and not memory_data.get("group_id"):
+        from memory.project import resolve_project_id
+
+        hook_input = memory_data["hook_input"]
+        cwd = hook_input.get("cwd")
+        if not cwd:
+            return entry, "hook_input entry has no cwd to resolve scope from"
+        try:
+            group_id = resolve_project_id(cwd)
+        except ValueError as exc:
+            return entry, f"cwd '{cwd}' not resolvable offline ({exc})"
+        # Stamp resolved scope + provenance so the fixed drain path reads them.
+        memory_data["group_id"] = group_id
+        memory_data.setdefault(
+            "source_hook", hook_input.get("hook_event_name") or "PostToolUse"
+        )
+        memory_data.setdefault("session_id", hook_input.get("session_id", "manual"))
+        return entry, None
+
+    # Direct/content or hook_input entry that already carries a persisted
+    # group_id but is missing a valid source_hook (the BUG-521 legacy defect).
+    # BP-180 legacy carve-out: backfill a VALID 'manual' source_hook (never the
+    # invalid 'retry') — and only for entries whose group_id is present.
+    if memory_data.get("group_id"):
+        if not memory_data.get("source_hook"):
+            memory_data["source_hook"] = "manual"
+        return entry, None
+
+    # Payload-wrapper with a persisted group_id in its metadata.
+    if "payload" in memory_data:
+        meta = memory_data["payload"].get("metadata", {})
+        if meta.get("group_id"):
+            if not meta.get("source_hook"):
+                meta["source_hook"] = "manual"
+            return entry, None
+        return entry, "payload entry has no persisted group_id in metadata"
+
+    return entry, "not a recognised memory record (no group_id / hook_input / payload)"
+
+
+def backfill(snapshot_dir: Path, dry_run: bool, limit: int | None) -> dict:
+    """Backfill snapshot entries. Returns a stats dict."""
+    # storage is only constructed for a real execute; dry-run makes no Qdrant calls.
+    storage = None
+    if not dry_run:
+        from memory.storage import MemoryStorage
+
+        storage = MemoryStorage()
+
+    stats = {
+        "read": 0,
+        "stored": 0,
+        "duplicate": 0,
+        "filtered": 0,
+        "skipped": 0,
+        "failed": 0,
+        "by_group": Counter(),
+        "skip_reasons": Counter(),
+    }
+
+    processed = 0
+    for filename in _SNAPSHOT_FILES:
+        path = snapshot_dir / filename
+        if not path.exists():
+            print(f"  (snapshot file not found, skipping: {path})")
+            continue
+
+        with open(path, encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                if limit is not None and processed >= limit:
+                    break
+                stats["read"] += 1
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    stats["skipped"] += 1
+                    stats["skip_reasons"]["corrupt JSON line"] += 1
+                    continue
+
+                entry, skip_reason = _stamp_legacy_scope(entry)
+                if skip_reason is not None:
+                    stats["skipped"] += 1
+                    stats["skip_reasons"][skip_reason] += 1
+                    continue
+
+                processed += 1
+                group_id = entry["memory_data"].get("group_id") or (
+                    entry["memory_data"]
+                    .get("payload", {})
+                    .get("metadata", {})
+                    .get("group_id")
+                )
+                success, message = process_entry(entry, storage, dry_run=dry_run)
+                if success:
+                    lowered = message.lower()
+                    if lowered.startswith("filtered") or "skipping" in lowered:
+                        stats["filtered"] += 1
+                    elif "duplicate" in lowered:
+                        stats["duplicate"] += 1
+                    else:
+                        stats["stored"] += 1
+                        stats["by_group"][group_id] += 1
+                    print(f"  [{group_id}] {message}")
+                else:
+                    stats["failed"] += 1
+                    stats["skip_reasons"][message] += 1
+                    print(f"  [SKIP {group_id}] {message}")
+
+    return stats
+
+
+def main() -> int:
+    default_snapshot = (
+        "/mnt/e/projects/dev-ai-memory/oversight/tasks/pm386-lane-c/"
+        "queue-snapshot-2026-07-09"
+    )
+    parser = argparse.ArgumentParser(
+        description="Backfill preserved retry-queue snapshot entries (BUG-521/522)."
+    )
+    parser.add_argument(
+        "--snapshot-dir",
+        default=default_snapshot,
+        help=f"Directory holding the snapshot .jsonl files (default: {default_snapshot})",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help=(
+            "Actually store to Qdrant. W-02: a Will-gated database write — do NOT "
+            "run without his explicit go-ahead. Omit for a safe dry run (default)."
+        ),
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Max recoverable entries to process (default: all)",
+    )
+    args = parser.parse_args()
+
+    dry_run = not args.execute
+    snapshot_dir = Path(args.snapshot_dir)
+
+    mode = (
+        "DRY RUN (no Qdrant writes)"
+        if dry_run
+        else "EXECUTE (W-02 — writing to Qdrant)"
+    )
+    print(f"Retry-queue snapshot backfill — {mode}")
+    print(f"Snapshot dir: {snapshot_dir}\n")
+
+    if not snapshot_dir.exists():
+        print(f"ERROR: snapshot dir does not exist: {snapshot_dir}")
+        return 1
+
+    stats = backfill(snapshot_dir, dry_run=dry_run, limit=args.limit)
+
+    print("\nSummary:")
+    print(f"  Entries read:        {stats['read']}")
+    verb = "Would store" if dry_run else "Stored"
+    print(f"  {verb}:         {stats['stored']}")
+    print(f"  Duplicate (skip):    {stats['duplicate']}")
+    print(f"  Filtered (live-path parity): {stats['filtered']}")
+    print(f"  Skipped (unrecoverable):     {stats['skipped']}")
+    print(f"  Failed:              {stats['failed']}")
+
+    if stats["by_group"]:
+        print(f"\n  {verb} by group:")
+        for group, count in sorted(stats["by_group"].items()):
+            print(f"    {group}: {count}")
+
+    if stats["skip_reasons"]:
+        print("\n  Skip/failure reasons:")
+        for reason, count in stats["skip_reasons"].most_common():
+            print(f"    {count}x {reason}")
+
+    if dry_run:
+        print(
+            "\nDry run complete — nothing was written. To execute (W-02, "
+            "Will-gated), re-run with --execute."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/memory/process_retry_queue.py
+++ b/scripts/memory/process_retry_queue.py
@@ -29,9 +29,11 @@ Usage:
 """
 
 import argparse
+import fcntl
 import json
 import os
 import sys
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -56,9 +58,52 @@ logger = setup_hook_logging("ai_memory.retry_processor")
 # Dead letter queue for items that exceed max retries or are permanently unparseable
 DLQ_FILE = Path(INSTALL_DIR) / "queue" / "retry_queue_dlq.jsonl"
 
+# Shared non-blocking drain lock. The in-stack daemon and an on-session-start
+# opportunistic drain both acquire THIS lock before draining, so at most one
+# drain runs at a time (they never double-process the queue concurrently).
+DRAIN_LOCK_FILE = Path(INSTALL_DIR) / "queue" / "retry_drain.lock"
+
+
+@contextmanager
+def drain_lock():
+    """Yield True if the exclusive drain lock was acquired, else False.
+
+    Non-blocking (LOCK_NB): if another drain already holds it, yields False so
+    the caller skips this pass instead of piling up. Best-effort — if the lock
+    file cannot be created, yields True (degrade to unlocked rather than block).
+    """
+    lock_file = None
+    try:
+        DRAIN_LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+        # The handle is held across the yield (closed in finally below), so a
+        # `with` block cannot span the context-manager's lifetime (SIM115).
+        lock_file = open(DRAIN_LOCK_FILE, "w")  # noqa: SIM115
+    except OSError:
+        yield True  # Degrade to unlocked rather than block the drain.
+        return
+    try:
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            yield False
+            return
+        try:
+            yield True
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+    finally:
+        lock_file.close()
+
+
 # Substrings in a process_entry failure message that mark an entry as permanently
 # unparseable — no amount of retrying will fix these.  Dead-letter on first encounter.
-_PERMANENT_FAILURE_MARKERS: frozenset = frozenset({"Unknown payload format"})
+#   "Unknown payload format"    — memory_data carries no recognised key.
+#   "entry not self-contained"  — BP-180 / BUG-522: the entry lacks a persisted
+#                                 group_id/source_hook, so no retry can ever
+#                                 re-store it (drain must not re-derive scope).
+_PERMANENT_FAILURE_MARKERS: frozenset = frozenset(
+    {"Unknown payload format", "entry not self-contained"}
+)
 
 
 def _is_permanent_failure(message: str) -> bool:
@@ -141,13 +186,22 @@ def process_entry(
         if not content or len(content) < 20:
             return False, "Content too short or empty"
 
-        # Build memory params (BUG-314: via the one shared resolver)
-        from memory.project import resolve_project_id
-
-        cwd = hook_input.get("cwd", "/")
-        group_id = resolve_project_id(cwd)
-        session_id = hook_input.get("session_id", "retry")
-        source_hook = "PostToolUse"
+        # BP-180 / BUG-522: scope + provenance are read ONLY from the entry's
+        # persisted fields (stamped at enqueue in the producer's live context).
+        # NEVER re-resolve group_id from the stored cwd at drain time — the
+        # contextless drainer cannot resolve a producer's workspace, which is
+        # exactly what made Fix B recover ≈0 (BUG-522). A legacy entry that
+        # predates the persist fix has no group_id → poison → DLQ.
+        group_id = memory_data.get("group_id")
+        if not group_id or not str(group_id).strip():
+            return False, (
+                "entry not self-contained: hook_input entry has no persisted "
+                "group_id (legacy pre-BP-180 entry)"
+            )
+        session_id = memory_data.get("session_id") or hook_input.get(
+            "session_id", "retry"
+        )
+        source_hook = memory_data.get("source_hook") or "PostToolUse"
         file_path = tool_input.get("file_path", "")
 
         # Mirror live capture path: apply ImplementationFilter before extraction
@@ -176,21 +230,35 @@ def process_entry(
         content = payload.get("content", "")
         metadata = payload.get("metadata", {})
         memory_type = metadata.get("type", "implementation")
-        group_id = metadata.get("group_id", "unknown")
+        # BP-180 / BUG-521: no catch-all defaults — an entry that omits its
+        # persisted scope/provenance is poison (would mis-file or fail storage
+        # validation), so route it to the DLQ instead of guessing.
+        group_id = metadata.get("group_id")
         session_id = metadata.get("session_id", "retry")
-        source_hook = metadata.get("source_hook", "retry")
+        source_hook = metadata.get("source_hook")
         file_path = metadata.get("file_path", "")
         collection = get_collection_for_type(memory_type)
+        if not group_id or not str(group_id).strip() or not source_hook:
+            return False, (
+                "entry not self-contained: payload entry missing persisted "
+                "group_id/source_hook"
+            )
 
     elif "content" in memory_data:
         # Direct format
         content = memory_data.get("content", "")
         memory_type = memory_data.get("type", "implementation")
-        group_id = memory_data.get("group_id", "unknown")
+        # BP-180 / BUG-521: no catch-all defaults — see payload branch above.
+        group_id = memory_data.get("group_id")
         session_id = memory_data.get("session_id", "retry")
-        source_hook = memory_data.get("source_hook", "retry")
+        source_hook = memory_data.get("source_hook")
         file_path = memory_data.get("file_path", "")
         collection = get_collection_for_type(memory_type)
+        if not group_id or not str(group_id).strip() or not source_hook:
+            return False, (
+                "entry not self-contained: direct entry missing persisted "
+                "group_id/source_hook"
+            )
 
     else:
         return False, f"Unknown payload format: {list(memory_data.keys())}"
@@ -236,20 +304,21 @@ def extract_group_id(entry: dict) -> str | None:
     """Return the group_id an entry would be stored under.
 
     Mirrors the per-format group_id resolution in process_entry so a scoped
-    drain (--group-id) can match an entry without storing it. Returns None when
-    the group cannot be determined (unknown payload format).
+    drain (--group-id) can match an entry without storing it.
+
+    BP-180 / BUG-522: the group is read ONLY from the entry's persisted
+    ``group_id`` — never re-resolved from a stored cwd at drain time. Returns
+    None when no persisted group_id is present (unknown/legacy entry), so a
+    scoped drain skips it and a global drain routes it to the DLQ.
     """
     memory_data = entry.get("memory_data", {})
 
     if "hook_input" in memory_data:
-        from memory.project import resolve_project_id
-
-        cwd = memory_data["hook_input"].get("cwd", "/")
-        return resolve_project_id(cwd)
+        return memory_data.get("group_id")
     elif "payload" in memory_data:
-        return memory_data["payload"].get("metadata", {}).get("group_id", "unknown")
+        return memory_data["payload"].get("metadata", {}).get("group_id")
     elif "content" in memory_data:
-        return memory_data.get("group_id", "unknown")
+        return memory_data.get("group_id")
     return None
 
 
@@ -457,12 +526,18 @@ def main():
             print("Aborted")
             return 1
 
-    stats = process_queue(
-        force=args.force,
-        dry_run=args.dry_run,
-        limit=args.limit,
-        group_id=args.group_id,
-    )
+    # Hold the shared drain lock so a CLI/session-start drain and the in-stack
+    # daemon never drain concurrently. A dry run inspects only — no lock needed.
+    with drain_lock() as acquired:
+        if not acquired and not args.dry_run:
+            print("Another drain is already running — skipping.")
+            return 0
+        stats = process_queue(
+            force=args.force,
+            dry_run=args.dry_run,
+            limit=args.limit,
+            group_id=args.group_id,
+        )
 
     print("\nProcessing Complete:")
     print(f"  Processed: {stats['processed']}")

--- a/scripts/memory/retry_drain_scheduler.py
+++ b/scripts/memory/retry_drain_scheduler.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Retry-queue drain scheduler daemon.
+
+Runs ``process_retry_queue.process_queue()`` on a fixed interval from inside the
+Docker Compose stack, replacing the WSL2 host cron that recovered ≈0 entries
+(BUG-522). A container-side loop is the only dependable + portable scheduler on
+WSL2: the Docker utility VM stays up when the user's distro idles out, which is
+the exact case an in-distro cron/systemd-timer fails (BP-181).
+
+Architecture (mirrors the evaluator-scheduler daemon, DEC-110):
+- Synchronous daemon with a fixed-interval loop (BP-181 — no cron cadence needed)
+- Health-file heartbeat at /tmp/retry-queue-drain.health for the Docker healthcheck
+- Graceful shutdown via SIGTERM handler + interruptible sleep
+- Never crashes on a drain failure — logs and continues to the next cycle
+
+Usage:
+    python scripts/memory/retry_drain_scheduler.py
+
+Environment:
+    RETRY_DRAIN_INTERVAL_SECONDS   Seconds between drains (default: 900 = 15 min)
+    RETRY_DRAIN_LIMIT              Max entries per drain cycle (default: 100)
+    AI_MEMORY_LOG_LEVEL           Log level (default: INFO)
+
+Reference:
+- BP-181 (WSL2 periodic execution), BP-180 (durable retry queue), BUG-522
+- DEC-110 (standalone scheduler container pattern)
+"""
+
+import logging
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+# Setup Python path for imports (mirrors evaluator_scheduler.py)
+INSTALL_DIR = os.environ.get(
+    "AI_MEMORY_INSTALL_DIR", os.path.expanduser("~/.ai-memory")
+)
+sys.path.insert(0, os.path.join(INSTALL_DIR, "src"))
+
+# process_retry_queue.py lives alongside this module; import its drain entry point.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from process_retry_queue import drain_lock, process_queue  # noqa: E402
+
+HEALTH_FILE = Path("/tmp/retry-queue-drain.health")
+
+# Defaults chosen per BP-181: a ~15-minute cadence is a good balance between
+# recovery latency and load for a durable queue.
+DEFAULT_INTERVAL_SECONDS = 900
+DEFAULT_LIMIT = 100
+
+logging.basicConfig(
+    level=os.environ.get("AI_MEMORY_LOG_LEVEL", "INFO"),
+    format="%(asctime)s %(name)s %(levelname)s %(message)s",
+)
+logger = logging.getLogger("ai_memory.retry_drain.scheduler")
+
+# Graceful shutdown flag (set by SIGTERM handler)
+_shutdown_requested = False
+
+
+def _handle_sigterm(signum, frame) -> None:
+    """SIGTERM handler — request graceful shutdown."""
+    global _shutdown_requested
+    logger.info("sigterm_received — requesting graceful shutdown")
+    _shutdown_requested = True
+
+
+def _touch_health_file() -> None:
+    """Write the health-check marker for the Docker healthcheck (best-effort)."""
+    try:
+        HEALTH_FILE.touch()
+        logger.debug("health_file_updated: %s", HEALTH_FILE)
+    except Exception as exc:
+        logger.warning("health_file_update_failed: %s", exc)
+
+
+def _interruptible_sleep(seconds: float, chunk: float = 5.0) -> None:
+    """Sleep for *seconds*, waking every *chunk* seconds to check the shutdown flag."""
+    remaining = seconds
+    while remaining > 0 and not _shutdown_requested:
+        sleep_for = min(remaining, chunk)
+        time.sleep(sleep_for)
+        remaining -= sleep_for
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    """Read a positive int from the environment, falling back to *default*."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("invalid_%s=%r — using default %d", name.lower(), raw, default)
+        return default
+    if value <= 0:
+        logger.warning(
+            "non_positive_%s=%d — using default %d", name.lower(), value, default
+        )
+        return default
+    return value
+
+
+def run_scheduler() -> None:
+    """Main drain loop: drain, heartbeat, sleep — until shutdown is requested."""
+    interval = _positive_int_env(
+        "RETRY_DRAIN_INTERVAL_SECONDS", DEFAULT_INTERVAL_SECONDS
+    )
+    limit = _positive_int_env("RETRY_DRAIN_LIMIT", DEFAULT_LIMIT)
+
+    logger.info(
+        "retry_drain_scheduler_starting interval_seconds=%d limit=%d", interval, limit
+    )
+
+    # Touch health file on startup so the Docker healthcheck passes immediately
+    # (do not wait until the first drain completes — BUG-045 pattern).
+    _touch_health_file()
+
+    while not _shutdown_requested:
+        try:
+            # Global drain across all groups (each entry stores under its own
+            # persisted group_id — BP-180). Never crash the daemon on failure.
+            # Hold the shared drain lock so this cycle and an on-session-start
+            # opportunistic drain never run concurrently.
+            with drain_lock() as acquired:
+                if not acquired:
+                    logger.info("drain_skipped — another drain holds the lock")
+                    _touch_health_file()
+                    _interruptible_sleep(interval)
+                    continue
+                stats = process_queue(limit=limit)
+            logger.info(
+                "drain_cycle_complete processed=%d success=%d failed=%d moved_to_dlq=%d",
+                stats.get("processed", 0),
+                stats.get("success", 0),
+                stats.get("failed", 0),
+                stats.get("moved_to_dlq", 0),
+            )
+            _touch_health_file()
+        except Exception as exc:
+            logger.error(
+                "drain_cycle_failed: %s — continuing to next cycle", exc, exc_info=True
+            )
+            # Do NOT update the health file on failure.
+
+        _interruptible_sleep(interval)
+
+
+def main() -> None:
+    """Entry point."""
+    signal.signal(signal.SIGTERM, _handle_sigterm)
+    try:
+        run_scheduler()
+    except KeyboardInterrupt:
+        logger.info("keyboard_interrupt_received")
+    finally:
+        logger.info("retry_drain_scheduler_stopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/memory/queue.py
+++ b/src/memory/queue.py
@@ -647,7 +647,12 @@ def _extract_replay_fields(data: dict) -> tuple[str | None, dict]:
             "explicit_gid": data.get("group_id"),
             "cwd": hi.get("cwd"),
             "type": data.get("type") or data.get("memory_type"),
-            "source_hook": data.get("source_hook") or hi.get("hook_event_name"),
+            # store_async is the only hook_input producer and only ever emits
+            # PostToolUse; when both keys are absent, default to it (matches
+            # the old drain's unconditional PostToolUse — Fix M1).
+            "source_hook": data.get("source_hook")
+            or hi.get("hook_event_name")
+            or "PostToolUse",
             "session_id": data.get("session_id") or hi.get("session_id"),
         }
     if "payload" in data:

--- a/src/memory/queue.py
+++ b/src/memory/queue.py
@@ -629,13 +629,130 @@ class LockedReadModifyWrite:
             self.lock_file.close()
 
 
+def _extract_replay_fields(data: dict) -> tuple[str | None, dict]:
+    """Locate the replay fields across the known failed-store producer formats.
+
+    Producers are inconsistent (BUG-521/522 root surface): the type key is
+    ``type`` OR ``memory_type``, scope/provenance may sit at the top level or
+    nested under ``metadata``/``hook_input``. This normalises the read so the
+    guard resolves from a single place.
+
+    Returns ``(content, fields)`` where ``content`` is None for the hook_input
+    format (content is derived at drain time) and ``fields`` carries
+    ``explicit_gid``, ``cwd``, ``type``, ``source_hook``, ``session_id``.
+    """
+    if "hook_input" in data:
+        hi = data.get("hook_input", {})
+        return None, {
+            "explicit_gid": data.get("group_id"),
+            "cwd": hi.get("cwd"),
+            "type": data.get("type") or data.get("memory_type"),
+            "source_hook": data.get("source_hook") or hi.get("hook_event_name"),
+            "session_id": data.get("session_id") or hi.get("session_id"),
+        }
+    if "payload" in data:
+        payload = data.get("payload", {})
+        meta = payload.get("metadata", {})
+        return payload.get("content"), {
+            "explicit_gid": meta.get("group_id"),
+            "cwd": meta.get("cwd"),
+            "type": meta.get("type") or meta.get("memory_type"),
+            "source_hook": meta.get("source_hook"),
+            "session_id": meta.get("session_id"),
+        }
+    # Direct format (may also carry a nested metadata dict, e.g. post_work).
+    meta = data.get("metadata", {})
+    return data.get("content"), {
+        "explicit_gid": data.get("group_id") or meta.get("group_id"),
+        "cwd": data.get("cwd") or meta.get("cwd"),
+        "type": data.get("type")
+        or data.get("memory_type")
+        or meta.get("type")
+        or meta.get("memory_type"),
+        "source_hook": data.get("source_hook") or meta.get("source_hook"),
+        "session_id": data.get("session_id") or meta.get("session_id"),
+    }
+
+
+def _prepare_failed_store_entry(data: dict) -> dict:
+    """Resolve scope + provenance in the producer's LIVE context and stamp a
+    self-contained, replay-valid entry (BP-180 / BUG-521 / BUG-522).
+
+    This is the failed-store producer boundary: every entry ENTERING the retry
+    queue is made self-contained here, in the producer's live context, so the
+    drainer is a pure function of the persisted entry and never re-derives scope
+    from an ambient cwd at drain time.
+
+    - ``group_id`` is resolved ONCE via the canonical resolver (explicit → env →
+      marker → cwd/git → fail-loud). The ``"unknown"`` catch-all sentinel is
+      treated as unset so it can be re-resolved from the live cwd.
+    - ``type``/``source_hook``/``session_id`` are read across the producer key
+      variants and stamped at the top level where the drainer reads them.
+    - The stamped entry must round-trip the SAME storage validation
+      (``validate_payload``) the drainer will apply; if it cannot, the entry is
+      NOT replay-valid and this raises ``ValueError`` (the caller rejects it,
+      loudly, at the boundary — never queuing a doomed entry).
+
+    Raises:
+        ValueError: If scope cannot be resolved or the entry is not replay-valid.
+    """
+    from .project import resolve_project_id
+    from .validation import validate_payload
+
+    content, f = _extract_replay_fields(data)
+
+    # Treat the forbidden 'unknown' catch-all as unset so scope is re-resolved
+    # from the producer's live context (Will PM #380 — no catch-all group_ids).
+    explicit = f["explicit_gid"]
+    if isinstance(explicit, str) and explicit.strip().lower() == "unknown":
+        explicit = None
+
+    # Resolve ONCE in the producer's live context; fail-loud if unresolvable.
+    group_id = resolve_project_id(f["cwd"], explicit=explicit, warn=False)
+
+    memory_type = f["type"] or "implementation"
+    source_hook = f["source_hook"]
+    session_id = f["session_id"]
+
+    # Replay-validity: round-trip the SAME validator the drainer/storage use.
+    # For hook_input the content is derived at drain, so validate scope/provenance
+    # with a length-valid placeholder (content fidelity is enforced at drain).
+    validation_payload = {
+        "content": content if content is not None else "x" * 10,
+        "group_id": group_id,
+        "type": memory_type,
+        "source_hook": source_hook,
+    }
+    errors = validate_payload(validation_payload)
+    if errors:
+        raise ValueError(f"entry is not replay-valid: {errors}")
+
+    # Stamp resolved scope + provenance at the top level (self-contained). The
+    # drainer reads group_id/source_hook/session_id/type from here and never
+    # re-resolves. Producer-specific extras (metadata, hook_input, turn_number)
+    # are preserved untouched.
+    prepared = dict(data)
+    prepared["group_id"] = group_id
+    prepared["type"] = memory_type
+    prepared["source_hook"] = source_hook
+    if session_id:
+        prepared["session_id"] = session_id
+    return prepared
+
+
 def queue_operation(
     data: dict, reason: str = "HOOK_STORAGE_FAILED", immediate: bool = False
 ) -> bool:
-    """Queue a memory operation for later retry.
+    """Queue a failed memory operation for later retry.
 
-    Simple wrapper for hooks that need to queue failed operations.
-    Provides graceful degradation by never raising exceptions.
+    The failed-store producer boundary (BP-180): resolves scope + provenance in
+    the producer's live context and persists a self-contained, replay-valid
+    entry before it enters the queue, so the contextless drainer never
+    re-derives scope from an ambient cwd (BUG-522) and never replays an entry
+    with missing/invalid provenance (BUG-521). An entry that cannot be made
+    replay-valid is rejected here, loudly, rather than queued to fail forever.
+
+    Provides graceful degradation: never raises — returns False on any error.
 
     Enhanced in CR-1.3 to consolidate queue_to_file() from hook scripts.
 
@@ -646,11 +763,29 @@ def queue_operation(
         immediate: If True, queued item is immediately ready for retry (no backoff)
 
     Returns:
-        True if queued successfully, False on any error
+        True if queued successfully, False if rejected or on any error
     """
     try:
+        prepared = _prepare_failed_store_entry(data)
+    except ValueError as e:
+        # Not replay-valid (unresolvable scope / missing-invalid provenance).
+        # Fail loud at the boundary — do NOT queue an entry that can never store.
+        logger.error(
+            "queue_operation_rejected_not_replay_valid",
+            extra={"error": str(e), "reason": reason},
+        )
+        return False
+    except Exception as e:
+        # Graceful degradation: never crash a capture hook.
+        logger.error(
+            "queue_operation_prepare_failed",
+            extra={"error": str(e), "error_type": type(e).__name__},
+        )
+        return False
+
+    try:
         queue = MemoryQueue()
-        queue.enqueue(data, reason, immediate=immediate)
+        queue.enqueue(prepared, reason, immediate=immediate)
         return True
     except Exception as e:
         # Graceful degradation: log error but never crash

--- a/tests/hooks/test_error_store_async.py
+++ b/tests/hooks/test_error_store_async.py
@@ -95,38 +95,38 @@ class TestBuildRecoverablePayload:
     memory-data key) and would rot unrecoverably; the rebuilt direct payload
     reconstructs what the main store path would have written and drains via
     process_retry_queue's format-1 handler.
+
+    BUG-523 fix: group_id is no longer resolved (or defaulted to "unknown")
+    here — the raw cwd is carried on the entry and resolved ONCE, canonically,
+    by the failed-store producer boundary (queue.py::_prepare_failed_store_entry).
     """
 
     def test_payload_is_faithful_to_main_store_path(self, error_context):
-        """content/type/group_id/session_id mirror the main (Qdrant-up) store path."""
-        with patch.object(esav, "resolve_project_id", return_value="myorg-myrepo"):
-            payload = esav._build_recoverable_payload(error_context)
+        """content/type/cwd/source_hook/session_id mirror the main store path."""
+        payload = esav._build_recoverable_payload(error_context)
 
         assert payload["content"] == esav.format_error_content(error_context)
         assert payload["type"] == "error_pattern"
-        assert payload["group_id"] == "myorg-myrepo"
+        assert payload["cwd"] == error_context["cwd"]
+        assert payload["source_hook"] == "PostToolUse"
         assert payload["session_id"] == error_context["session_id"]
 
     def test_payload_passes_queue_guard(self, error_context):
         """The rebuilt payload is accepted by the real queue guard (raw context isn't)."""
         from memory.queue import _is_memory_payload
 
-        with patch.object(esav, "resolve_project_id", return_value="myorg-myrepo"):
-            payload = esav._build_recoverable_payload(error_context)
+        payload = esav._build_recoverable_payload(error_context)
 
         assert _is_memory_payload(payload) is True
         # The raw error_context the hook used to enqueue would be rejected.
         assert _is_memory_payload(error_context) is False
 
-    def test_group_id_falls_back_when_resolution_fails(self, error_context):
-        """A ValueError from resolve_project_id degrades to the 'unknown' sentinel."""
-        with patch.object(
-            esav, "resolve_project_id", side_effect=ValueError("undetectable")
-        ):
-            payload = esav._build_recoverable_payload(error_context)
+    def test_never_fabricates_unknown_group_id(self, error_context):
+        """The payload never carries a group_id at all — never a fabricated
+        'unknown' catch-all (BUG-523; Will PM #380)."""
+        payload = esav._build_recoverable_payload(error_context)
 
-        assert payload["group_id"] == "unknown"
-        assert payload["content"] == esav.format_error_content(error_context)
+        assert "group_id" not in payload
 
 
 class TestErrorStoreAsync:

--- a/tests/test_backfill_retry_queue_snapshot.py
+++ b/tests/test_backfill_retry_queue_snapshot.py
@@ -146,6 +146,76 @@ class TestStampLegacyScope:
         assert reason is not None
 
 
+class TestMainCLI:
+    """Fix M-portability / M-safety: --snapshot-dir has no hardcoded default,
+    and --execute (a W-02-gated production Qdrant write) is gated behind an
+    interactive yes/no confirmation, matching process_retry_queue.py's
+    --clear pattern."""
+
+    def test_snapshot_dir_is_required(self, monkeypatch, capsys):
+        mod = _load_module(monkeypatch)
+        monkeypatch.setattr(sys, "argv", ["backfill_retry_queue_snapshot.py"])
+        with pytest.raises(SystemExit) as exc_info:
+            mod.main()
+        assert exc_info.value.code == 2
+        assert "--snapshot-dir" in capsys.readouterr().err
+
+    def test_execute_aborts_without_yes_confirmation(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        mod = _load_module(monkeypatch)
+        called = MagicMock()
+        monkeypatch.setattr(mod, "backfill", called)
+        monkeypatch.setattr("builtins.input", lambda _prompt: "no")
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "backfill_retry_queue_snapshot.py",
+                "--snapshot-dir",
+                str(tmp_path),
+                "--execute",
+            ],
+        )
+        result = mod.main()
+        assert result == 1
+        called.assert_not_called()
+        assert "Aborted" in capsys.readouterr().out
+
+    def test_execute_proceeds_with_yes_confirmation(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        mod = _load_module(monkeypatch)
+        called = MagicMock(
+            return_value={
+                "read": 0,
+                "stored": 0,
+                "duplicate": 0,
+                "filtered": 0,
+                "skipped": 0,
+                "failed": 0,
+                "by_group": {},
+                "skip_reasons": {},
+            }
+        )
+        monkeypatch.setattr(mod, "backfill", called)
+        monkeypatch.setattr("builtins.input", lambda _prompt: "yes")
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "backfill_retry_queue_snapshot.py",
+                "--snapshot-dir",
+                str(tmp_path),
+                "--execute",
+            ],
+        )
+        result = mod.main()
+        assert result == 0
+        called.assert_called_once()
+        assert called.call_args.kwargs["dry_run"] is False
+
+
 class TestBackfillDryRun:
     def _write_snapshot(self, tmp_path, pending, dlq):
         (tmp_path / "pending_queue.jsonl").write_text(

--- a/tests/test_backfill_retry_queue_snapshot.py
+++ b/tests/test_backfill_retry_queue_snapshot.py
@@ -1,0 +1,203 @@
+"""Hermetic tests for scripts/memory/backfill_retry_queue_snapshot.py (WI-4).
+
+Verifies the one-off snapshot backfill (BUG-521 / BUG-522):
+  - hook_input entries lacking a persisted group_id are re-scoped OFFLINE from
+    their persisted cwd (the BP-180 legacy carve-out — deliberate, not the
+    forbidden drain-time re-resolution).
+  - direct/payload entries with a persisted group_id but missing source_hook get
+    a VALID 'manual' source_hook (never 'retry').
+  - non-memory records and unresolvable entries are skipped, never stored under a
+    catch-all.
+  - dry-run makes ZERO Qdrant calls.
+
+Mocks the memory.* stack at the import boundary (same approach as
+test_process_retry_queue.py); never touches the live Qdrant.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import logging
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO / "scripts" / "memory" / "backfill_retry_queue_snapshot.py"
+
+
+def _inject_mocks(monkeypatch):
+    """Inject fake memory.* modules so the script imports without the real stack."""
+    mem_pkg = types.ModuleType("memory")
+
+    cfg_mod = types.ModuleType("memory.config")
+    cfg_mod.COLLECTION_CODE_PATTERNS = "code-patterns"
+    cfg_mod.COLLECTION_CONVENTIONS = "conventions"
+    cfg_mod.COLLECTION_DISCUSSIONS = "discussions"
+
+    hooks_mod = types.ModuleType("memory.hooks_common")
+    hooks_mod.setup_hook_logging = MagicMock(
+        return_value=logging.getLogger("test_backfill")
+    )
+
+    models_mod = types.ModuleType("memory.models")
+
+    class _MemoryType:
+        IMPLEMENTATION = "implementation"
+
+        def __new__(cls, value):
+            return value
+
+    models_mod.MemoryType = _MemoryType
+
+    queue_mod = types.ModuleType("memory.queue")
+    queue_mod.MemoryQueue = MagicMock()
+
+    storage_mod = types.ModuleType("memory.storage")
+    storage_mod.MemoryStorage = MagicMock()
+
+    project_mod = types.ModuleType("memory.project")
+    project_mod.resolve_project_id = MagicMock(return_value="resolved-from-cwd")
+
+    import importlib as _importlib
+
+    _real_extraction = _importlib.import_module("memory.extraction")
+    _real_filters = _importlib.import_module("memory.filters")
+
+    for name, mod in [
+        ("memory", mem_pkg),
+        ("memory.config", cfg_mod),
+        ("memory.hooks_common", hooks_mod),
+        ("memory.models", models_mod),
+        ("memory.queue", queue_mod),
+        ("memory.storage", storage_mod),
+        ("memory.project", project_mod),
+        ("memory.extraction", _real_extraction),
+        ("memory.filters", _real_filters),
+    ]:
+        monkeypatch.setitem(sys.modules, name, mod)
+
+
+def _load_module(monkeypatch):
+    _inject_mocks(monkeypatch)
+    monkeypatch.delitem(sys.modules, "process_retry_queue", raising=False)
+    monkeypatch.delitem(sys.modules, "backfill_retry_queue_snapshot", raising=False)
+    spec = importlib.util.spec_from_file_location(
+        "backfill_retry_queue_snapshot", _SCRIPT
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    monkeypatch.delenv("AI_MEMORY_PROJECT_ID", raising=False)
+
+
+class TestStampLegacyScope:
+    def test_hook_input_without_group_id_resolves_from_cwd(self, monkeypatch):
+        mod = _load_module(monkeypatch)
+        sys.modules["memory.project"].resolve_project_id.return_value = "proj-from-cwd"
+        entry = {"memory_data": {"hook_input": {"cwd": "/x/proj", "session_id": "s"}}}
+        out, reason = mod._stamp_legacy_scope(entry)
+        assert reason is None
+        assert out["memory_data"]["group_id"] == "proj-from-cwd"
+        assert out["memory_data"]["source_hook"]  # a valid hook stamped
+
+    def test_hook_input_unresolvable_cwd_is_skipped(self, monkeypatch):
+        mod = _load_module(monkeypatch)
+        sys.modules["memory.project"].resolve_project_id.side_effect = ValueError(
+            "project detection failed"
+        )
+        entry = {"memory_data": {"hook_input": {"cwd": "/nope"}}}
+        _out, reason = mod._stamp_legacy_scope(entry)
+        assert reason is not None
+        assert "not resolvable" in reason
+
+    def test_direct_with_group_id_gets_manual_source_hook(self, monkeypatch):
+        mod = _load_module(monkeypatch)
+        entry = {
+            "memory_data": {
+                "content": "x" * 40,
+                "group_id": "g",
+                "type": "implementation",
+            }
+        }
+        out, reason = mod._stamp_legacy_scope(entry)
+        assert reason is None
+        # BP-180: valid 'manual', never 'retry'
+        assert out["memory_data"]["source_hook"] == "manual"
+
+    def test_direct_without_group_id_is_skipped(self, monkeypatch):
+        mod = _load_module(monkeypatch)
+        entry = {"memory_data": {"content": "x" * 40, "type": "implementation"}}
+        _out, reason = mod._stamp_legacy_scope(entry)
+        assert reason is not None
+
+    def test_non_memory_record_is_skipped(self, monkeypatch):
+        mod = _load_module(monkeypatch)
+        entry = {"memory_data": {"command": "ls", "exit_code": 0, "output": "x"}}
+        _out, reason = mod._stamp_legacy_scope(entry)
+        assert reason is not None
+
+
+class TestBackfillDryRun:
+    def _write_snapshot(self, tmp_path, pending, dlq):
+        (tmp_path / "pending_queue.jsonl").write_text(
+            "\n".join(json.dumps(e) for e in pending) + "\n"
+        )
+        (tmp_path / "retry_queue_dlq.jsonl").write_text(
+            "\n".join(json.dumps(e) for e in dlq) + "\n"
+        )
+
+    def test_dry_run_tallies_and_makes_no_storage_calls(self, monkeypatch, tmp_path):
+        mod = _load_module(monkeypatch)
+        sys.modules["memory.project"].resolve_project_id.return_value = "resolved-proj"
+
+        pending = [
+            # hook_input, no persisted group_id → resolved offline from cwd
+            {
+                "id": "p1",
+                "memory_data": {
+                    "hook_input": {
+                        "tool_name": "Write",
+                        "tool_input": {
+                            "file_path": "a.py",
+                            "content": "def f():\n    return compute_value()\n",
+                        },
+                        "session_id": "s1",
+                        "cwd": "/repo/proj",
+                    }
+                },
+            },
+        ]
+        dlq = [
+            # direct with group_id, missing source_hook → recoverable ('manual')
+            {
+                "id": "d1",
+                "memory_data": {
+                    "content": "[error_pattern] boom happened during test run",
+                    "type": "error_pattern",
+                    "group_id": "myproj",
+                },
+            },
+            # non-memory raw command record → skipped
+            {"id": "d2", "memory_data": {"command": "ls", "exit_code": 0}},
+        ]
+        self._write_snapshot(tmp_path, pending, dlq)
+
+        stats = mod.backfill(tmp_path, dry_run=True, limit=None)
+
+        assert stats["read"] == 3
+        assert stats["stored"] == 2  # p1 (resolved) + d1 (manual source_hook)
+        assert stats["failed"] == 0
+        assert stats["skipped"] == 1  # d2 non-memory
+        # Storage must never be constructed/called in dry-run.
+        sys.modules["memory.storage"].MemoryStorage.assert_not_called()
+        assert stats["by_group"]["resolved-proj"] == 1
+        assert stats["by_group"]["myproj"] == 1

--- a/tests/test_process_retry_queue.py
+++ b/tests/test_process_retry_queue.py
@@ -33,7 +33,11 @@ _COL_DISC = "discussions"
 
 
 def _direct_entry(entry_id: str, group_id: str) -> dict:
-    """A queue entry in the direct (content) payload format."""
+    """A queue entry in the direct (content) payload format.
+
+    Self-contained per BP-180: carries a persisted group_id AND source_hook so
+    the fixed drain reads scope/provenance from the entry (never re-resolves).
+    """
     return {
         "id": entry_id,
         "retry_count": 0,
@@ -42,6 +46,7 @@ def _direct_entry(entry_id: str, group_id: str) -> dict:
             "content": "x" * 50,
             "type": "implementation",
             "group_id": group_id,
+            "source_hook": "manual",
         },
     }
 
@@ -191,12 +196,27 @@ class TestExtractGroupId:
         entry = {"memory_data": {"payload": {"metadata": {"group_id": "proj-b"}}}}
         assert mod.extract_group_id(entry) == "proj-b"
 
-    def test_hook_input_format_uses_resolver(self, monkeypatch):
+    def test_hook_input_format_reads_persisted_group_id(self, monkeypatch):
+        """BP-180/BUG-522: hook_input group is read from the persisted field,
+        NEVER re-resolved from the stored cwd at drain time."""
+        mod = _load_module(monkeypatch)
+        entry = {
+            "memory_data": {
+                "group_id": "persisted-x",
+                "hook_input": {"cwd": "/some/where"},
+            }
+        }
+        # A drain-time resolver call would be the BUG-522 regression — spy proves none.
+        sys.modules["memory.project"].resolve_project_id.reset_mock()
+        assert mod.extract_group_id(entry) == "persisted-x"
+        sys.modules["memory.project"].resolve_project_id.assert_not_called()
+
+    def test_hook_input_without_persisted_group_id_returns_none(self, monkeypatch):
+        """A legacy hook_input entry lacking a persisted group_id yields None
+        (poison → DLQ), instead of a drain-time cwd re-resolution."""
         mod = _load_module(monkeypatch)
         entry = {"memory_data": {"hook_input": {"cwd": "/some/where"}}}
-        # extract_group_id imports resolve_project_id from the injected module.
-        sys.modules["memory.project"].resolve_project_id.return_value = "resolved-x"
-        assert mod.extract_group_id(entry) == "resolved-x"
+        assert mod.extract_group_id(entry) is None
 
     def test_unknown_format_returns_none(self, monkeypatch):
         mod = _load_module(monkeypatch)
@@ -249,6 +269,7 @@ def _exhausted_entry(entry_id: str, group_id: str) -> dict:
             "content": "x" * 50,
             "type": "implementation",
             "group_id": group_id,
+            "source_hook": "manual",
         },
     }
 
@@ -335,6 +356,7 @@ class TestDeadLetterQueue:
                 "content": "x" * 50,
                 "type": "implementation",
                 "group_id": "g",
+                "source_hook": "manual",
             },
         }
         queue, storage = _wire_queue_storage(mod, [entry])
@@ -361,11 +383,13 @@ class TestL5RecoverableForms:
     """
 
     def test_store_async_hook_input_wrapper_drains_via_format2(self, monkeypatch):
-        """A {"hook_input": <PostToolUse event>} entry stores the extracted content."""
+        """A {"hook_input": <PostToolUse event>} entry stores the extracted content.
+
+        BP-180/BUG-522: group_id is read from the entry's persisted field, not
+        re-resolved from the stored cwd at drain time.
+        """
         mod = _load_module(monkeypatch)
-        sys.modules["memory.project"].resolve_project_id.return_value = (
-            "resolved-project"
-        )
+        sys.modules["memory.project"].resolve_project_id.reset_mock()
         storage = MagicMock()
         storage.store_memory.return_value = {"status": "stored", "memory_id": "m1"}
 
@@ -374,6 +398,7 @@ class TestL5RecoverableForms:
             "retry_count": 0,
             "max_retries": 3,
             "memory_data": {
+                "group_id": "persisted-project",
                 "hook_input": {
                     "tool_name": "Edit",
                     "tool_input": {
@@ -382,7 +407,7 @@ class TestL5RecoverableForms:
                     },
                     "session_id": "sess-1",
                     "cwd": "/repo",
-                }
+                },
             },
         }
 
@@ -397,9 +422,11 @@ class TestL5RecoverableForms:
             "content"
         ]
         assert kwargs["content"] == expected_content
-        assert kwargs["group_id"] == "resolved-project"
+        assert kwargs["group_id"] == "persisted-project"
         assert kwargs["memory_type"] == "implementation"
         assert kwargs["session_id"] == "sess-1"
+        # No drain-time cwd re-resolution (the BUG-522 regression).
+        sys.modules["memory.project"].resolve_project_id.assert_not_called()
 
     def test_error_store_direct_payload_drains_via_format1(self, monkeypatch):
         """A direct error-store payload stores its content/type/group_id/session_id."""
@@ -416,6 +443,7 @@ class TestL5RecoverableForms:
                 "type": "error_pattern",
                 "group_id": "myorg-myrepo",
                 "session_id": "sess-2",
+                "source_hook": "manual",
             },
         }
 
@@ -453,7 +481,6 @@ class TestFormatTwoTypeCoercion:
         """Write tool: stored content == extract_patterns enriched, type == implementation,
         collection derived from type (not hardcoded)."""
         mod = _load_module(monkeypatch)
-        sys.modules["memory.project"].resolve_project_id.return_value = "proj-td728"
         storage = MagicMock()
         storage.store_memory.return_value = {"status": "stored", "memory_id": "m-td728"}
 
@@ -467,12 +494,13 @@ class TestFormatTwoTypeCoercion:
             "retry_count": 0,
             "max_retries": 3,
             "memory_data": {
+                "group_id": "proj-td728",
                 "hook_input": {
                     "tool_name": "Write",
                     "tool_input": {"file_path": "api/users.py", "content": code},
                     "session_id": "sess-td728",
                     "cwd": "/myproject",
-                }
+                },
             },
         }
 
@@ -496,7 +524,6 @@ class TestFormatTwoTypeCoercion:
     def test_edit_tool_field_level_fidelity(self, monkeypatch):
         """Edit tool: enriched content + correct collection via get_collection_for_type."""
         mod = _load_module(monkeypatch)
-        sys.modules["memory.project"].resolve_project_id.return_value = "proj-edit"
         storage = MagicMock()
         storage.store_memory.return_value = {"status": "stored", "memory_id": "m-edit"}
 
@@ -509,6 +536,7 @@ class TestFormatTwoTypeCoercion:
             "retry_count": 0,
             "max_retries": 3,
             "memory_data": {
+                "group_id": "proj-edit",
                 "hook_input": {
                     "tool_name": "Edit",
                     "tool_input": {
@@ -517,7 +545,7 @@ class TestFormatTwoTypeCoercion:
                     },
                     "session_id": "sess-edit",
                     "cwd": "/myproject",
-                }
+                },
             },
         }
 
@@ -566,3 +594,131 @@ class TestFormatTwoTypeCoercion:
         ), f"decision type must land in {_COL_DISC!r}, got {call_kw['collection']!r}"
         assert call_kw["memory_type"] == "decision"
         assert call_kw["group_id"] == "proj-arch"
+
+
+class TestDrainLock:
+    """The shared drain lock makes the in-stack daemon and an on-session-start
+    drain mutually exclusive (never drain concurrently)."""
+
+    def test_second_acquire_is_nonblocking_false(self, monkeypatch, tmp_path):
+        mod = _load_module(monkeypatch)
+        monkeypatch.setattr(mod, "DRAIN_LOCK_FILE", tmp_path / "retry_drain.lock")
+
+        with mod.drain_lock() as first:
+            assert first is True
+            # A second acquisition while the first is held returns False (NB).
+            with mod.drain_lock() as second:
+                assert second is False
+
+        # Once released, the lock can be acquired again.
+        with mod.drain_lock() as third:
+            assert third is True
+
+
+class TestDrainScopeFidelity:
+    """BUG-522 regression: the drain scopes each entry by its PERSISTED group_id
+    and NEVER re-derives scope from a stored cwd at drain time.
+
+    The autouse _isolate_env fixture guarantees AI_MEMORY_PROJECT_ID is unset —
+    the exact contextless-cron environment where the old drain fail-louded.
+    """
+
+    def test_drains_under_persisted_group_id_without_cwd_redetect(self, monkeypatch):
+        """Persisted group_id wins; resolve_project_id is never called even though
+        the entry carries a stored cwd that does not resolve here."""
+        mod = _load_module(monkeypatch)
+
+        # Any drain-time resolve_project_id() call blows up — mirroring the
+        # contextless cron that could not resolve the producer's workspace (the
+        # very failure that made Fix B recover ≈0). If the drain calls it, the
+        # test fails loudly.
+        def _boom(*args, **kwargs):
+            raise ValueError(
+                "project detection failed — drain must not re-resolve at drain time"
+            )
+
+        sys.modules["memory.project"].resolve_project_id.side_effect = _boom
+
+        entry = {
+            "id": "scope-1",
+            "retry_count": 0,
+            "max_retries": 3,
+            "memory_data": {
+                "group_id": "proj-A",  # captured under proj-A
+                "hook_input": {
+                    "tool_name": "Write",
+                    "tool_input": {
+                        "file_path": "svc/app.py",
+                        "content": "def run():\n    return compute()\n",
+                    },
+                    "session_id": "s-scope",
+                    # cwd belongs to a different, unresolvable workspace — ignored.
+                    "cwd": "/mnt/e/projects/some-other-unresolvable-project",
+                },
+            },
+        }
+        queue, storage = _wire_queue_storage(mod, [entry])
+
+        stats = mod.process_queue()  # global drain, AI_MEMORY_PROJECT_ID unset
+
+        assert stats["success"] == 1, stats
+        kwargs = storage.store_memory.call_args.kwargs
+        assert kwargs["group_id"] == "proj-A"  # persisted, NOT cwd-derived
+        sys.modules["memory.project"].resolve_project_id.assert_not_called()
+        queue.dequeue.assert_called_once_with("scope-1")
+
+    def test_missing_source_hook_is_poison_never_stored_under_default(
+        self, monkeypatch, tmp_path
+    ):
+        """BUG-521: an entry without persisted source_hook is dead-lettered, never
+        stored with a synthesized 'retry' source_hook."""
+        mod = _load_module(monkeypatch)
+        dlq = tmp_path / "dlq.jsonl"
+        monkeypatch.setattr(mod, "DLQ_FILE", dlq)
+
+        entry = {
+            "id": "poison-hook",
+            "retry_count": 0,
+            "max_retries": 3,
+            "memory_data": {
+                "content": "x" * 50,
+                "type": "implementation",
+                "group_id": "g",
+                # no source_hook
+            },
+        }
+        queue, storage = _wire_queue_storage(mod, [entry])
+
+        stats = mod.process_queue()
+
+        assert stats["moved_to_dlq"] == 1
+        storage.store_memory.assert_not_called()
+        queue.dequeue.assert_called_once_with("poison-hook")
+        queue.mark_failed.assert_not_called()
+
+    def test_missing_group_id_never_stored_under_catch_all(self, monkeypatch, tmp_path):
+        """BUG-522/PM #380: an entry without persisted group_id is dead-lettered,
+        never stored under an 'unknown' catch-all group."""
+        mod = _load_module(monkeypatch)
+        dlq = tmp_path / "dlq.jsonl"
+        monkeypatch.setattr(mod, "DLQ_FILE", dlq)
+
+        entry = {
+            "id": "poison-grp",
+            "retry_count": 0,
+            "max_retries": 3,
+            "memory_data": {
+                "content": "x" * 50,
+                "type": "implementation",
+                "source_hook": "manual",
+                # no group_id
+            },
+        }
+        queue, storage = _wire_queue_storage(mod, [entry])
+
+        stats = mod.process_queue()
+
+        assert stats["moved_to_dlq"] == 1
+        storage.store_memory.assert_not_called()
+        queue.dequeue.assert_called_once_with("poison-grp")
+        queue.mark_failed.assert_not_called()

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -643,10 +643,99 @@ class TestEnqueueGuard:
         assert result is False
 
     def test_queue_operation_returns_true_for_valid_payload(self, tmp_path):
-        """queue_operation() returns True for a valid memory-data record."""
+        """queue_operation() returns True for a replay-valid memory-data record."""
         with patch("src.memory.queue.QUEUE_FILE", tmp_path / "q.jsonl"):
             result = queue_operation(
-                {"content": "store this", "group_id": "proj"},
+                {
+                    "content": "store this",
+                    "group_id": "proj",
+                    "type": "implementation",
+                    "source_hook": "manual",
+                },
                 "qdrant_unavailable",
             )
         assert result is True
+
+
+class TestQueueOperationReplayValidity:
+    """WI-1 / BP-180 / BUG-521 / BUG-522: the failed-store producer boundary
+    (queue_operation) resolves scope in the producer's live context and persists
+    a self-contained, replay-valid entry — or rejects a malformed op loudly,
+    never queuing an entry that can never store.
+    """
+
+    def test_malformed_op_rejected_at_boundary(self, tmp_path):
+        """An op missing a storable source_hook is rejected and never written."""
+        qfile = tmp_path / "q.jsonl"
+        with patch("src.memory.queue.QUEUE_FILE", qfile):
+            # group_id resolvable (explicit), but source_hook absent → not replay-valid.
+            result = queue_operation(
+                {"content": "x" * 50, "group_id": "proj-x", "type": "implementation"},
+                "qdrant_unavailable",
+            )
+        assert result is False
+        assert not qfile.exists() or qfile.read_text().strip() == ""
+
+    def test_valid_op_roundtrips_and_is_self_contained(self, tmp_path):
+        """A valid op is queued with persisted group_id + provenance stamped so the
+        drainer never re-resolves scope."""
+        qfile = tmp_path / "q.jsonl"
+        with patch("src.memory.queue.QUEUE_FILE", qfile):
+            result = queue_operation(
+                {
+                    "content": "x" * 50,
+                    "group_id": "proj-x",
+                    "type": "implementation",
+                    "source_hook": "PostToolUse",
+                    "session_id": "sess-9",
+                },
+                "qdrant_unavailable",
+            )
+        assert result is True
+        entry = json.loads(qfile.read_text().strip())
+        md = entry["memory_data"]
+        assert md["group_id"] == "proj-x"  # persisted, resolved in live context
+        assert md["source_hook"] == "PostToolUse"
+        assert md["session_id"] == "sess-9"
+        assert md["type"] == "implementation"
+
+    def test_unknown_catch_all_never_persisted(self, tmp_path, monkeypatch):
+        """An explicit 'unknown' catch-all is treated as unset; with an
+        unresolvable cwd + no env, the op is rejected rather than stored under
+        the forbidden 'unknown' group (Will PM #380)."""
+        monkeypatch.delenv("AI_MEMORY_PROJECT_ID", raising=False)
+        qfile = tmp_path / "q.jsonl"
+        with patch("src.memory.queue.QUEUE_FILE", qfile):
+            result = queue_operation(
+                {
+                    "content": "x" * 50,
+                    "group_id": "unknown",
+                    "type": "implementation",
+                    "source_hook": "PostToolUse",
+                    "cwd": "/nonexistent-unresolvable-xyz-123",
+                },
+                "qdrant_unavailable",
+            )
+        assert result is False
+        assert not qfile.exists() or qfile.read_text().strip() == ""
+
+    def test_memory_type_key_variant_normalized(self, tmp_path):
+        """A producer using 'memory_type' (not 'type') is normalized + stamped so
+        the entry is self-contained and correctly typed (no false rejection)."""
+        qfile = tmp_path / "q.jsonl"
+        with patch("src.memory.queue.QUEUE_FILE", qfile):
+            result = queue_operation(
+                {
+                    "content": "x" * 50,
+                    "group_id": "proj-x",
+                    "memory_type": "decision",
+                    "source_hook": "Stop",
+                    "session_id": "s1",
+                },
+                "qdrant_unavailable",
+            )
+        assert result is True
+        md = json.loads(qfile.read_text().strip())["memory_data"]
+        assert md["type"] == "decision"  # normalized from memory_type
+        assert md["group_id"] == "proj-x"
+        assert md["source_hook"] == "Stop"

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -739,3 +739,146 @@ class TestQueueOperationReplayValidity:
         assert md["type"] == "decision"  # normalized from memory_type
         assert md["group_id"] == "proj-x"
         assert md["source_hook"] == "Stop"
+
+    def test_hook_input_format_defaults_source_hook_to_posttooluse(self, tmp_path):
+        """M1: hook_input entries with neither source_hook nor hook_event_name
+        default to 'PostToolUse' — matches the OLD drain's unconditional
+        default; store_async is the only hook_input producer and only ever
+        emits PostToolUse, so this is safe."""
+        qfile = tmp_path / "q.jsonl"
+        with patch("src.memory.queue.QUEUE_FILE", qfile):
+            result = queue_operation(
+                {
+                    "group_id": "proj-x",
+                    "type": "implementation",
+                    "hook_input": {
+                        "cwd": "/some/path",
+                        "session_id": "s1",
+                        "tool_name": "Edit",
+                    },
+                },
+                "qdrant_unavailable",
+            )
+        assert result is True
+        md = json.loads(qfile.read_text().strip())["memory_data"]
+        assert md["source_hook"] == "PostToolUse"
+        assert md["group_id"] == "proj-x"
+
+    def test_hook_input_format_uses_hook_event_name_when_present(self, tmp_path):
+        """hook_event_name still wins over the PostToolUse default when present."""
+        qfile = tmp_path / "q.jsonl"
+        with patch("src.memory.queue.QUEUE_FILE", qfile):
+            result = queue_operation(
+                {
+                    "group_id": "proj-x",
+                    "type": "implementation",
+                    "hook_input": {
+                        "cwd": "/some/path",
+                        "session_id": "s1",
+                        "hook_event_name": "Stop",
+                    },
+                },
+                "qdrant_unavailable",
+            )
+        assert result is True
+        md = json.loads(qfile.read_text().strip())["memory_data"]
+        assert md["source_hook"] == "Stop"
+
+    def test_payload_wrapper_format_roundtrips(self, tmp_path):
+        """M2: the payload-wrapper format (in addition to direct + hook_input)
+        is exercised through the guard."""
+        qfile = tmp_path / "q.jsonl"
+        with patch("src.memory.queue.QUEUE_FILE", qfile):
+            result = queue_operation(
+                {
+                    "payload": {
+                        "content": "x" * 50,
+                        "metadata": {
+                            "group_id": "proj-x",
+                            "type": "implementation",
+                            "source_hook": "SDKWrapper",
+                            "session_id": "s1",
+                        },
+                    },
+                },
+                "qdrant_unavailable",
+            )
+        assert result is True
+        md = json.loads(qfile.read_text().strip())["memory_data"]
+        assert md["source_hook"] == "SDKWrapper"
+        assert md["group_id"] == "proj-x"
+
+    def test_payload_wrapper_format_missing_source_hook_rejected(self, tmp_path):
+        """The payload-wrapper format has no PostToolUse default (that default
+        is hook_input-specific, M1) — a missing source_hook is still rejected."""
+        qfile = tmp_path / "q.jsonl"
+        with patch("src.memory.queue.QUEUE_FILE", qfile):
+            result = queue_operation(
+                {
+                    "payload": {
+                        "content": "x" * 50,
+                        "metadata": {"group_id": "proj-x", "type": "implementation"},
+                    },
+                },
+                "qdrant_unavailable",
+            )
+        assert result is False
+        assert not qfile.exists() or qfile.read_text().strip() == ""
+
+
+class TestRealProducerPayloadsPassGuard:
+    """BUG-521 / BUG-523 fix: the two producers that were emitting
+    invalid/missing provenance now pass the replay-validity guard with a
+    valid source_hook + resolved group_id. Fixed AT THE PRODUCERS — no
+    catch-all default was added to the live guard.
+    """
+
+    def test_manual_save_queue_payload_passes_guard(self, tmp_path):
+        """Mirrors the queue_data dict built in manual_save_memory.py's
+        store_manual_summary() ResponseHandlingException/UnexpectedResponse/
+        ApiException/QdrantUnavailable except-block (BUG-521 fix:
+        source_hook is now 'manual', not the invalid 'ManualSave')."""
+        qfile = tmp_path / "q.jsonl"
+        queue_data = {
+            "content": "Manual Session Save: myorg-myrepo\n" + "x" * 20,
+            "group_id": "myorg-myrepo",
+            "memory_type": "session",
+            "source_hook": "manual",
+            "session_id": "sess-1",
+            "importance": "normal",
+        }
+        with patch("src.memory.queue.QUEUE_FILE", qfile):
+            result = queue_operation(queue_data)
+        assert result is True
+        md = json.loads(qfile.read_text().strip())["memory_data"]
+        assert md["source_hook"] == "manual"
+        assert md["group_id"] == "myorg-myrepo"
+
+    def test_error_store_recoverable_payload_passes_guard(self, tmp_path, monkeypatch):
+        """The REAL payload built by error_store_async.py's
+        _build_recoverable_payload() (BUG-523 fix: source_hook is now the
+        valid 'PostToolUse'; group_id is resolved by the guard from the
+        producer's live cwd — never the fabricated 'unknown' sentinel)."""
+        import sys
+        from pathlib import Path
+
+        sys.path.insert(0, str(Path(__file__).parent.parent / ".claude/hooks/scripts"))
+        import error_store_async as esav
+
+        monkeypatch.setenv("AI_MEMORY_PROJECT_ID", "myorg-myrepo")
+        error_context = {
+            "session_id": "sess-2",
+            "cwd": "/mnt/e/projects/dev-ai-memory/ai-memory",
+            "command": "pytest tests/",
+            "error_message": "boom",
+            "exit_code": 1,
+        }
+        payload = esav._build_recoverable_payload(error_context)
+
+        qfile = tmp_path / "q.jsonl"
+        with patch("src.memory.queue.QUEUE_FILE", qfile):
+            result = queue_operation(payload, "timeout")
+        assert result is True
+        md = json.loads(qfile.read_text().strip())["memory_data"]
+        assert md["source_hook"] == "PostToolUse"
+        assert md["group_id"] == "myorg-myrepo"


### PR DESCRIPTION
## What

Makes the failed-store retry path durable and correctly project-scoped.

- **Self-contained queue entries.** `group_id` and provenance are resolved once at the failed-store producer boundary, and a replay-validity guard rejects any entry that can't round-trip storage validation — a malformed entry can no longer enter the queue.
- **Persisted-scope drain.** The drainer resolves scope from each entry's own persisted `group_id` instead of re-detecting the project from the runtime working directory, so entries drain correctly regardless of where the drainer runs.
- **In-stack drain daemon.** Replaces the retry-drain host cron with a long-lived container service (mirrors the evaluator-scheduler pattern), plus a non-blocking on-session-start opportunistic drain.
- **Backfill utility.** Recovers the existing backlog under correct scope; dry-run by default, execution gated behind an interactive confirmation.
- **Producer provenance fixes.** Manual-save and error-pattern captures now carry valid provenance, and a latent misroute (entries keyed by `memory_type` were stored under the wrong type) is corrected.

## Why

The prior retry path re-detected project scope from the runtime working directory at drain time, so a standing drainer recovered almost nothing and failed-store captures across projects were effectively lost. Entries also carried incomplete provenance and failed validation on replay.

## Notes

- The retry-drain host cron this daemon replaces is retired in the companion installer PR (`fix/installer-config-reuse-env-parity`), which must land **after** this PR.
- Backfill execution against the datastore is gated and not performed by this change.
- Refs BUG-521, BUG-522, BUG-523.
