### PR TITLE
fix(install): reuse persisted config on reinstall, compose env parity, retire retry-drain cron

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -373,6 +373,9 @@ EMBEDDING_CLIENT_SUBBATCH=128
 # The embedding server enforces the same envelope directly — a lone request whose
 # work-units exceed it is rejected with HTTP 413.
 EMBEDDING_SAFE_INFLIGHT_TEXTS=48
+# TD-774: per-request read timeout for the en model (seconds; default 15s).
+# CPU mode typical: 10-15s. GPU mode: <2s. Increase for underpowered hardware.
+EMBEDDING_READ_TIMEOUT=15.0
 # Per-request read timeout for code model (seconds; default 30s — code model is slower than en)
 # CPU mode typical: 20-30s. Increase for very large files or underpowered hardware.
 EMBEDDING_READ_TIMEOUT_CODE=30

--- a/docker/docker-compose.langfuse.yml
+++ b/docker/docker-compose.langfuse.yml
@@ -386,6 +386,12 @@ services:
       - path: ${PROJECT_ENV_FILE:-/dev/null}
         required: false
     environment:
+      # Service-specific overrides — matches classifier-worker's container-internal
+      # pins (docker-compose.yml). Without these, env_file: delivers the host-mapped
+      # QDRANT_PORT (e.g. 26350) with no QDRANT_HOST override — a latent footgun for
+      # any future MemoryConfig.qdrant_port read from this service.
+      - QDRANT_HOST=qdrant                            # container-internal hostname
+      - QDRANT_PORT=6333                               # container-internal port
       - LANGFUSE_ENABLED=true
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:?Run langfuse_setup.sh first to generate API keys}
       - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY:?Run langfuse_setup.sh first to generate API keys}

--- a/docker/docker-compose.langfuse.yml
+++ b/docker/docker-compose.langfuse.yml
@@ -372,6 +372,19 @@ services:
       # not bind-mounted: single-file bind mounts are fragile on WSL2/Docker
       # Desktop reboots (TD-748). Override at runtime via EVALUATOR_CONFIG_PATH.
       - ${AI_MEMORY_INSTALL_DIR:-.}/.audit:/app/.audit
+    # TD-773 / BP-182 §3.4: YAML anchors/x-* fields are file-scoped (docker/compose#5621) —
+    # x-python-service-defaults (docker-compose.yml) cannot be referenced here, so its
+    # env_file: list is replicated literally. Delivers every MemoryConfig/os.environ knob
+    # (e.g. EMBEDDING_TOTAL_TIMEOUT) that classifier-worker already receives via the anchor,
+    # instead of relying on the hand-maintained environment: allow-list below to be kept in
+    # sync by hand (the exact gap that let EMBEDDING_TOTAL_TIMEOUT go undelivered here).
+    env_file:
+      - path: .env
+        required: true
+      - path: .env.secrets
+        required: false
+      - path: ${PROJECT_ENV_FILE:-/dev/null}
+        required: false
     environment:
       - LANGFUSE_ENABLED=true
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:?Run langfuse_setup.sh first to generate API keys}

--- a/scripts/_env_split_helpers.sh
+++ b/scripts/_env_split_helpers.sh
@@ -79,6 +79,29 @@ _read_env_key() {
     printf '%s' "$val"
 }
 
+# _read_env_key_json — read a JSON-valued KEY=VALUE from a flat env file
+# (secrets_file-first fallthrough), preserving embedded double-quotes.
+# Companion to _read_env_key(): that helper's `tr -d` strips ALL quote
+# characters from the value, which corrupts a JSON array (e.g.
+# JIRA_PROJECTS='["A","B"]' -> `[A,B]` — invalid JSON, breaking every
+# MemoryConfig() consumer after a reinstall). This helper strips only the ONE
+# wrapping layer of quotes the installer wraps the value in when persisting
+# (single, then double — BUG-101 precedent at install.sh's docker/.env
+# in-place JIRA_PROJECTS migration), leaving internal JSON quoting intact.
+_read_env_key_json() {
+    local key="$1"
+    local secrets_file="$2"
+    local env_file="$3"
+    local val
+    val=$(grep "^${key}=" "$secrets_file" 2>/dev/null | head -1 | cut -d= -f2- || true)
+    if [[ -z "$val" ]]; then
+        val=$(grep "^${key}=" "$env_file" 2>/dev/null | head -1 | cut -d= -f2- || true)
+    fi
+    val="${val#\'}"; val="${val%\'}"
+    val="${val#\"}"; val="${val%\"}"
+    printf '%s' "$val"
+}
+
 # migrate_secret_to_secrets_file — BP-154 §3 Option γ atomic single-key migration.
 # Moves one key from .env (chmod 644) to .env.secrets (chmod 600).
 # Idempotent: safe to re-run; verify-before-blank prevents data loss.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1425,8 +1425,9 @@ main() {
 
             # BUG-125: Drain queued events that failed during service startup
             drain_pending_queue
-            # TD-710: Standing scheduler so the retry queue keeps draining after install
-            setup_retry_drain_cron
+            # TD-710 cron→daemon migration: retry-queue draining now runs as an
+            # in-stack daemon (docker-compose.yml); remove any legacy host cron.
+            remove_legacy_retry_drain_cron
         fi
     else
         log_info "Skipping shared infrastructure setup (add-project mode)"
@@ -4298,44 +4299,36 @@ verify_embedding_readiness() {
     log_warning "Embedding service slow to respond — GitHub sync may have embedding timeouts"
 }
 
-# Set up cron job for automated retry-queue draining (TD-710)
-# Without this, process_retry_queue.py only runs once at install time (drain_pending_queue),
-# so failed-store events accumulate append-only between installs.
-setup_retry_drain_cron() {
-    log_info "Configuring automated retry-queue drain (every 15 minutes)..."
+# Remove the legacy retry-queue-drain host cron (TD-710 cron→daemon migration).
+# TD-710 originally installed a host cron entry (marker "# ai-memory-retry-drain")
+# to run process_retry_queue.py every 15 minutes. That standing scheduler has
+# moved to an in-stack daemon container (docker-compose.yml) so it runs under the
+# same lifecycle as the rest of the stack. This function no longer installs any
+# cron — it ONLY removes a prior installation's tagged entry (or a legacy
+# untagged process_retry_queue.py entry), so an operator upgrading doesn't end up
+# with BOTH the old host cron and the new daemon draining the queue concurrently.
+# Idempotent: no-op on a fresh install or a host with no crontab, and no-op on a
+# second run once the legacy entry is already gone. Never touches unrelated
+# crontab entries — only lines matching the marker or the legacy script path.
+remove_legacy_retry_drain_cron() {
+    # crontab may not exist on this host at all (e.g. a minimal container) —
+    # nothing to migrate.
+    command -v crontab >/dev/null 2>&1 || return 0
 
-    # Ensure locks directory exists for flock
-    mkdir -p "$INSTALL_DIR/.locks"
-
-    # Build cron command (BP-053: direct interpreter + flock + tagged entry)
-    # cd to docker/ so get_config() finds .env (pydantic env_file=".env")
-    # --limit raised above the 100 default so a multi-week backlog clears over a few runs.
-    local cron_tag="# ai-memory-retry-drain"
-    local cron_cmd
-    if [[ "$PLATFORM" == "macos" ]]; then
-        # macOS: no flock available by default
-        cron_cmd="cd $INSTALL_DIR/docker && $INSTALL_DIR/.venv/bin/python $INSTALL_DIR/scripts/memory/process_retry_queue.py --limit 500"
-    else
-        # Linux/WSL: use flock for overlap prevention
-        cron_cmd="cd $INSTALL_DIR/docker && flock -n $INSTALL_DIR/.locks/retry_drain.lock $INSTALL_DIR/.venv/bin/python $INSTALL_DIR/scripts/memory/process_retry_queue.py --limit 500"
-    fi
-    local cron_entry="*/15 * * * * $cron_cmd >> $INSTALL_DIR/logs/retry_drain.log 2>&1 $cron_tag"
-
-    # Idempotent: remove any existing ai-memory-retry-drain entry, then add fresh
     local existing_crontab
     existing_crontab=$(crontab -l 2>/dev/null || true)
+    [[ -z "$existing_crontab" ]] && return 0
 
-    # Filter out old entries (by tag OR by legacy process_retry_queue.py match)
+    # Nothing to remove — never installed, or already migrated.
+    echo "$existing_crontab" | grep -qE "ai-memory-retry-drain|process_retry_queue\.py" || return 0
+
     local filtered_crontab
     filtered_crontab=$(echo "$existing_crontab" | grep -v "ai-memory-retry-drain" | grep -v "process_retry_queue.py" || true)
 
-    # Add new entry
-    if printf '%s\n%s\n' "$filtered_crontab" "$cron_entry" | crontab - 2>/dev/null; then
-        log_success "Cron job configured (retry-queue drain every 15 minutes)"
-        log_debug "To view: crontab -l | grep ai-memory-retry-drain"
+    if printf '%s\n' "$filtered_crontab" | crontab - 2>/dev/null; then
+        log_success "Removed legacy retry-queue drain cron (now handled by the in-stack daemon)"
     else
-        log_warning "Failed to configure cron job - set up manually if needed"
-        log_info "Add to crontab: $cron_entry"
+        log_warning "Failed to remove legacy retry-drain cron entry — remove manually: crontab -e"
     fi
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4304,12 +4304,12 @@ verify_embedding_readiness() {
 # to run process_retry_queue.py every 15 minutes. That standing scheduler has
 # moved to an in-stack daemon container (docker-compose.yml) so it runs under the
 # same lifecycle as the rest of the stack. This function no longer installs any
-# cron — it ONLY removes a prior installation's tagged entry (or a legacy
-# untagged process_retry_queue.py entry), so an operator upgrading doesn't end up
-# with BOTH the old host cron and the new daemon draining the queue concurrently.
-# Idempotent: no-op on a fresh install or a host with no crontab, and no-op on a
-# second run once the legacy entry is already gone. Never touches unrelated
-# crontab entries — only lines matching the marker or the legacy script path.
+# cron — it ONLY removes a prior installation's tagged entry, so an operator
+# upgrading doesn't end up with BOTH the old host cron and the new daemon
+# draining the queue concurrently. Idempotent: no-op on a fresh install or a
+# host with no crontab, and no-op on a second run once the entry is already
+# gone. Matches ONLY the "# ai-memory-retry-drain" marker line — never touches
+# any other crontab entry, including an operator's own unrelated cron jobs.
 remove_legacy_retry_drain_cron() {
     # crontab may not exist on this host at all (e.g. a minimal container) —
     # nothing to migrate.
@@ -4320,10 +4320,10 @@ remove_legacy_retry_drain_cron() {
     [[ -z "$existing_crontab" ]] && return 0
 
     # Nothing to remove — never installed, or already migrated.
-    echo "$existing_crontab" | grep -qE "ai-memory-retry-drain|process_retry_queue\.py" || return 0
+    echo "$existing_crontab" | grep -q "ai-memory-retry-drain" || return 0
 
     local filtered_crontab
-    filtered_crontab=$(echo "$existing_crontab" | grep -v "ai-memory-retry-drain" | grep -v "process_retry_queue.py" || true)
+    filtered_crontab=$(echo "$existing_crontab" | grep -v "ai-memory-retry-drain" || true)
 
     if printf '%s\n' "$filtered_crontab" | crontab - 2>/dev/null; then
         log_success "Removed legacy retry-queue drain cron (now handled by the in-stack daemon)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -868,7 +868,7 @@ load_persisted_config() {
         j_url=$(_read_env_key   "JIRA_INSTANCE_URL" "$secrets_file" "$env_file")
         j_email=$(_read_env_key "JIRA_EMAIL"        "$secrets_file" "$env_file")
         j_tok=$(_read_env_key   "JIRA_API_TOKEN"    "$secrets_file" "$env_file")
-        j_proj=$(_read_env_key  "JIRA_PROJECTS"     "$secrets_file" "$env_file")
+        j_proj=$(_read_env_key_json "JIRA_PROJECTS" "$secrets_file" "$env_file")
         if [[ "$j_en" == "true" && -n "$j_url" && -n "$j_email" && -n "$j_tok" ]]; then
             JIRA_SYNC_ENABLED="$j_en"; JIRA_INSTANCE_URL="$j_url"; JIRA_EMAIL="$j_email"
             JIRA_API_TOKEN="$j_tok"; JIRA_PROJECTS="$j_proj"; hydrated+=("Jira")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -825,6 +825,81 @@ else:
     echo ""
 }
 
+# load_persisted_config — Tier-2 (user-managed) prompt-suppression on reinstall.
+# BP-182 §2 / BUG-520: the shell analogue of debconf's "seen" flag — hydrate
+# prompt-gated vars from persisted docker/.env + docker/.env.secrets so
+# configure_options' `[[ -z "$VAR" ]]` guards skip already-answered questions.
+# Reuses the secrets-first _read_env_key idiom already proven in
+# configure_project_sources (BUG-309) and derive_and_persist_compose_profiles
+# (BP-160).
+#
+# Constraints (BP-182 §2.2): (1) only fill UNSET vars — preserves
+# shell > .env > default precedence; (2) all-or-nothing per feature — hydrate an
+# enable-flag only with its dependents present; (3) secrets from .env.secrets
+# first, never echoed; (4) gate on existing install — no-op on fresh.
+load_persisted_config() {
+    local env_file="$INSTALL_DIR/docker/.env"
+    local secrets_file="$INSTALL_DIR/docker/.env.secrets"
+
+    # (4) Gate on existing install — no-op on fresh (blank placeholders must prompt)
+    [[ -f "$env_file" ]] || return 0
+
+    local hydrated=()
+
+    # --- GitHub (all-or-nothing: enable-flag + repo + token) ---
+    if [[ -z "${GITHUB_SYNC_ENABLED:-}" ]]; then
+        local g_enabled g_repo g_token
+        g_enabled=$(_read_env_key "GITHUB_SYNC_ENABLED" "$secrets_file" "$env_file")
+        g_repo=$(_read_env_key    "GITHUB_REPO"         "$secrets_file" "$env_file")
+        g_token=$(_read_env_key   "GITHUB_TOKEN"        "$secrets_file" "$env_file")
+        if [[ "$g_enabled" == "true" && -n "$g_repo" && -n "$g_token" ]]; then
+            GITHUB_SYNC_ENABLED="$g_enabled"; GITHUB_REPO="$g_repo"; GITHUB_TOKEN="$g_token"
+            hydrated+=("GitHub")
+        elif [[ "$g_enabled" == "false" ]]; then
+            GITHUB_SYNC_ENABLED="false"; hydrated+=("GitHub(disabled)")
+        fi
+        # else: incomplete prior config → leave unset → prompt (all-or-nothing)
+    fi
+
+    # --- Jira (enable-flag + url + email + token + projects) ---
+    if [[ -z "${JIRA_SYNC_ENABLED:-}" ]]; then
+        local j_en j_url j_email j_tok j_proj
+        j_en=$(_read_env_key    "JIRA_SYNC_ENABLED" "$secrets_file" "$env_file")
+        j_url=$(_read_env_key   "JIRA_INSTANCE_URL" "$secrets_file" "$env_file")
+        j_email=$(_read_env_key "JIRA_EMAIL"        "$secrets_file" "$env_file")
+        j_tok=$(_read_env_key   "JIRA_API_TOKEN"    "$secrets_file" "$env_file")
+        j_proj=$(_read_env_key  "JIRA_PROJECTS"     "$secrets_file" "$env_file")
+        if [[ "$j_en" == "true" && -n "$j_url" && -n "$j_email" && -n "$j_tok" ]]; then
+            JIRA_SYNC_ENABLED="$j_en"; JIRA_INSTANCE_URL="$j_url"; JIRA_EMAIL="$j_email"
+            JIRA_API_TOKEN="$j_tok"; JIRA_PROJECTS="$j_proj"; hydrated+=("Jira")
+        elif [[ "$j_en" == "false" ]]; then
+            JIRA_SYNC_ENABLED="false"; hydrated+=("Jira(disabled)")
+        fi
+    fi
+
+    # --- Langfuse / monitoring (single-flag features) ---
+    if [[ -z "${LANGFUSE_ENABLED:-}" ]]; then
+        LANGFUSE_ENABLED=$(_read_env_key "LANGFUSE_ENABLED" "$secrets_file" "$env_file")
+        [[ -n "$LANGFUSE_ENABLED" ]] && hydrated+=("Langfuse")
+    fi
+    if [[ -z "${INSTALL_MONITORING:-}" ]]; then
+        INSTALL_MONITORING=$(_read_env_key "MONITORING_ENABLED" "$secrets_file" "$env_file")
+        [[ -n "$INSTALL_MONITORING" ]] && hydrated+=("Monitoring")
+    fi
+
+    # SEED_BEST_PRACTICES is an action, not persisted state — default to skip
+    # re-seed on reinstall (an existing install already has the DB seeded).
+    if [[ -z "${SEED_BEST_PRACTICES:-}" ]]; then
+        SEED_BEST_PRACTICES="false"
+    fi
+
+    # (5) Transparency — make the skipped prompts obviously intentional
+    if (( ${#hydrated[@]} )); then
+        log_info "Reusing existing config from ${env_file}: ${hydrated[*]}"
+        log_info "  (to change any value, edit docker/.env(.secrets) or export the var before install)"
+    fi
+}
+
 # Interactive configuration prompts
 configure_options() {
     # Skip prompts if running non-interactively or if all options pre-set
@@ -1305,6 +1380,7 @@ main() {
 
     # Full install steps - create shared infrastructure
     if [[ "$INSTALL_MODE" == "full" ]]; then
+        load_persisted_config          # BP-182 §2.4 / BUG-520 — hydrate before prompt
         # Interactive configuration (unless non-interactive mode)
         configure_options
 

--- a/tests/integration/test_install_load_persisted_config.py
+++ b/tests/integration/test_install_load_persisted_config.py
@@ -1,0 +1,361 @@
+"""Regression tests for install.sh's load_persisted_config() (BUG-520 / BP-182 §2).
+
+Before this fix, the full/reinstall install path (INSTALL_MODE=full over an existing
+~/.ai-memory) re-prompted the operator for EVERY previously-configured setting
+(GitHub owner/repo/token, Jira URL/email/token/projects, Langfuse, monitoring) because
+nothing reloaded the persisted docker/.env + docker/.env.secrets before configure_options
+ran — `import_user_env` was a deprecated no-op. Skipping a prompt (the intuitive
+"leave as-is" action) silently wrote the enable-flag to "false", disabling a live sync.
+
+load_persisted_config() hydrates the prompt-gated shell vars from persisted state before
+configure_options runs, so its existing `[[ -z "$VAR" ]]` prompt guards short-circuit —
+the shell analogue of debconf's "seen" flag. Reuses the secrets-first _read_env_key
+idiom already proven in configure_project_sources / derive_and_persist_compose_profiles.
+
+Non-negotiable constraints under test:
+  1. Only fill UNSET vars — shell-env override still wins (fill-unset-only).
+  2. All-or-nothing per feature — an enable-flag hydrates only WITH its dependents.
+  3. Secrets-first — GITHUB_TOKEN / JIRA_API_TOKEN read from .env.secrets first.
+  4. Gate on existing install — no-op on fresh install (no docker/.env yet).
+
+No external services required — shells out to bash only.
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).parent.parent.parent / "scripts"
+_INSTALL_SH = _SCRIPTS_DIR / "install.sh"
+
+
+def _minimal_env():
+    """Isolated environment with only PATH + HOME — prevents ambient shell vars (e.g.
+    this dev environment's own LANGFUSE_ENABLED=true from AI-Memory's Langfuse tracing)
+    from leaking into the shell-env-override-precedence assertions under test. HOME
+    must be present because install.sh's top-level INSTALL_DIR default (`$HOME/.ai-memory`)
+    is evaluated under `set -u` even though we override INSTALL_DIR immediately after.
+    """
+    return {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", "/tmp"),
+    }
+
+
+@pytest.fixture
+def install_sh_no_main(tmp_path) -> Path:
+    """Copy install.sh minus final 'main "$@"' line into tmp_path for safe sourcing."""
+    content = _INSTALL_SH.read_text(encoding="utf-8")
+    lines = content.splitlines(keepends=True)
+    assert lines[-1].strip() == 'main "$@"', (
+        f"Expected last line 'main \"$@\"', got: {lines[-1]!r}. "
+        "If install.sh structure changed, update this fixture."
+    )
+    copy = tmp_path / "install.sh"
+    copy.write_text("".join(lines[:-1]), encoding="utf-8")
+    copy.chmod(0o755)
+    shutil.copy(
+        _SCRIPTS_DIR / "_env_split_helpers.sh", tmp_path / "_env_split_helpers.sh"
+    )
+    return copy
+
+
+@pytest.fixture
+def install_dir(tmp_path) -> Path:
+    """INSTALL_DIR with a fully-configured prior install (GitHub + Jira + Langfuse + monitoring)."""
+    docker_dir = tmp_path / "install_dir" / "docker"
+    docker_dir.mkdir(parents=True)
+    (docker_dir / ".env").write_text(
+        "GITHUB_SYNC_ENABLED=true\n"
+        "GITHUB_REPO=owner/repo\n"
+        "GITHUB_TOKEN=\n"
+        "JIRA_SYNC_ENABLED=true\n"
+        "JIRA_INSTANCE_URL=https://company.atlassian.net\n"
+        "JIRA_EMAIL=user@example.com\n"
+        "JIRA_API_TOKEN=\n"
+        'JIRA_PROJECTS="[\\"PROJ\\"]"\n'
+        "LANGFUSE_ENABLED=false\n"
+        "MONITORING_ENABLED=true\n"
+    )
+    (docker_dir / ".env.secrets").write_text(
+        "GITHUB_TOKEN=ghp_persisted_token\n" "JIRA_API_TOKEN=ATATpersisted_token\n"
+    )
+    return tmp_path / "install_dir"
+
+
+def _run(
+    install_sh_copy: Path,
+    install_dir: Path,
+    extra: str = "",
+    functions: str = "load_persisted_config",
+    stdin: str | None = None,
+) -> subprocess.CompletedProcess:
+    """Source install.sh (no-main copy), export INSTALL_DIR + extra shell vars, run `functions`."""
+    bash_cmd = f"""
+set -euo pipefail
+export INSTALL_DIR="{install_dir}"
+{extra}
+source "{install_sh_copy}"
+INSTALL_DIR="{install_dir}"
+{functions}
+echo "__GITHUB_SYNC_ENABLED=${{GITHUB_SYNC_ENABLED:-}}"
+echo "__GITHUB_REPO=${{GITHUB_REPO:-}}"
+echo "__GITHUB_TOKEN=${{GITHUB_TOKEN:-}}"
+echo "__JIRA_SYNC_ENABLED=${{JIRA_SYNC_ENABLED:-}}"
+echo "__JIRA_INSTANCE_URL=${{JIRA_INSTANCE_URL:-}}"
+echo "__JIRA_EMAIL=${{JIRA_EMAIL:-}}"
+echo "__JIRA_API_TOKEN=${{JIRA_API_TOKEN:-}}"
+echo "__LANGFUSE_ENABLED=${{LANGFUSE_ENABLED:-}}"
+echo "__INSTALL_MONITORING=${{INSTALL_MONITORING:-}}"
+echo "__SEED_BEST_PRACTICES=${{SEED_BEST_PRACTICES:-}}"
+"""
+    return subprocess.run(
+        ["bash", "-c", bash_cmd],
+        capture_output=True,
+        text=True,
+        input=stdin,
+        env=_minimal_env(),
+    )
+
+
+def _parse(stdout: str) -> dict:
+    out = {}
+    for line in stdout.splitlines():
+        if line.startswith("__"):
+            key, _, val = line[2:].partition("=")
+            out[key] = val
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Constraint 4 — gate on existing install (no-op on fresh install)
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_install_noop(install_sh_no_main, tmp_path):
+    """No docker/.env present (fresh install) — load_persisted_config is a no-op."""
+    fresh_install_dir = tmp_path / "fresh_install_dir"
+    fresh_install_dir.mkdir()
+    result = _run(install_sh_no_main, fresh_install_dir)
+    assert result.returncode == 0, result.stderr
+    v = _parse(result.stdout)
+    assert v["GITHUB_SYNC_ENABLED"] == ""
+    assert v["JIRA_SYNC_ENABLED"] == ""
+    assert v["LANGFUSE_ENABLED"] == ""
+    assert v["INSTALL_MONITORING"] == ""
+    # SEED_BEST_PRACTICES is not defaulted on fresh install — must still prompt later
+    assert v["SEED_BEST_PRACTICES"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Full hydration — complete persisted config reused, secrets-first
+# ---------------------------------------------------------------------------
+
+
+def test_hydrates_complete_github_config(install_sh_no_main, install_dir):
+    result = _run(install_sh_no_main, install_dir)
+    assert result.returncode == 0, result.stderr
+    v = _parse(result.stdout)
+    assert v["GITHUB_SYNC_ENABLED"] == "true"
+    assert v["GITHUB_REPO"] == "owner/repo"
+    # Secrets-first: GITHUB_TOKEN in .env is blank; real value lives in .env.secrets
+    assert v["GITHUB_TOKEN"] == "ghp_persisted_token"
+
+
+def test_hydrates_complete_jira_config(install_sh_no_main, install_dir):
+    result = _run(install_sh_no_main, install_dir)
+    assert result.returncode == 0, result.stderr
+    v = _parse(result.stdout)
+    assert v["JIRA_SYNC_ENABLED"] == "true"
+    assert v["JIRA_INSTANCE_URL"] == "https://company.atlassian.net"
+    assert v["JIRA_EMAIL"] == "user@example.com"
+    assert v["JIRA_API_TOKEN"] == "ATATpersisted_token"
+
+
+def test_hydrates_langfuse_and_monitoring(install_sh_no_main, install_dir):
+    result = _run(install_sh_no_main, install_dir)
+    assert result.returncode == 0, result.stderr
+    v = _parse(result.stdout)
+    assert v["LANGFUSE_ENABLED"] == "false"
+    assert v["INSTALL_MONITORING"] == "true"
+
+
+def test_seed_best_practices_defaults_false_on_existing_install(
+    install_sh_no_main, install_dir
+):
+    """SEED_BEST_PRACTICES is an action (not persisted state) — defaults to skip
+    re-seed on reinstall so the DB isn't re-populated on every reinstall."""
+    result = _run(install_sh_no_main, install_dir)
+    assert result.returncode == 0, result.stderr
+    v = _parse(result.stdout)
+    assert v["SEED_BEST_PRACTICES"] == "false"
+
+
+# ---------------------------------------------------------------------------
+# Constraint 2 — all-or-nothing per feature (a partial prior config is NOT hydrated)
+# ---------------------------------------------------------------------------
+
+
+def test_github_partial_config_not_hydrated(install_sh_no_main, tmp_path):
+    """GITHUB_SYNC_ENABLED=true persisted but GITHUB_TOKEN missing → leave unset (prompt)."""
+    docker_dir = tmp_path / "partial_install" / "docker"
+    docker_dir.mkdir(parents=True)
+    (docker_dir / ".env").write_text(
+        "GITHUB_SYNC_ENABLED=true\nGITHUB_REPO=owner/repo\nGITHUB_TOKEN=\n"
+    )
+    (docker_dir / ".env.secrets").write_text("GITHUB_TOKEN=\n")
+    result = _run(install_sh_no_main, tmp_path / "partial_install")
+    assert result.returncode == 0, result.stderr
+    v = _parse(result.stdout)
+    assert v["GITHUB_SYNC_ENABLED"] == "", (
+        "Incomplete GitHub config (enabled but no token) must NOT be hydrated — "
+        "would pass validate_external_services's -z guard but fail credential validation."
+    )
+    assert v["GITHUB_REPO"] == ""
+
+
+def test_jira_partial_config_not_hydrated(install_sh_no_main, tmp_path):
+    """JIRA_SYNC_ENABLED=true persisted but JIRA_EMAIL missing → leave unset (prompt)."""
+    docker_dir = tmp_path / "partial_install" / "docker"
+    docker_dir.mkdir(parents=True)
+    (docker_dir / ".env").write_text(
+        "JIRA_SYNC_ENABLED=true\n"
+        "JIRA_INSTANCE_URL=https://company.atlassian.net\n"
+        "JIRA_EMAIL=\n"
+        "JIRA_API_TOKEN=\n"
+    )
+    (docker_dir / ".env.secrets").write_text("JIRA_API_TOKEN=tok\n")
+    result = _run(install_sh_no_main, tmp_path / "partial_install")
+    assert result.returncode == 0, result.stderr
+    v = _parse(result.stdout)
+    assert (
+        v["JIRA_SYNC_ENABLED"] == ""
+    ), "Incomplete Jira config (enabled but no email) must NOT be hydrated."
+
+
+def test_disabled_feature_persisted_reused(install_sh_no_main, tmp_path):
+    """A previously-disabled feature (enable-flag=false) IS hydrated — reuses the 'no' answer."""
+    docker_dir = tmp_path / "disabled_install" / "docker"
+    docker_dir.mkdir(parents=True)
+    (docker_dir / ".env").write_text(
+        "GITHUB_SYNC_ENABLED=false\nJIRA_SYNC_ENABLED=false\n"
+    )
+    (docker_dir / ".env.secrets").write_text("")
+    result = _run(install_sh_no_main, tmp_path / "disabled_install")
+    assert result.returncode == 0, result.stderr
+    v = _parse(result.stdout)
+    assert v["GITHUB_SYNC_ENABLED"] == "false"
+    assert v["JIRA_SYNC_ENABLED"] == "false"
+
+
+# ---------------------------------------------------------------------------
+# Constraint 1 — fill-unset-only: shell-env override wins over persisted state
+# ---------------------------------------------------------------------------
+
+
+def test_shell_env_override_wins_over_persisted(install_sh_no_main, install_dir):
+    """JIRA_SYNC_ENABLED=false exported in shell BEFORE load_persisted_config runs —
+    override wins even though a complete, enabled prior config is persisted."""
+    result = _run(
+        install_sh_no_main, install_dir, extra='export JIRA_SYNC_ENABLED="false"'
+    )
+    assert result.returncode == 0, result.stderr
+    v = _parse(result.stdout)
+    assert (
+        v["JIRA_SYNC_ENABLED"] == "false"
+    ), "Shell-env override must win over persisted state (shell > .env > default)"
+    # GitHub was NOT overridden — still hydrates normally from persisted state
+    assert v["GITHUB_SYNC_ENABLED"] == "true"
+
+
+def test_shell_env_override_wins_for_monitoring(install_sh_no_main, install_dir):
+    result = _run(
+        install_sh_no_main, install_dir, extra='export INSTALL_MONITORING="false"'
+    )
+    assert result.returncode == 0, result.stderr
+    v = _parse(result.stdout)
+    assert v["INSTALL_MONITORING"] == "false"
+
+
+# ---------------------------------------------------------------------------
+# Transparency log line
+# ---------------------------------------------------------------------------
+
+
+def test_transparency_log_line_emitted_on_hydration(install_sh_no_main, install_dir):
+    result = _run(install_sh_no_main, install_dir)
+    assert result.returncode == 0, result.stderr
+    assert "Reusing existing config" in result.stdout
+
+
+def test_no_transparency_log_line_on_fresh_install(install_sh_no_main, tmp_path):
+    fresh_install_dir = tmp_path / "fresh_install_dir"
+    fresh_install_dir.mkdir()
+    result = _run(install_sh_no_main, fresh_install_dir)
+    assert result.returncode == 0, result.stderr
+    assert "Reusing existing config" not in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Production-path integration — reinstall fires ZERO prompts (BP-182 §2.5 assertion #2)
+# ---------------------------------------------------------------------------
+# Exercises load_persisted_config() -> configure_options() as install.sh's main() calls
+# them (immediately adjacent, full-mode branch), with stdin closed (/dev/null) so any
+# `read -p` that DID fire would read EOF and take the "no"/default branch — reproducing
+# the exact BUG-520 footgun (skipped prompt silently disables a live sync) if hydration
+# were broken. Asserts the persisted "true" answers survive untouched.
+
+
+def test_reinstall_over_existing_install_fires_zero_prompts(
+    install_sh_no_main, install_dir
+):
+    # configure_options ends with an unconditional (ungated) "Proceed with
+    # installation?" confirmation — not one of the four feature prompts under
+    # test here. Feed it a bare newline (default/empty answer = proceed) so
+    # `read` doesn't hit EOF and abort the script under `set -e`; this does
+    # NOT feed any of the GitHub/Jira/Langfuse/monitoring prompt reads, which
+    # must not fire at all if hydration worked.
+    result = _run(
+        install_sh_no_main,
+        install_dir,
+        extra='export NON_INTERACTIVE="false"',
+        functions="load_persisted_config\nconfigure_options",
+        stdin="\n",
+    )
+    assert result.returncode == 0, result.stderr
+    v = _parse(result.stdout)
+    assert v["GITHUB_SYNC_ENABLED"] == "true", (
+        "GITHUB_SYNC_ENABLED flipped by a prompt reading EOF from /dev/null — "
+        "load_persisted_config did not hydrate before configure_options ran."
+    )
+    assert v["GITHUB_REPO"] == "owner/repo"
+    assert v["GITHUB_TOKEN"] == "ghp_persisted_token"
+    assert v["JIRA_SYNC_ENABLED"] == "true"
+    assert v["JIRA_API_TOKEN"] == "ATATpersisted_token"
+    assert v["INSTALL_MONITORING"] == "true"
+
+
+# ---------------------------------------------------------------------------
+# Structural — call-site reachability (BP-182 §2.4 call site)
+# ---------------------------------------------------------------------------
+# BUG-311/fix-r4 escape lesson: a function-in-isolation test can pass while the
+# production call chain is broken. Assert load_persisted_config is actually wired
+# into main()'s full-mode branch, immediately before configure_options.
+
+
+def test_load_persisted_config_called_immediately_before_configure_options():
+    lines = _INSTALL_SH.read_text().splitlines()
+    found = False
+    for i, line in enumerate(lines):
+        if "load_persisted_config" in line and not line.strip().startswith("#"):
+            window = "\n".join(lines[i : i + 3])
+            if "configure_options" in window:
+                found = True
+                break
+    assert found, (
+        "load_persisted_config must be called immediately before configure_options "
+        "in scripts/install.sh's full-mode branch (BP-182 §2.4 call site missing)."
+    )

--- a/tests/integration/test_install_load_persisted_config.py
+++ b/tests/integration/test_install_load_persisted_config.py
@@ -21,6 +21,7 @@ Non-negotiable constraints under test:
 No external services required — shells out to bash only.
 """
 
+import json
 import os
 import shutil
 import subprocess
@@ -76,7 +77,7 @@ def install_dir(tmp_path) -> Path:
         "JIRA_INSTANCE_URL=https://company.atlassian.net\n"
         "JIRA_EMAIL=user@example.com\n"
         "JIRA_API_TOKEN=\n"
-        'JIRA_PROJECTS="[\\"PROJ\\"]"\n'
+        "JIRA_PROJECTS='[\"PROJ\"]'\n"
         "LANGFUSE_ENABLED=false\n"
         "MONITORING_ENABLED=true\n"
     )
@@ -108,6 +109,7 @@ echo "__JIRA_SYNC_ENABLED=${{JIRA_SYNC_ENABLED:-}}"
 echo "__JIRA_INSTANCE_URL=${{JIRA_INSTANCE_URL:-}}"
 echo "__JIRA_EMAIL=${{JIRA_EMAIL:-}}"
 echo "__JIRA_API_TOKEN=${{JIRA_API_TOKEN:-}}"
+echo "__JIRA_PROJECTS=${{JIRA_PROJECTS:-}}"
 echo "__LANGFUSE_ENABLED=${{LANGFUSE_ENABLED:-}}"
 echo "__INSTALL_MONITORING=${{INSTALL_MONITORING:-}}"
 echo "__SEED_BEST_PRACTICES=${{SEED_BEST_PRACTICES:-}}"
@@ -173,6 +175,10 @@ def test_hydrates_complete_jira_config(install_sh_no_main, install_dir):
     assert v["JIRA_INSTANCE_URL"] == "https://company.atlassian.net"
     assert v["JIRA_EMAIL"] == "user@example.com"
     assert v["JIRA_API_TOKEN"] == "ATATpersisted_token"
+    # JIRA_PROJECTS hydration: must hydrate as valid JSON, quote-preserving
+    # (not the corrupted `[PROJ]` a `tr -d` quote-strip would produce).
+    assert v["JIRA_PROJECTS"] == '["PROJ"]'
+    assert json.loads(v["JIRA_PROJECTS"]) == ["PROJ"]
 
 
 def test_hydrates_langfuse_and_monitoring(install_sh_no_main, install_dir):
@@ -336,6 +342,67 @@ def test_reinstall_over_existing_install_fires_zero_prompts(
     assert v["JIRA_SYNC_ENABLED"] == "true"
     assert v["JIRA_API_TOKEN"] == "ATATpersisted_token"
     assert v["INSTALL_MONITORING"] == "true"
+    # Zero-prompts assertion covers the full real chain, including the
+    # single-flag features (not just GitHub/Jira/monitoring).
+    assert v["LANGFUSE_ENABLED"] == "false"
+    assert v["SEED_BEST_PRACTICES"] == "false"
+
+
+# ---------------------------------------------------------------------------
+# JIRA_PROJECTS reinstall round-trip — the value must survive hydrate
+# (load_persisted_config) -> persist (persist_user_choices_to_env) as
+# byte-for-byte valid JSON, identical to the pre-reinstall persisted value.
+# _read_env_key's `tr -d` quote-strip corrupts JIRA_PROJECTS='["A","B"]' into
+# `[A,B]` during hydration; persist_user_choices_to_env's `=~ ^\[` guard then
+# treats the corrupted value as already-JSON and writes it back verbatim — a
+# reinstall silently breaks every MemoryConfig() consumer downstream
+# (parse_jira_projects() fails pydantic JSON parsing on `[A,B]`).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "projects",
+    [["PROJ", "TEAM"], ["PROJ"]],
+    ids=["multi-project", "single-project"],
+)
+def test_jira_projects_round_trips_valid_json_on_reinstall(
+    install_sh_no_main, tmp_path, projects
+):
+    projects_json = json.dumps(projects)
+    original_line = f"JIRA_PROJECTS='{projects_json}'"
+
+    docker_dir = tmp_path / "roundtrip_install" / "docker"
+    docker_dir.mkdir(parents=True)
+    env_file = docker_dir / ".env"
+    env_file.write_text(
+        "JIRA_SYNC_ENABLED=true\n"
+        "JIRA_INSTANCE_URL=https://company.atlassian.net\n"
+        "JIRA_EMAIL=user@example.com\n"
+        "JIRA_API_TOKEN=\n"
+        f"{original_line}\n"
+    )
+    (docker_dir / ".env.secrets").write_text("JIRA_API_TOKEN=ATATpersisted_token\n")
+
+    install_dir = tmp_path / "roundtrip_install"
+    result = _run(
+        install_sh_no_main,
+        install_dir,
+        functions="load_persisted_config\npersist_user_choices_to_env",
+    )
+    assert result.returncode == 0, result.stderr
+
+    persisted_line = next(
+        line
+        for line in env_file.read_text().splitlines()
+        if line.startswith("JIRA_PROJECTS=")
+    )
+    assert persisted_line == original_line, (
+        f"JIRA_PROJECTS corrupted on reinstall round-trip: {persisted_line!r} "
+        f"!= original {original_line!r}"
+    )
+    persisted_value = persisted_line[len("JIRA_PROJECTS=") :]
+    assert persisted_value[0] == "'" and persisted_value[-1] == "'"
+    assert json.loads(persisted_value[1:-1]) == projects
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_compose_bare_up_topology.py
+++ b/tests/test_compose_bare_up_topology.py
@@ -66,11 +66,11 @@ ENV_FILE_SERVICES = ["prometheus-init", "prometheus", "grafana", "qdrant"]
 # so both must receive the identical knob set (TD-773: evaluator-scheduler's
 # hand-maintained environment: allow-list never got EMBEDDING_TOTAL_TIMEOUT when
 # Fix A/PR #278 added it — a silent per-service divergence in embed wall-time
-# bounding). EMBEDDING_READ_TIMEOUT is deliberately excluded: it is consumed by
-# embeddings.py but has no docker/.env.example entry at all (a separate,
-# symmetric, pre-existing gap — not an install-mode/service asymmetry).
+# bounding). EMBEDDING_READ_TIMEOUT (TD-774) was consumed by embeddings.py but had
+# no docker/.env.example entry at all; now documented there and included here.
 EMBEDDING_CLIENT_KNOBS = {
     "EMBEDDING_TOTAL_TIMEOUT",
+    "EMBEDDING_READ_TIMEOUT",
     "EMBEDDING_READ_TIMEOUT_CODE",
     "EMBEDDING_MAX_RETRIES",
     "EMBEDDING_BACKOFF_BASE",

--- a/tests/test_compose_bare_up_topology.py
+++ b/tests/test_compose_bare_up_topology.py
@@ -59,6 +59,24 @@ SECRET_CLASS_KEYS = [
 # Services that must declare env_file: with .env.secrets after TD-582.
 ENV_FILE_SERVICES = ["prometheus-init", "prometheus", "grafana", "qdrant"]
 
+# EmbeddingClient tunable knobs (src/memory/embeddings.py) that are documented in
+# docker/.env.example — the deliverable, effective-env-subset surface for TD-773.
+# Both classifier-worker (docker-compose.yml) and evaluator-scheduler
+# (docker-compose.langfuse.yml) bake src/memory and can call EmbeddingClient.embed(),
+# so both must receive the identical knob set (TD-773: evaluator-scheduler's
+# hand-maintained environment: allow-list never got EMBEDDING_TOTAL_TIMEOUT when
+# Fix A/PR #278 added it — a silent per-service divergence in embed wall-time
+# bounding). EMBEDDING_READ_TIMEOUT is deliberately excluded: it is consumed by
+# embeddings.py but has no docker/.env.example entry at all (a separate,
+# symmetric, pre-existing gap — not an install-mode/service asymmetry).
+EMBEDDING_CLIENT_KNOBS = {
+    "EMBEDDING_TOTAL_TIMEOUT",
+    "EMBEDDING_READ_TIMEOUT_CODE",
+    "EMBEDDING_MAX_RETRIES",
+    "EMBEDDING_BACKOFF_BASE",
+    "EMBEDDING_BACKOFF_CAP",
+}
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -663,6 +681,17 @@ EXPECTED_CONSUMER_ENV_PER_SERVICE: dict[str, set[str]] = {
         "GF_SECURITY_SECRET_KEY",
         "PROMETHEUS_ADMIN_PASSWORD",
     },
+    # TD-773: services baking src/memory must both receive EmbeddingClient's knobs.
+    "classifier-worker": EMBEDDING_CLIENT_KNOBS,
+    "evaluator-scheduler": EMBEDDING_CLIENT_KNOBS,
+}
+
+# classifier-worker lives in docker-compose.yml; evaluator-scheduler lives in
+# docker-compose.langfuse.yml (TD-773 — the two-file split is the root cause:
+# YAML anchors/x-* fields are file-scoped, docker/compose#5621). Services not
+# listed here are assumed to live in docker-compose.yml (the pre-TD-773 default).
+SERVICE_COMPOSE_FILE = {
+    "evaluator-scheduler": DOCKER_COMPOSE_LANGFUSE_PATH,
 }
 
 # Path containing docker-compose.yml — env_file: paths are relative to it,
@@ -795,11 +824,24 @@ class TestEffectiveContainerEnvCoverage:
         with open(DOCKER_COMPOSE_PATH) as fh:
             return yaml.safe_load(fh)
 
+    @pytest.fixture(scope="class")
+    def langfuse_config(self):
+        with open(DOCKER_COMPOSE_LANGFUSE_PATH) as fh:
+            return yaml.safe_load(fh)
+
     @pytest.mark.parametrize("service", sorted(EXPECTED_CONSUMER_ENV_PER_SERVICE))
     def test_effective_env_satisfies_consumer_expectations(
-        self, source_config, service
+        self, source_config, langfuse_config, service
     ):
-        block = source_config["services"][service]
+        # TD-773: service may live in docker-compose.yml or docker-compose.langfuse.yml
+        # (SERVICE_COMPOSE_FILE) — anchors are file-scoped so the two files' services
+        # must be checked against their own source file.
+        config = (
+            langfuse_config
+            if SERVICE_COMPOSE_FILE.get(service) == DOCKER_COMPOSE_LANGFUSE_PATH
+            else source_config
+        )
+        block = config["services"][service]
         effective = _effective_env(block)
         expected = EXPECTED_CONSUMER_ENV_PER_SERVICE[service]
         missing = expected - effective
@@ -1222,4 +1264,40 @@ class TestEvaluatorSchedulerLangfuseEnv:
             f"evaluator-scheduler: LANGFUSE_ENABLED={langfuse_val!r}; expected 'true' — "
             "a false value disables the bounded atexit drain registered by "
             "_register_langfuse_shutdown() (TD-698, F-ADV-1)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TD-773 — evaluator-scheduler env_file: replicated-anchor parity
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluatorSchedulerEnvFileAnchorParity:
+    """evaluator-scheduler's env_file: list must match x-python-service-defaults's
+    env_file: list path-for-path.
+
+    Anchors/x-* fields are file-scoped (docker/compose#5621) — evaluator-scheduler
+    (docker-compose.langfuse.yml) cannot reference the anchor defined in
+    docker-compose.yml, so its env_file: list is a literal duplicate (TD-773 fix).
+    This is the only static guard against the two lists silently drifting apart
+    again (e.g. a future knob added only to one file's env_file: list).
+    """
+
+    def test_env_file_matches_python_service_defaults_anchor(self):
+        with open(DOCKER_COMPOSE_PATH) as fh:
+            main_compose = yaml.safe_load(fh)
+        anchor_env_file = main_compose["x-python-service-defaults"]["env_file"]
+
+        with open(DOCKER_COMPOSE_LANGFUSE_PATH) as fh:
+            langfuse_compose = yaml.safe_load(fh)
+        evaluator_service = langfuse_compose["services"]["evaluator-scheduler"]
+
+        assert "env_file" in evaluator_service, (
+            "evaluator-scheduler must have an env_file: block (TD-773 fix) — "
+            "docker-compose.langfuse.yml structure changed?"
+        )
+        assert evaluator_service["env_file"] == anchor_env_file, (
+            "evaluator-scheduler's env_file: list has drifted from "
+            "x-python-service-defaults's anchor list in docker-compose.yml. "
+            f"anchor={anchor_env_file!r} evaluator={evaluator_service['env_file']!r}"
         )

--- a/tests/test_install_retry_drain_cron.py
+++ b/tests/test_install_retry_drain_cron.py
@@ -4,13 +4,15 @@ TD-710 originally had install.sh register a flock-guarded host cron entry (marke
 "# ai-memory-retry-drain") that ran process_retry_queue.py every 15 minutes. The
 standing scheduler has since moved to an in-stack daemon container
 (docker-compose.yml, owned separately), so install.sh must no longer install that
-cron — it must instead REMOVE any prior installation's tagged entry (or a legacy
-untagged process_retry_queue.py entry) so an upgrading operator doesn't end up with
-BOTH the old host cron and the new daemon draining the queue concurrently.
+cron — it must instead REMOVE any prior installation's tagged entry so an
+upgrading operator doesn't end up with BOTH the old host cron and the new daemon
+draining the queue concurrently.
 
 remove_legacy_retry_drain_cron() is the migration function: idempotent, no-op on a
-fresh install or a host with no crontab, and it must never touch unrelated crontab
-entries — only lines matching the marker or the legacy script path.
+fresh install or a host with no crontab, and it must never touch any crontab entry
+other than the one carrying the "# ai-memory-retry-drain" marker — including an
+untagged/operator-authored cron line that happens to reference
+process_retry_queue.py for its own purposes.
 
 A fake `crontab` binary is placed on PATH so these tests never touch the real
 crontab of the machine running them.
@@ -145,16 +147,18 @@ class TestRemoveLegacyRetryDrainCron:
         assert "ai-memory-retry-drain" not in crontab_content
         assert "process_retry_queue.py" not in crontab_content
 
-    def test_removes_legacy_untagged_entry(
+    def test_untagged_process_retry_queue_entry_is_preserved(
         self, install_sh_no_main, fake_crontab_env, tmp_path
     ):
-        """A pre-TD-710 untagged entry (process_retry_queue.py, no marker) is also
-        removed — the migration must not leave a pre-marker cron installation behind."""
+        """An untagged entry that happens to reference process_retry_queue.py (no
+        "# ai-memory-retry-drain" marker) is left alone — matching is marker-only,
+        so an operator's own unrelated cron line referencing the same script path
+        is never touched."""
         bin_dir, state_file = fake_crontab_env
         install_dir = tmp_path / "install_dir"
         install_dir.mkdir()
-        legacy_entry = "*/30 * * * * /usr/bin/python3 /opt/legacy/process_retry_queue.py --limit 50\n"
-        state_file.write_text(legacy_entry, encoding="utf-8")
+        untagged_entry = "*/30 * * * * /usr/bin/python3 /opt/legacy/process_retry_queue.py --limit 50\n"
+        state_file.write_text(untagged_entry, encoding="utf-8")
 
         result = _run_remove_legacy_retry_drain_cron(
             install_sh_no_main, install_dir, bin_dir, state_file
@@ -162,13 +166,13 @@ class TestRemoveLegacyRetryDrainCron:
         assert result.returncode == 0, result.stderr
 
         crontab_content = state_file.read_text(encoding="utf-8")
-        assert "/opt/legacy/process_retry_queue.py" not in crontab_content
+        assert "/opt/legacy/process_retry_queue.py" in crontab_content
 
     def test_preserves_unrelated_existing_crontab_entries(
         self, install_sh_no_main, fake_crontab_env, tmp_path
     ):
-        """Unrelated crontab entries are never touched — only the marker/legacy-script
-        lines are matched for removal."""
+        """Unrelated crontab entries are never touched — only the marker line is
+        matched for removal."""
         bin_dir, state_file = fake_crontab_env
         install_dir = tmp_path / "install_dir"
         install_dir.mkdir()

--- a/tests/test_install_retry_drain_cron.py
+++ b/tests/test_install_retry_drain_cron.py
@@ -1,14 +1,16 @@
-"""Install tests for the retry-queue drain cron job (TD-710).
+"""Install tests for retiring the retry-queue drain host cron (TD-710 → daemon migration).
 
-Before this fix, scripts/memory/process_retry_queue.py was invoked ONLY once, at
-install time (drain_pending_queue). There was no standing scheduler, so the
-failed-store queue accumulated append-only between installs (7-week, 203-item
-backlog observed in production).
+TD-710 originally had install.sh register a flock-guarded host cron entry (marker
+"# ai-memory-retry-drain") that ran process_retry_queue.py every 15 minutes. The
+standing scheduler has since moved to an in-stack daemon container
+(docker-compose.yml, owned separately), so install.sh must no longer install that
+cron — it must instead REMOVE any prior installation's tagged entry (or a legacy
+untagged process_retry_queue.py entry) so an upgrading operator doesn't end up with
+BOTH the old host cron and the new daemon draining the queue concurrently.
 
-setup_retry_drain_cron() registers a flock-guarded cron entry (marker
-"# ai-memory-retry-drain") that runs process_retry_queue.py every 15 minutes,
-mirroring the existing setup_jira_cron() pattern. Core safety property: re-running
-install must not duplicate the cron entry (idempotent by marker).
+remove_legacy_retry_drain_cron() is the migration function: idempotent, no-op on a
+fresh install or a host with no crontab, and it must never touch unrelated crontab
+entries — only lines matching the marker or the legacy script path.
 
 A fake `crontab` binary is placed on PATH so these tests never touch the real
 crontab of the machine running them.
@@ -68,7 +70,7 @@ def fake_crontab_env(tmp_path):
     """Fake `crontab` binary on PATH + the state file it reads/writes.
 
     Returns (bin_dir, state_file) so tests can prepend bin_dir to PATH and
-    inspect state_file's contents after calling setup_retry_drain_cron.
+    inspect state_file's contents after calling remove_legacy_retry_drain_cron.
     """
     bin_dir = tmp_path / "fakebin"
     bin_dir.mkdir()
@@ -79,165 +81,192 @@ def fake_crontab_env(tmp_path):
     return bin_dir, state_file
 
 
-def _run_setup_retry_drain_cron(
+def _run_remove_legacy_retry_drain_cron(
     install_sh_copy: Path,
     install_dir: Path,
     bin_dir: Path,
     state_file: Path,
-    platform: str = "linux",
 ) -> subprocess.CompletedProcess:
-    """Source install.sh (no-main copy) and call setup_retry_drain_cron with a fake crontab."""
+    """Source install.sh (no-main copy) and call remove_legacy_retry_drain_cron
+    with a fake crontab."""
     bash_cmd = f"""
 set -euo pipefail
 export PATH="{bin_dir}:$PATH"
 export FAKE_CRONTAB_FILE="{state_file}"
 export INSTALL_DIR="{install_dir}"
-export PLATFORM="{platform}"
 source "{install_sh_copy}"
 INSTALL_DIR="{install_dir}"
-PLATFORM="{platform}"
-setup_retry_drain_cron
+remove_legacy_retry_drain_cron
 """
     return subprocess.run(["bash", "-c", bash_cmd], capture_output=True, text=True)
 
 
-class TestSetupRetryDrainCron:
-    def test_registers_entry_with_marker_and_schedule(
+class TestRemoveLegacyRetryDrainCron:
+    def test_fresh_install_no_crontab_write(
         self, install_sh_no_main, fake_crontab_env, tmp_path
     ):
+        """No prior crontab at all (fake crontab -l exits 1, state_file absent) —
+        the function must be a pure no-op: no crontab write, state_file never
+        created."""
         bin_dir, state_file = fake_crontab_env
         install_dir = tmp_path / "install_dir"
         install_dir.mkdir()
 
-        result = _run_setup_retry_drain_cron(
+        result = _run_remove_legacy_retry_drain_cron(
             install_sh_no_main, install_dir, bin_dir, state_file
         )
         assert (
             result.returncode == 0
-        ), f"setup_retry_drain_cron failed:\n{result.stderr}"
-
-        crontab_content = state_file.read_text(encoding="utf-8")
-        matching = [
-            line
-            for line in crontab_content.splitlines()
-            if "ai-memory-retry-drain" in line
-        ]
-        assert len(matching) == 1, f"expected exactly one entry, got: {matching}"
-        entry = matching[0]
-        assert entry.startswith("*/15 * * * *"), entry
-        assert "process_retry_queue.py" in entry
-        assert "--limit 500" in entry  # raised above the 100 default so backlog clears
-        assert f"{install_dir}/.locks/retry_drain.lock" in entry
-        assert "flock -n" in entry
-        assert f">> {install_dir}/logs/retry_drain.log 2>&1" in entry
-
-    def test_locks_dir_created(self, install_sh_no_main, fake_crontab_env, tmp_path):
-        bin_dir, state_file = fake_crontab_env
-        install_dir = tmp_path / "install_dir"
-        install_dir.mkdir()
-
-        _run_setup_retry_drain_cron(
-            install_sh_no_main, install_dir, bin_dir, state_file
-        )
-        assert (install_dir / ".locks").is_dir()
-
-    def test_idempotent_no_duplicate_on_second_run(
-        self, install_sh_no_main, fake_crontab_env, tmp_path
-    ):
-        bin_dir, state_file = fake_crontab_env
-        install_dir = tmp_path / "install_dir"
-        install_dir.mkdir()
-
-        first = _run_setup_retry_drain_cron(
-            install_sh_no_main, install_dir, bin_dir, state_file
-        )
-        assert first.returncode == 0, first.stderr
-
-        second = _run_setup_retry_drain_cron(
-            install_sh_no_main, install_dir, bin_dir, state_file
-        )
-        assert second.returncode == 0, second.stderr
-
-        crontab_content = state_file.read_text(encoding="utf-8")
-        matching = [
-            line
-            for line in crontab_content.splitlines()
-            if "ai-memory-retry-drain" in line
-        ]
+        ), f"remove_legacy_retry_drain_cron failed:\n{result.stderr}"
         assert (
-            len(matching) == 1
-        ), f"re-running install must not duplicate the cron entry, got: {matching}"
+            not state_file.exists()
+        ), "Fresh install with no crontab must not create one"
 
-    def test_preserves_unrelated_existing_crontab_entries(
+    def test_removes_marked_legacy_entry(
         self, install_sh_no_main, fake_crontab_env, tmp_path
     ):
+        """A pre-existing tagged entry (marker "# ai-memory-retry-drain") is removed."""
         bin_dir, state_file = fake_crontab_env
         install_dir = tmp_path / "install_dir"
         install_dir.mkdir()
-        state_file.write_text("0 0 * * * /usr/bin/some-other-job\n", encoding="utf-8")
+        legacy_entry = (
+            "*/15 * * * * flock -n /tmp/.locks/retry_drain.lock "
+            "/tmp/.venv/bin/python /tmp/scripts/memory/process_retry_queue.py "
+            "--limit 500 >> /tmp/logs/retry_drain.log 2>&1 # ai-memory-retry-drain\n"
+        )
+        state_file.write_text(legacy_entry, encoding="utf-8")
 
-        result = _run_setup_retry_drain_cron(
+        result = _run_remove_legacy_retry_drain_cron(
             install_sh_no_main, install_dir, bin_dir, state_file
         )
         assert result.returncode == 0, result.stderr
 
         crontab_content = state_file.read_text(encoding="utf-8")
-        assert "/usr/bin/some-other-job" in crontab_content
-        matching = [
-            line
-            for line in crontab_content.splitlines()
-            if "ai-memory-retry-drain" in line
-        ]
-        assert len(matching) == 1
+        assert "ai-memory-retry-drain" not in crontab_content
+        assert "process_retry_queue.py" not in crontab_content
 
-    def test_legacy_untagged_entry_is_replaced_not_duplicated(
+    def test_removes_legacy_untagged_entry(
         self, install_sh_no_main, fake_crontab_env, tmp_path
     ):
-        """A pre-TD-710 crontab entry that calls process_retry_queue.py but lacks the
-        "# ai-memory-retry-drain" marker must be replaced by the new tagged entry, not
-        left in place alongside it (the filter greps both the marker and the script name).
-        """
+        """A pre-TD-710 untagged entry (process_retry_queue.py, no marker) is also
+        removed — the migration must not leave a pre-marker cron installation behind."""
         bin_dir, state_file = fake_crontab_env
         install_dir = tmp_path / "install_dir"
         install_dir.mkdir()
         legacy_entry = "*/30 * * * * /usr/bin/python3 /opt/legacy/process_retry_queue.py --limit 50\n"
         state_file.write_text(legacy_entry, encoding="utf-8")
 
-        result = _run_setup_retry_drain_cron(
+        result = _run_remove_legacy_retry_drain_cron(
             install_sh_no_main, install_dir, bin_dir, state_file
         )
         assert result.returncode == 0, result.stderr
 
         crontab_content = state_file.read_text(encoding="utf-8")
         assert "/opt/legacy/process_retry_queue.py" not in crontab_content
-        matching = [
-            line
-            for line in crontab_content.splitlines()
-            if "process_retry_queue.py" in line
-        ]
-        assert (
-            len(matching) == 1
-        ), f"legacy untagged entry must be replaced not duplicated, got: {matching}"
-        assert "ai-memory-retry-drain" in matching[0]
 
-    def test_macos_platform_omits_flock(
+    def test_preserves_unrelated_existing_crontab_entries(
         self, install_sh_no_main, fake_crontab_env, tmp_path
     ):
+        """Unrelated crontab entries are never touched — only the marker/legacy-script
+        lines are matched for removal."""
         bin_dir, state_file = fake_crontab_env
         install_dir = tmp_path / "install_dir"
         install_dir.mkdir()
+        state_file.write_text(
+            "0 0 * * * /usr/bin/some-other-job\n"
+            "*/15 * * * * /usr/bin/python3 /opt/process_retry_queue.py # ai-memory-retry-drain\n",
+            encoding="utf-8",
+        )
 
-        result = _run_setup_retry_drain_cron(
-            install_sh_no_main, install_dir, bin_dir, state_file, platform="macos"
+        result = _run_remove_legacy_retry_drain_cron(
+            install_sh_no_main, install_dir, bin_dir, state_file
         )
         assert result.returncode == 0, result.stderr
 
         crontab_content = state_file.read_text(encoding="utf-8")
-        matching = [
+        assert "/usr/bin/some-other-job" in crontab_content
+        assert "ai-memory-retry-drain" not in crontab_content
+        assert "process_retry_queue.py" not in crontab_content
+
+    def test_idempotent_second_run_is_noop(
+        self, install_sh_no_main, fake_crontab_env, tmp_path
+    ):
+        """Re-running after the legacy entry is already removed makes no further
+        crontab write and leaves the (now-clean) crontab unchanged."""
+        bin_dir, state_file = fake_crontab_env
+        install_dir = tmp_path / "install_dir"
+        install_dir.mkdir()
+        state_file.write_text(
+            "*/15 * * * * /usr/bin/python3 /opt/process_retry_queue.py # ai-memory-retry-drain\n"
+            "0 0 * * * /usr/bin/some-other-job\n",
+            encoding="utf-8",
+        )
+
+        first = _run_remove_legacy_retry_drain_cron(
+            install_sh_no_main, install_dir, bin_dir, state_file
+        )
+        assert first.returncode == 0, first.stderr
+        after_first = state_file.read_text(encoding="utf-8")
+        assert "ai-memory-retry-drain" not in after_first
+        assert "/usr/bin/some-other-job" in after_first
+
+        second = _run_remove_legacy_retry_drain_cron(
+            install_sh_no_main, install_dir, bin_dir, state_file
+        )
+        assert second.returncode == 0, second.stderr
+        after_second = state_file.read_text(encoding="utf-8")
+        assert after_second == after_first, (
+            "Second run must be a no-op once the legacy entry is already gone "
+            f"— before: {after_first!r} after: {after_second!r}"
+        )
+
+    def test_noop_when_crontab_binary_unavailable(self, install_sh_no_main, tmp_path):
+        """On a host with no `crontab` binary at all (e.g. a minimal container),
+        the function must exit 0 without attempting to invoke crontab."""
+        install_dir = tmp_path / "install_dir"
+        install_dir.mkdir()
+        empty_path_dir = tmp_path / "empty_path_dir"
+        empty_path_dir.mkdir()
+        bash_cmd = f"""
+set -euo pipefail
+export INSTALL_DIR="{install_dir}"
+source "{install_sh_no_main}"
+INSTALL_DIR="{install_dir}"
+export PATH="{empty_path_dir}"
+remove_legacy_retry_drain_cron
+echo "REACHED_END"
+"""
+        result = subprocess.run(
+            ["bash", "-c", bash_cmd], capture_output=True, text=True
+        )
+        assert result.returncode == 0, result.stderr
+        assert "REACHED_END" in result.stdout
+
+    def test_no_cron_installing_function_defined(self):
+        """Structural regression guard: install.sh must not define a
+        setup_retry_drain_cron function (the pre-migration cron-INSTALLING
+        symbol) — only the removal function remove_legacy_retry_drain_cron."""
+        text = _INSTALL_SH.read_text()
+        assert "setup_retry_drain_cron()" not in text, (
+            "install.sh must not define setup_retry_drain_cron() — the standing "
+            "retry-drain scheduler moved to an in-stack daemon; install.sh should "
+            "only remove a legacy host cron, not install one."
+        )
+        assert (
+            "remove_legacy_retry_drain_cron() {" in text
+        ), "remove_legacy_retry_drain_cron() function definition not found"
+
+    def test_removal_function_called_from_main(self):
+        """Structural regression guard: remove_legacy_retry_drain_cron must
+        actually be called from main() — a defined-but-unreachable function
+        would silently never clean up an operator's legacy cron."""
+        text = _INSTALL_SH.read_text()
+        call_sites = [
             line
-            for line in crontab_content.splitlines()
-            if "ai-memory-retry-drain" in line
+            for line in text.splitlines()
+            if line.strip() == "remove_legacy_retry_drain_cron"
         ]
-        assert len(matching) == 1
-        assert "flock" not in matching[0]
-        assert "process_retry_queue.py" in matching[0]
+        assert call_sites, (
+            "remove_legacy_retry_drain_cron is defined but never called — "
+            "it must be invoked from main()'s full-install branch."
+        )


### PR DESCRIPTION
## What

- **Config reuse on reinstall.** Reinstalling over an existing install now reuses previously-configured GitHub / Jira / Langfuse / monitoring settings from the persisted env files instead of re-prompting for all of them. JSON-valued settings (the Jira project list) are preserved exactly.
- **Compose env parity.** Delivers the embedding-timeout tunables to the evaluator-scheduler service (they previously reached only the classifier worker), adds an effective-env-subset check across the baked services, and pins the container-internal Qdrant host/port on evaluator-scheduler.
- **Retire the retry-drain host cron.** Superseded by the in-stack daemon in the companion retry-queue PR: new installs no longer create it, and any existing tagged entry is removed idempotently.

## Why

A full reinstall re-prompted for every previously-configured value — a footgun where one skipped prompt could silently disable a live sync, and could corrupt the persisted Jira project list. Separately, an embedding tunable reached one service but not its sibling — a silent per-service divergence.

## Notes

- Depends on the companion retry-queue PR (`fix/retry-durability`) landing **first**, since this PR removes the host cron the daemon replaces.
- Refs BUG-520, TD-773, TD-774.
