### PR TITLE
Add embedding capacity/soak measurement harness (PLAN-030 Phase 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ test-results/
 screenshots/
 queue/*.jsonl
 
+# Embedding capacity/soak harness output (PLAN-030 Phase 2, BP-179)
+scripts/perf/results/
+
 # Migration backups (may contain secrets)
 migration-backup*/
 scripts/_migration_state.json

--- a/scripts/perf/embedding_capacity/cgroup.py
+++ b/scripts/perf/embedding_capacity/cgroup.py
@@ -12,10 +12,12 @@ from __future__ import annotations
 
 import re
 import subprocess
+import threading
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 DEFAULT_CGROUP_ROOT = "/sys/fs/cgroup"
+DEFAULT_POLL_INTERVAL_SECONDS = 0.05
 
 ExecFn = Callable[..., str]
 
@@ -80,10 +82,30 @@ class DockerCgroupReader:
         return self._read_maybe_int("memory.max")
 
     def reset_peak(self) -> None:
-        """Reset memory.peak to the current value (Linux >= 5.19, BP-179 §2)."""
+        """Reset memory.peak to the current value.
+
+        Requires Linux >= 6.8 AND a writable cgroup mount (BP-179 §2, corrected
+        PM #387) — reading memory.peak alone only needs >= 5.19. Raises
+        CgroupAccessError if the reset is unsupported (e.g. a read-only cgroup
+        FS, as verified on the WSL2 6.6 target); callers needing a fallback
+        should use `try_reset_peak()` instead of calling this directly.
+        """
         self.exec_fn(
             self.container, "sh", "-c", f"echo 0 > {self._path('memory.peak')}"
         )
+
+    def try_reset_peak(self) -> bool:
+        """Attempt `reset_peak()`, returning False instead of raising if unsupported.
+
+        Use this to decide between the memory.peak-reset burst measurement and
+        the dense-poll `memory.current` fallback (BP-179 §2 corrected). A True
+        return means memory.peak has already been reset as a side effect.
+        """
+        try:
+            self.reset_peak()
+        except CgroupAccessError:
+            return False
+        return True
 
     def read_events(self) -> dict[str, int]:
         raw = self.exec_fn(self.container, "cat", self._path("memory.events"))
@@ -109,23 +131,99 @@ class DockerCgroupReader:
             raise CgroupAccessError(f"unparseable {name}: {raw!r}") from e
 
 
+@dataclass
+class PeakPoller:
+    """Background dense-poll of memory.current — the burst-peak fallback when
+    memory.peak reset is unsupported (BP-179 §2 corrected: kernel < 6.8 or a
+    read-only cgroup mount, verified true on the WSL2 6.6.114 target).
+
+    Runs `reader.read_current()` on a poll thread (docker exec is blocking)
+    every `interval_seconds` and tracks the max observed, so it can run
+    alongside an async burst without blocking the event loop. Call `start()`
+    before driving load, `stop()` after — `stop()` returns the observed max.
+    """
+
+    reader: DockerCgroupReader
+    interval_seconds: float = DEFAULT_POLL_INTERVAL_SECONDS
+    _max_seen: int = field(default=0, init=False)
+    _stop_event: threading.Event = field(default_factory=threading.Event, init=False)
+    _thread: threading.Thread | None = field(default=None, init=False)
+
+    def start(self) -> None:
+        self._max_seen = self.reader.read_current()
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._poll_loop, daemon=True)
+        self._thread.start()
+
+    def _poll_loop(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                current = self.reader.read_current()
+            except CgroupAccessError:
+                break
+            self._max_seen = max(self._max_seen, current)
+            self._stop_event.wait(self.interval_seconds)
+
+    def stop(self) -> int:
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self.interval_seconds + 5)
+        return self._max_seen
+
+
 _DMESG_OOM_PATTERN = re.compile(r"Out of memory|Killed process", re.IGNORECASE)
+_DMESG_TIMESTAMP_PATTERN = re.compile(r"^\[\s*(\d+\.\d+)\]")
 
 
-def scan_dmesg_oom(process_pattern: str = "embed|onnx|python") -> list[str]:
+def _parse_dmesg_timestamp(line: str) -> float | None:
+    match = _DMESG_TIMESTAMP_PATTERN.match(line)
+    return float(match.group(1)) if match else None
+
+
+def dmesg_baseline() -> float:
+    """Pre-flight dmesg readability check + baseline kernel timestamp.
+
+    Call this at the START of a soak (not hours in) so a permission problem
+    surfaces immediately, and pass the returned timestamp to `scan_dmesg_oom`
+    as `since_timestamp` so stale prior-run kills in the ring buffer aren't
+    re-reported as this run's failures (BP-179 §3 corrected). Raises
+    CgroupAccessError if dmesg cannot be read.
+    """
+    result = subprocess.run(["dmesg"], capture_output=True, text=True, timeout=10)
+    if result.returncode != 0:
+        raise CgroupAccessError(f"dmesg failed: {result.stderr.strip()}")
+    timestamps = [
+        ts
+        for line in result.stdout.splitlines()
+        if (ts := _parse_dmesg_timestamp(line)) is not None
+    ]
+    return max(timestamps) if timestamps else 0.0
+
+
+def scan_dmesg_oom(
+    process_pattern: str = "embed|onnx|python", since_timestamp: float = 0.0
+) -> list[str]:
     """Return dmesg lines showing an OOM-kill matching `process_pattern`.
 
     Per BP-179 §3, dmesg is one of the two authoritative OOM signals (the other
-    is cgroup memory.events:oom_kill). Raises CgroupAccessError if dmesg cannot
-    be read (e.g. permission denied) — callers must surface this per the
-    BLOCKER PROTOCOL rather than silently treating it as zero kills.
+    is cgroup memory.events:oom_kill). `since_timestamp` (from `dmesg_baseline()`
+    taken before the run) excludes stale prior-run kills — the ring buffer
+    holds everything since boot, not just this run. A line whose timestamp
+    can't be parsed is kept (fail toward reporting, not silently dropping a
+    possible kill). Raises CgroupAccessError if dmesg cannot be read (e.g.
+    permission denied) — callers must surface this per the BLOCKER PROTOCOL
+    rather than silently treating it as zero kills.
     """
     result = subprocess.run(["dmesg"], capture_output=True, text=True, timeout=10)
     if result.returncode != 0:
         raise CgroupAccessError(f"dmesg failed: {result.stderr.strip()}")
     proc_re = re.compile(process_pattern, re.IGNORECASE)
-    return [
-        line
-        for line in result.stdout.splitlines()
-        if _DMESG_OOM_PATTERN.search(line) and proc_re.search(line)
-    ]
+    lines = []
+    for line in result.stdout.splitlines():
+        if not (_DMESG_OOM_PATTERN.search(line) and proc_re.search(line)):
+            continue
+        ts = _parse_dmesg_timestamp(line)
+        if ts is not None and ts <= since_timestamp:
+            continue
+        lines.append(line)
+    return lines

--- a/scripts/perf/embedding_capacity/cgroup.py
+++ b/scripts/perf/embedding_capacity/cgroup.py
@@ -148,10 +148,12 @@ class PeakPoller:
     _max_seen: int = field(default=0, init=False)
     _stop_event: threading.Event = field(default_factory=threading.Event, init=False)
     _thread: threading.Thread | None = field(default=None, init=False)
+    _poll_error: Exception | None = field(default=None, init=False)
 
     def start(self) -> None:
         self._max_seen = self.reader.read_current()
         self._stop_event.clear()
+        self._poll_error = None
         self._thread = threading.Thread(target=self._poll_loop, daemon=True)
         self._thread.start()
 
@@ -159,7 +161,17 @@ class PeakPoller:
         while not self._stop_event.is_set():
             try:
                 current = self.reader.read_current()
-            except CgroupAccessError:
+            except CgroupAccessError as e:
+                # Non-fatal (a long soak shouldn't abort on one transient
+                # docker exec hiccup) but must not be silent — the peak from
+                # this point on is a floor, not a true max, so callers need
+                # to see it (BLOCKER PROTOCOL: never guess a value quietly).
+                self._poll_error = e
+                print(
+                    f"WARNING: PeakPoller lost its docker exec read mid-poll "
+                    f"({e}) — peak reporting is degraded from here on (last "
+                    f"observed: {self._max_seen} bytes)"
+                )
                 break
             self._max_seen = max(self._max_seen, current)
             self._stop_event.wait(self.interval_seconds)
@@ -169,6 +181,11 @@ class PeakPoller:
         if self._thread is not None:
             self._thread.join(timeout=self.interval_seconds + 5)
         return self._max_seen
+
+    @property
+    def degraded(self) -> bool:
+        """True if the poll loop exited early on a docker exec read failure."""
+        return self._poll_error is not None
 
 
 _DMESG_OOM_PATTERN = re.compile(r"Out of memory|Killed process", re.IGNORECASE)

--- a/scripts/perf/embedding_capacity/cgroup.py
+++ b/scripts/perf/embedding_capacity/cgroup.py
@@ -1,0 +1,131 @@
+"""cgroup-v2 memory signal access for the embedding capacity harness (BP-179 §2/§3).
+
+Reads memory.current / memory.peak / memory.events / memory.max from inside the
+running embedding container via `docker exec`, and scans dmesg for OOM-kill lines.
+Per BP-179 §3, `memory.events:oom_kill` + dmesg are the ONLY authoritative OOM
+signals for the soak gate — the Docker OOMKilled flag and the app's own
+embedding_oom_events_total gauge are blind to worker-level kills and must never
+be used to certify an envelope safe.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+
+DEFAULT_CGROUP_ROOT = "/sys/fs/cgroup"
+
+ExecFn = Callable[..., str]
+
+
+class CgroupAccessError(RuntimeError):
+    """Raised when a cgroup file or dmesg cannot be read from the harness context."""
+
+
+def _docker_exec(container: str, *cmd: str) -> str:
+    """Run a command inside `container` via `docker exec` and return stdout."""
+    result = subprocess.run(
+        ["docker", "exec", container, *cmd],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise CgroupAccessError(
+            f"docker exec {container} {' '.join(cmd)} failed "
+            f"(exit {result.returncode}): {result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def _parse_events(raw: str) -> dict[str, int]:
+    events: dict[str, int] = {}
+    for line in raw.splitlines():
+        parts = line.split()
+        if len(parts) == 2:
+            try:
+                events[parts[0]] = int(parts[1])
+            except ValueError:
+                continue
+    return events
+
+
+@dataclass
+class DockerCgroupReader:
+    """Reads cgroup-v2 memory files from inside a container.
+
+    `exec_fn` defaults to a real `docker exec` call; tests inject a stub that
+    returns canned output for a given command, so this class is fully
+    unit-testable without a live container (BLOCKER PROTOCOL: if the real
+    `exec_fn` raises CgroupAccessError against the live container, the harness
+    must stop and report — never guess a value).
+    """
+
+    container: str
+    cgroup_root: str = DEFAULT_CGROUP_ROOT
+    exec_fn: ExecFn = _docker_exec
+
+    def _path(self, name: str) -> str:
+        return f"{self.cgroup_root}/{name}"
+
+    def read_current(self) -> int:
+        return self._read_int("memory.current")
+
+    def read_peak(self) -> int:
+        return self._read_int("memory.peak")
+
+    def read_max(self) -> int | None:
+        return self._read_maybe_int("memory.max")
+
+    def reset_peak(self) -> None:
+        """Reset memory.peak to the current value (Linux >= 5.19, BP-179 §2)."""
+        self.exec_fn(
+            self.container, "sh", "-c", f"echo 0 > {self._path('memory.peak')}"
+        )
+
+    def read_events(self) -> dict[str, int]:
+        raw = self.exec_fn(self.container, "cat", self._path("memory.events"))
+        return _parse_events(raw)
+
+    def oom_kill_count(self) -> int:
+        return self.read_events().get("oom_kill", 0)
+
+    def _read_int(self, name: str) -> int:
+        raw = self.exec_fn(self.container, "cat", self._path(name)).strip()
+        try:
+            return int(raw)
+        except ValueError as e:
+            raise CgroupAccessError(f"non-integer {name}: {raw!r}") from e
+
+    def _read_maybe_int(self, name: str) -> int | None:
+        raw = self.exec_fn(self.container, "cat", self._path(name)).strip()
+        if raw == "max":
+            return None
+        try:
+            return int(raw)
+        except ValueError as e:
+            raise CgroupAccessError(f"unparseable {name}: {raw!r}") from e
+
+
+_DMESG_OOM_PATTERN = re.compile(r"Out of memory|Killed process", re.IGNORECASE)
+
+
+def scan_dmesg_oom(process_pattern: str = "embed|onnx|python") -> list[str]:
+    """Return dmesg lines showing an OOM-kill matching `process_pattern`.
+
+    Per BP-179 §3, dmesg is one of the two authoritative OOM signals (the other
+    is cgroup memory.events:oom_kill). Raises CgroupAccessError if dmesg cannot
+    be read (e.g. permission denied) — callers must surface this per the
+    BLOCKER PROTOCOL rather than silently treating it as zero kills.
+    """
+    result = subprocess.run(["dmesg"], capture_output=True, text=True, timeout=10)
+    if result.returncode != 0:
+        raise CgroupAccessError(f"dmesg failed: {result.stderr.strip()}")
+    proc_re = re.compile(process_pattern, re.IGNORECASE)
+    return [
+        line
+        for line in result.stdout.splitlines()
+        if _DMESG_OOM_PATTERN.search(line) and proc_re.search(line)
+    ]

--- a/scripts/perf/embedding_capacity/envelope.py
+++ b/scripts/perf/embedding_capacity/envelope.py
@@ -1,0 +1,88 @@
+"""Joint memory-envelope sizing math (BP-179 §0/§1).
+
+    peak_mem ~= base_rss + (max_concurrency x per_request_burst_peak)
+
+The safe envelope is any (mem_limit, max_concurrency) pair satisfying:
+
+    base_rss + max_concurrency x per_request_burst_peak + safety_margin <= mem_limit
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+def per_request_burst_peak(
+    peak_bytes: int, base_bytes: int, n_concurrent: int
+) -> float:
+    """(peak - base) / N — BP-179 §2. `n_concurrent` must be >= 1."""
+    if n_concurrent < 1:
+        raise ValueError("n_concurrent must be >= 1")
+    return (peak_bytes - base_bytes) / n_concurrent
+
+
+def projected_peak(
+    base_rss: float, max_concurrency: int, per_request_peak: float
+) -> float:
+    """base + max_concurrency x per_req_peak — the joint envelope model (BP-179 §1)."""
+    return base_rss + max_concurrency * per_request_peak
+
+
+def required_mem_limit(
+    base_rss: float,
+    per_request_peak: float,
+    max_concurrency: int,
+    safety_margin_ratio: float = 0.15,
+) -> int:
+    """Smallest mem_limit satisfying the envelope for a target concurrency ceiling."""
+    projected = projected_peak(base_rss, max_concurrency, per_request_peak)
+    return round(projected * (1 + safety_margin_ratio))
+
+
+def max_concurrency_for_limit(
+    base_rss: float,
+    per_request_peak: float,
+    mem_limit: float,
+    safety_margin_ratio: float = 0.15,
+) -> int:
+    """Largest max_concurrency that fits `mem_limit` with the safety margin, floored at 1."""
+    if per_request_peak <= 0:
+        raise ValueError("per_request_peak must be > 0")
+    budget = mem_limit / (1 + safety_margin_ratio) - base_rss
+    concurrency = int(budget // per_request_peak)
+    return max(1, concurrency)
+
+
+@dataclass
+class EnvelopeCandidate:
+    max_concurrency: int
+    mem_limit_bytes: int
+    projected_peak_bytes: float
+    safety_margin_ratio: float
+
+
+def recommend_envelope(
+    base_rss: float,
+    per_request_peak: float,
+    safety_margin_ratio: float = 0.15,
+    candidate_concurrencies: range = range(1, 9),
+) -> list[EnvelopeCandidate]:
+    """A table of joint (mem_limit, max_concurrency) candidates, one per concurrency level.
+
+    Callers pick the row matching their throughput/RAM tradeoff, per BP-179 §1's
+    three levers in preference order: lower concurrency, lower per-request peak,
+    then raise mem_limit.
+    """
+    return [
+        EnvelopeCandidate(
+            max_concurrency=concurrency,
+            mem_limit_bytes=required_mem_limit(
+                base_rss, per_request_peak, concurrency, safety_margin_ratio
+            ),
+            projected_peak_bytes=projected_peak(
+                base_rss, concurrency, per_request_peak
+            ),
+            safety_margin_ratio=safety_margin_ratio,
+        )
+        for concurrency in candidate_concurrencies
+    ]

--- a/scripts/perf/embedding_capacity/envelope.py
+++ b/scripts/perf/embedding_capacity/envelope.py
@@ -39,20 +39,6 @@ def required_mem_limit(
     return round(projected * (1 + safety_margin_ratio))
 
 
-def max_concurrency_for_limit(
-    base_rss: float,
-    per_request_peak: float,
-    mem_limit: float,
-    safety_margin_ratio: float = 0.15,
-) -> int:
-    """Largest max_concurrency that fits `mem_limit` with the safety margin, floored at 1."""
-    if per_request_peak <= 0:
-        raise ValueError("per_request_peak must be > 0")
-    budget = mem_limit / (1 + safety_margin_ratio) - base_rss
-    concurrency = int(budget // per_request_peak)
-    return max(1, concurrency)
-
-
 @dataclass
 class EnvelopeCandidate:
     max_concurrency: int

--- a/scripts/perf/embedding_capacity/gate.py
+++ b/scripts/perf/embedding_capacity/gate.py
@@ -18,12 +18,73 @@ class CriterionResult:
 
 
 @dataclass
+class LoadValidity:
+    valid: bool
+    detail: str
+
+
+def evaluate_load_validity(
+    *,
+    total_requests: int,
+    total_failures: int,
+    memory_peak_bytes: int,
+    base_rss_bytes: int,
+    min_success_ratio: float = 0.5,
+    min_peak_above_base_ratio: float = 0.02,
+) -> LoadValidity:
+    """Guard against certifying a run whose load never actually landed.
+
+    BP-179 §4's trap: an all-503 / wrong-port / not-ready run goes flat and
+    would otherwise pass every gate criterion (oom==0, shed==0, etc. all
+    trivially hold when nothing happened). Requires both a success-ratio floor
+    and memory.peak meaningfully above base_rss.
+    """
+    if total_requests == 0:
+        return LoadValidity(False, "no requests were sent")
+
+    success_ratio = 1 - (total_failures / total_requests)
+    if success_ratio < min_success_ratio:
+        return LoadValidity(
+            False,
+            f"success_ratio={success_ratio:.2%} below min={min_success_ratio:.2%} "
+            f"({total_failures}/{total_requests} requests failed) — load may not "
+            "have landed",
+        )
+
+    peak_above_base = memory_peak_bytes - base_rss_bytes
+    min_peak_above_base = base_rss_bytes * min_peak_above_base_ratio
+    if peak_above_base < min_peak_above_base:
+        return LoadValidity(
+            False,
+            f"memory.peak rose {peak_above_base}B above base_rss "
+            f"(min required {min_peak_above_base:.0f}B) — burst may not have "
+            "landed",
+        )
+
+    return LoadValidity(True, "load validity checks passed")
+
+
+@dataclass
 class GateResult:
     criteria: list[CriterionResult] = field(default_factory=list)
+    load_valid: bool = True
+    load_validity_detail: str = ""
 
     @property
     def passed(self) -> bool:
-        return bool(self.criteria) and all(c.passed for c in self.criteria)
+        return (
+            self.load_valid
+            and bool(self.criteria)
+            and all(c.passed for c in self.criteria)
+        )
+
+    @property
+    def outcome(self) -> str:
+        """PASS | FAIL | INVALID — INVALID means the load never landed, so the
+        other 6 criteria's trivial passes don't certify anything (BP-179 §4)."""
+        if not self.load_valid:
+            return "INVALID"
+        return "PASS" if self.passed else "FAIL"
 
     def add(self, name: str, passed: bool, detail: str) -> None:
         self.criteria.append(CriterionResult(name, passed, detail))
@@ -41,9 +102,27 @@ def evaluate_gate(
     leak_tolerance_ratio: float,
     memory_peak_bytes: int,
     mem_limit_bytes: int,
+    total_requests: int,
+    total_failures: int,
+    base_rss_bytes: int,
+    min_success_ratio: float = 0.5,
+    min_peak_above_base_ratio: float = 0.02,
 ) -> GateResult:
-    """Evaluate all 6 BP-179 §4 pass/fail criteria; the gate passes only if all pass."""
-    gate = GateResult()
+    """Evaluate all 6 BP-179 §4 pass/fail criteria plus the load-validity guard.
+
+    The gate only PASSes if the load-validity guard holds AND all 6 criteria
+    pass; if the guard fails, the outcome is the distinct INVALID (not PASS
+    or FAIL) — the run didn't prove anything either way.
+    """
+    validity = evaluate_load_validity(
+        total_requests=total_requests,
+        total_failures=total_failures,
+        memory_peak_bytes=memory_peak_bytes,
+        base_rss_bytes=base_rss_bytes,
+        min_success_ratio=min_success_ratio,
+        min_peak_above_base_ratio=min_peak_above_base_ratio,
+    )
+    gate = GateResult(load_valid=validity.valid, load_validity_detail=validity.detail)
 
     gate.add(
         "oom_kill_delta_zero",

--- a/scripts/perf/embedding_capacity/gate.py
+++ b/scripts/perf/embedding_capacity/gate.py
@@ -1,0 +1,92 @@
+"""Soak pass/fail gate — BP-179 §4, assert ALL six criteria.
+
+The OOM signal is cgroup `memory.events:oom_kill` + dmesg ONLY (BP-179 §3/§5) —
+never the Docker `OOMKilled` flag or the app's own `oom_events_total` gauge,
+both of which are blind to a killed worker/child process.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class CriterionResult:
+    name: str
+    passed: bool
+    detail: str
+
+
+@dataclass
+class GateResult:
+    criteria: list[CriterionResult] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        return bool(self.criteria) and all(c.passed for c in self.criteria)
+
+    def add(self, name: str, passed: bool, detail: str) -> None:
+        self.criteria.append(CriterionResult(name, passed, detail))
+
+
+def evaluate_gate(
+    *,
+    oom_kill_delta: int,
+    dmesg_oom_count: int,
+    shed_delta: float,
+    admission_wait_p95_seconds: float | None,
+    client_read_timeout_seconds: float,
+    working_set_start_bytes: int,
+    working_set_end_bytes: int,
+    leak_tolerance_ratio: float,
+    memory_peak_bytes: int,
+    mem_limit_bytes: int,
+) -> GateResult:
+    """Evaluate all 6 BP-179 §4 pass/fail criteria; the gate passes only if all pass."""
+    gate = GateResult()
+
+    gate.add(
+        "oom_kill_delta_zero",
+        oom_kill_delta == 0,
+        f"memory.events:oom_kill delta={oom_kill_delta} (must be 0)",
+    )
+    gate.add(
+        "dmesg_oom_zero",
+        dmesg_oom_count == 0,
+        f"dmesg OOM-kill lines={dmesg_oom_count} (must be 0)",
+    )
+    gate.add(
+        "backpressure_shed_zero",
+        shed_delta == 0,
+        f"embedding_backpressure_total{{action='shed'}} delta={shed_delta} (must be 0)",
+    )
+
+    if admission_wait_p95_seconds is None:
+        gate.add(
+            "admission_wait_p95_within_timeout",
+            False,
+            "admission_wait p95 unavailable (no samples) — cannot certify",
+        )
+    else:
+        gate.add(
+            "admission_wait_p95_within_timeout",
+            admission_wait_p95_seconds <= client_read_timeout_seconds,
+            f"p95={admission_wait_p95_seconds:.3f}s vs "
+            f"read_timeout={client_read_timeout_seconds:.3f}s",
+        )
+
+    leak_threshold = working_set_start_bytes * (1 + leak_tolerance_ratio)
+    gate.add(
+        "no_working_set_climb",
+        working_set_end_bytes <= leak_threshold,
+        f"end={working_set_end_bytes}B vs start={working_set_start_bytes}B "
+        f"(threshold={leak_threshold:.0f}B, tolerance={leak_tolerance_ratio:.0%})",
+    )
+
+    gate.add(
+        "peak_under_mem_limit",
+        memory_peak_bytes < mem_limit_bytes,
+        f"memory.peak={memory_peak_bytes}B vs mem_limit={mem_limit_bytes}B",
+    )
+
+    return gate

--- a/scripts/perf/embedding_capacity/load.py
+++ b/scripts/perf/embedding_capacity/load.py
@@ -1,0 +1,125 @@
+"""Async load generation against the embedding service (BP-179 §4).
+
+Two shapes:
+  - `run_burst`: N request batches fired concurrently (all submitted before any
+    completes) — the measure mode's + capacity-ramp mode's input.
+  - `run_soak_callers`: genuine multi-caller sustained load — independent async
+    "callers" (each modelling a distinct project/client) looping bursts with
+    jitter for a duration, exercising the AIMD self-throttle the way arbitrary-N
+    real callers do (BP-179 §4, point 4).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+import httpx
+
+
+@dataclass
+class RequestResult:
+    status_code: int
+    elapsed_seconds: float
+    error: str | None = None
+
+
+async def _post_embed(
+    client: httpx.AsyncClient, base_url: str, texts: list[str], model: str
+) -> RequestResult:
+    start = time.monotonic()
+    try:
+        response = await client.post(
+            f"{base_url.rstrip('/')}/embed/dense",
+            json={"texts": texts, "model": model},
+        )
+        return RequestResult(response.status_code, time.monotonic() - start)
+    except httpx.HTTPError as e:
+        return RequestResult(0, time.monotonic() - start, error=str(e))
+
+
+async def run_burst(
+    base_url: str,
+    requests: list[list[str]],
+    model: str = "en",
+    timeout: float = 60.0,
+    client: httpx.AsyncClient | None = None,
+) -> list[RequestResult]:
+    """Fire all `requests` (one text-batch each) concurrently; wait for all to finish.
+
+    This is the N-concurrent burst BP-179 §2 requires for measuring
+    per_request_burst_peak: every request is submitted before any completes.
+    """
+    owns_client = client is None
+    client = client or httpx.AsyncClient(timeout=timeout)
+    try:
+        return list(
+            await asyncio.gather(
+                *(_post_embed(client, base_url, texts, model) for texts in requests)
+            )
+        )
+    finally:
+        if owns_client:
+            await client.aclose()
+
+
+@dataclass
+class CallerStats:
+    caller_id: int
+    requests_sent: int = 0
+    results: list[RequestResult] = field(default_factory=list)
+
+
+async def _caller_loop(
+    caller_id: int,
+    base_url: str,
+    payload_fn: Callable[[], list[str]],
+    model: str,
+    stop_at: float,
+    client: httpx.AsyncClient,
+    jitter_seconds: tuple[float, float],
+) -> CallerStats:
+    stats = CallerStats(caller_id=caller_id)
+    rng = random.Random(caller_id)
+    while time.monotonic() < stop_at:
+        texts = payload_fn()
+        result = await _post_embed(client, base_url, texts, model)
+        stats.requests_sent += 1
+        stats.results.append(result)
+        await asyncio.sleep(rng.uniform(*jitter_seconds))
+    return stats
+
+
+async def run_soak_callers(
+    base_url: str,
+    n_callers: int,
+    duration_seconds: float,
+    payload_fn: Callable[[], list[str]],
+    model: str = "en",
+    timeout: float = 60.0,
+    jitter_seconds: tuple[float, float] = (0.05, 0.5),
+    transport: httpx.BaseTransport | None = None,
+) -> list[CallerStats]:
+    """Run `n_callers` independent async callers concurrently for `duration_seconds`.
+
+    Each caller is its own loop with jittered inter-request timing — genuine
+    multi-caller concurrency (BP-179 §4), not one serialized loop. `n_callers`
+    should be set >= the envelope's concurrency ceiling plus waiters so the
+    backpressure queue is genuinely exercised. `transport` lets tests inject an
+    `httpx.MockTransport` so this runs fully offline.
+    """
+    stop_at = time.monotonic() + duration_seconds
+    async with httpx.AsyncClient(timeout=timeout, transport=transport) as client:
+        return list(
+            await asyncio.gather(
+                *(
+                    _caller_loop(
+                        i, base_url, payload_fn, model, stop_at, client, jitter_seconds
+                    )
+                    for i in range(n_callers)
+                )
+            )
+        )

--- a/scripts/perf/embedding_capacity/metrics_client.py
+++ b/scripts/perf/embedding_capacity/metrics_client.py
@@ -1,0 +1,94 @@
+"""Prometheus /metrics scraping + parsing for the embedding capacity harness.
+
+Parses the raw exposition text the embedding service's own `/metrics` endpoint
+returns (BP-179 §6): `embedding_backpressure_total{action}`,
+`embedding_effective_concurrency_limit`, and the `embedding_admission_wait_seconds`
+histogram. Matches on each sample's own name rather than its family name — the
+service's Counter/Histogram collectors are registered under a base name (e.g.
+"embedding_backpressure") while their exposed samples carry the OpenMetrics
+suffix ("embedding_backpressure_total"), which the parser surfaces as separate,
+mismatched families. Working from sample names is robust to that and requires
+no live service to test.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import httpx
+from prometheus_client.parser import text_string_to_metric_families
+
+
+@dataclass
+class MetricsSnapshot:
+    backpressure: dict[str, float]  # action -> counter value
+    effective_concurrency_limit: float | None
+    admission_wait_p95_seconds: float | None
+    admission_wait_count: float
+    admission_wait_sum: float
+
+
+def fetch_metrics_text(base_url: str, timeout: float = 10.0) -> str:
+    response = httpx.get(f"{base_url.rstrip('/')}/metrics", timeout=timeout)
+    response.raise_for_status()
+    return response.text
+
+
+def parse_metrics(text: str) -> MetricsSnapshot:
+    backpressure: dict[str, float] = {}
+    effective_limit: float | None = None
+    hist_buckets: dict[float, float] = {}
+    hist_count = 0.0
+    hist_sum = 0.0
+
+    for family in text_string_to_metric_families(text):
+        for sample in family.samples:
+            if sample.name == "embedding_backpressure_total":
+                action = sample.labels.get("action", "unknown")
+                backpressure[action] = sample.value
+            elif sample.name == "embedding_effective_concurrency_limit":
+                effective_limit = sample.value
+            elif sample.name == "embedding_admission_wait_seconds_bucket":
+                le = sample.labels.get("le")
+                if le is not None:
+                    hist_buckets[float(le)] = sample.value
+            elif sample.name == "embedding_admission_wait_seconds_count":
+                hist_count = sample.value
+            elif sample.name == "embedding_admission_wait_seconds_sum":
+                hist_sum = sample.value
+
+    p95 = _histogram_quantile(hist_buckets, hist_count, 0.95) if hist_buckets else None
+
+    return MetricsSnapshot(
+        backpressure=backpressure,
+        effective_concurrency_limit=effective_limit,
+        admission_wait_p95_seconds=p95,
+        admission_wait_count=hist_count,
+        admission_wait_sum=hist_sum,
+    )
+
+
+def _histogram_quantile(
+    buckets: dict[float, float], total_count: float, q: float
+) -> float | None:
+    """Linear-interpolation histogram quantile (the PromQL histogram_quantile algorithm).
+
+    `buckets` maps upper bound `le` -> cumulative count. Returns None if there is
+    no data or the target quantile falls beyond the highest finite bucket.
+    """
+    if total_count <= 0:
+        return None
+    target = q * total_count
+    sorted_bounds = sorted(b for b in buckets if not math.isinf(b))
+    prev_bound = 0.0
+    prev_count = 0.0
+    for bound in sorted_bounds:
+        count = buckets[bound]
+        if count >= target:
+            if count == prev_count:
+                return bound
+            fraction = (target - prev_count) / (count - prev_count)
+            return prev_bound + fraction * (bound - prev_bound)
+        prev_bound, prev_count = bound, count
+    return None

--- a/scripts/perf/embedding_capacity/payloads.py
+++ b/scripts/perf/embedding_capacity/payloads.py
@@ -1,0 +1,90 @@
+"""Realistic payload generation for the embedding capacity harness (BP-179 §2/§4).
+
+BP-179 §2 is explicit that sizing off a light single-caller / toy-string
+measurement is the #1 way to ship an envelope that passes CI and dies in
+production. This module slices real repository content (prose for the "en"
+model, code for the "code" model) to hit a target character-length
+distribution, instead of generating lorem-ipsum.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+from pathlib import Path
+
+EN_GLOB_PATTERNS = ("*.md",)
+CODE_GLOB_PATTERNS = ("*.py",)
+
+# Bound how much corpus text a single harness run reads, so pointing --corpus-dir
+# at a large tree (e.g. the whole repo) stays fast instead of walking everything.
+MAX_CORPUS_FILES = 200
+MAX_CORPUS_CHARS = 2_000_000
+
+
+@dataclass
+class LengthDistribution:
+    """A payload character-length distribution, anchored to measured production data.
+
+    Defaults are BP-179 §6's anchor (~2KB/text at the S115 cap-reproducing load).
+    Override p50/p99 with a fresh measured sample when one becomes available.
+    """
+
+    p50_chars: int = 800
+    p99_chars: int = 2048
+
+    def sample(self, rng: random.Random) -> int:
+        """Log-uniform draw between p50 and p99; ~1% of draws exceed p99 (tail)."""
+        if rng.random() < 0.01:
+            return int(self.p99_chars * rng.uniform(1.0, 1.5))
+        lo, hi = math.log(max(self.p50_chars, 1)), math.log(max(self.p99_chars, 2))
+        return int(math.exp(rng.uniform(lo, hi)))
+
+
+def _collect_corpus_text(corpus_dir: Path, patterns: tuple[str, ...]) -> str:
+    chunks: list[str] = []
+    total_chars = 0
+    files_read = 0
+    for pattern in patterns:
+        for path in sorted(corpus_dir.rglob(pattern)):
+            if files_read >= MAX_CORPUS_FILES or total_chars >= MAX_CORPUS_CHARS:
+                break
+            try:
+                text = path.read_text(errors="ignore")
+            except OSError:
+                continue
+            chunks.append(text)
+            total_chars += len(text)
+            files_read += 1
+    return "\n\n".join(chunks)
+
+
+def sample_texts(
+    corpus_dir: Path,
+    n: int,
+    distribution: LengthDistribution,
+    model: str = "en",
+    seed: int | None = None,
+) -> list[str]:
+    """Slice `n` real contiguous windows of corpus text sized per `distribution`.
+
+    Falls back to a clearly-marked repeated placeholder if the corpus is empty —
+    a degraded mode for smoke-testing the harness itself, NOT a substitute for
+    BP-179 §2's "realistic payloads" requirement in an actual measurement run.
+    """
+    rng = random.Random(seed)
+    patterns = CODE_GLOB_PATTERNS if model == "code" else EN_GLOB_PATTERNS
+    corpus = _collect_corpus_text(corpus_dir, patterns)
+    if not corpus:
+        return [
+            "[harness-smoke-placeholder-corpus-empty] "
+            * (distribution.sample(rng) // 40 + 1)
+            for _ in range(n)
+        ]
+    texts = []
+    for _ in range(n):
+        length = min(distribution.sample(rng), len(corpus))
+        start = rng.randint(0, len(corpus) - length) if len(corpus) > length else 0
+        texts.append(corpus[start : start + length])
+    return texts

--- a/scripts/perf/embedding_capacity/payloads.py
+++ b/scripts/perf/embedding_capacity/payloads.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import math
 import random
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -60,6 +61,16 @@ def _collect_corpus_text(corpus_dir: Path, patterns: tuple[str, ...]) -> str:
     return "\n\n".join(chunks)
 
 
+def corpus_is_empty(corpus_dir: Path, model: str = "en") -> bool:
+    """True if `sample_texts` would fall back to the placeholder corpus for this
+    dir/model. Callers check this once up front to set a loud, machine-readable
+    `corpus_fallback_used` flag in their results — an overnight soak run on toy
+    strings must never silently pass (BP-179 §2).
+    """
+    patterns = CODE_GLOB_PATTERNS if model == "code" else EN_GLOB_PATTERNS
+    return not _collect_corpus_text(corpus_dir, patterns)
+
+
 def sample_texts(
     corpus_dir: Path,
     n: int,
@@ -72,11 +83,18 @@ def sample_texts(
     Falls back to a clearly-marked repeated placeholder if the corpus is empty —
     a degraded mode for smoke-testing the harness itself, NOT a substitute for
     BP-179 §2's "realistic payloads" requirement in an actual measurement run.
+    Emits a UserWarning when the fallback fires.
     """
     rng = random.Random(seed)
     patterns = CODE_GLOB_PATTERNS if model == "code" else EN_GLOB_PATTERNS
     corpus = _collect_corpus_text(corpus_dir, patterns)
     if not corpus:
+        warnings.warn(
+            f"corpus_dir={corpus_dir} has no matching files for model={model!r} "
+            "— falling back to placeholder toy strings; this run's measurements "
+            "are NOT representative of BP-179 §2 realistic payloads",
+            stacklevel=2,
+        )
         return [
             "[harness-smoke-placeholder-corpus-empty] "
             * (distribution.sample(rng) // 40 + 1)

--- a/scripts/perf/embedding_capacity/results.py
+++ b/scripts/perf/embedding_capacity/results.py
@@ -1,0 +1,23 @@
+"""Machine-readable results emission for the capacity harness (BP-179 §6)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any
+
+
+def _to_jsonable(value: Any) -> Any:
+    if is_dataclass(value) and not isinstance(value, type):
+        return {k: _to_jsonable(v) for k, v in asdict(value).items()}
+    if isinstance(value, dict):
+        return {k: _to_jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(v) for v in value]
+    return value
+
+
+def write_results_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(_to_jsonable(data), indent=2, sort_keys=True) + "\n")

--- a/scripts/perf/embedding_capacity_harness.py
+++ b/scripts/perf/embedding_capacity_harness.py
@@ -63,12 +63,15 @@ def _timestamp() -> str:
 def _measure_peak_during(
     reader: cgroup.DockerCgroupReader, coro, poll_interval_seconds: float
 ):
-    """Run `coro` (an unawaited coroutine) and return `(result, peak_bytes, used_fallback)`.
+    """Run `coro` (an unawaited coroutine) and return `(result, peak_bytes,
+    used_fallback, poll_degraded, poll_error)`.
 
     Prefers a memory.peak reset before/read after (BP-179 §2); falls back to
     dense-polling memory.current for the coro's duration when reset is
     unsupported (kernel < 6.8 or a read-only cgroup — verified true on the
-    WSL2 6.6 target, BP-179 §2 corrected PM #387).
+    WSL2 6.6 target, BP-179 §2 corrected PM #387). `poll_degraded` is True
+    when the dense-poll fallback lost its docker exec read mid-run — the
+    peak is then a floor, not a confirmed max.
     """
     reset_ok = reader.try_reset_peak()
     poller = None
@@ -80,7 +83,9 @@ def _measure_peak_during(
     finally:
         polled_peak = poller.stop() if poller is not None else None
     peak = reader.read_peak() if reset_ok else polled_peak
-    return result, peak, not reset_ok
+    poll_degraded = poller.degraded if poller is not None else False
+    poll_error = str(poller._poll_error) if poll_degraded else None
+    return result, peak, not reset_ok, poll_degraded, poll_error
 
 
 def _add_common_args(parser: argparse.ArgumentParser) -> None:
@@ -117,10 +122,12 @@ def cmd_measure(args: argparse.Namespace) -> int:
         )
         for i in range(args.concurrency)
     ]
-    request_results, peak, peak_fallback_used = _measure_peak_during(
-        reader,
-        load.run_burst(args.base_url, request_batches, model=args.model),
-        BURST_POLL_INTERVAL_SECONDS,
+    request_results, peak, peak_fallback_used, peak_poll_degraded, peak_poll_error = (
+        _measure_peak_during(
+            reader,
+            load.run_burst(args.base_url, request_batches, model=args.model),
+            BURST_POLL_INTERVAL_SECONDS,
+        )
     )
     failures = [r for r in request_results if r.status_code != 200]
     successes = len(request_results) - len(failures)
@@ -136,6 +143,8 @@ def cmd_measure(args: argparse.Namespace) -> int:
     print(f"memory.peak = {peak} bytes ({peak / 2**30:.3f} GiB)")
     if peak_fallback_used:
         print("  (via memory.current dense-poll fallback — reset unsupported)")
+    if peak_poll_degraded:
+        print(f"WARNING: peak poll degraded mid-run — {peak_poll_error}")
     if per_req_peak is not None:
         print(
             f"per_request_burst_peak = {per_req_peak:.0f} bytes "
@@ -158,6 +167,8 @@ def cmd_measure(args: argparse.Namespace) -> int:
         "base_rss_bytes": base_rss,
         "memory_peak_bytes": peak,
         "peak_measurement_fallback_used": peak_fallback_used,
+        "peak_poll_degraded": peak_poll_degraded,
+        "peak_poll_error": peak_poll_error,
         "per_request_burst_peak_bytes": per_req_peak,
         "request_count": len(request_results),
         "request_failures": len(failures),
@@ -198,7 +209,13 @@ def cmd_ramp(args: argparse.Namespace) -> int:
             )
             for i in range(concurrency)
         ]
-        request_results, peak, peak_fallback_used = _measure_peak_during(
+        (
+            request_results,
+            peak,
+            peak_fallback_used,
+            peak_poll_degraded,
+            peak_poll_error,
+        ) = _measure_peak_during(
             reader,
             load.run_burst(args.base_url, request_batches, model=args.model),
             BURST_POLL_INTERVAL_SECONDS,
@@ -221,6 +238,8 @@ def cmd_ramp(args: argparse.Namespace) -> int:
             "concurrency": concurrency,
             "memory_peak_bytes": peak,
             "peak_measurement_fallback_used": peak_fallback_used,
+            "peak_poll_degraded": peak_poll_degraded,
+            "peak_poll_error": peak_poll_error,
             "oom_kill_delta": oom_delta,
             "backpressure_shed_delta": shed_delta,
             "request_failures": request_failures,
@@ -233,6 +252,8 @@ def cmd_ramp(args: argparse.Namespace) -> int:
             f"oom_kill_delta={oom_delta} shed_delta={shed_delta} "
             f"load_valid={validity.valid}"
         )
+        if peak_poll_degraded:
+            print(f"  WARNING: peak poll degraded mid-round — {peak_poll_error}")
 
         if oom_delta > 0 or shed_delta > 0:
             print(
@@ -323,16 +344,18 @@ def cmd_soak(args: argparse.Namespace) -> int:
         f"soak starting: callers={n_callers} duration={args.duration_seconds:.0f}s "
         f"model={args.model} batch_size={args.batch_size}"
     )
-    caller_stats, peak, peak_fallback_used = _measure_peak_during(
-        reader,
-        load.run_soak_callers(
-            args.base_url,
-            n_callers,
-            args.duration_seconds,
-            payload_fn,
-            model=args.model,
-        ),
-        args.peak_poll_interval_seconds,
+    caller_stats, peak, peak_fallback_used, peak_poll_degraded, peak_poll_error = (
+        _measure_peak_during(
+            reader,
+            load.run_soak_callers(
+                args.base_url,
+                n_callers,
+                args.duration_seconds,
+                payload_fn,
+                model=args.model,
+            ),
+            args.peak_poll_interval_seconds,
+        )
     )
 
     working_set_end = reader.read_current()
@@ -368,6 +391,8 @@ def cmd_soak(args: argparse.Namespace) -> int:
     )
 
     print(f"soak complete: {total_requests} requests sent, {total_failures} non-200")
+    if peak_poll_degraded:
+        print(f"  WARNING: peak poll degraded mid-soak — {peak_poll_error}")
     if not gate_result.load_valid:
         print(f"  LOAD INVALID: {gate_result.load_validity_detail}")
     for criterion in gate_result.criteria:
@@ -391,6 +416,8 @@ def cmd_soak(args: argparse.Namespace) -> int:
         "working_set_end_bytes": working_set_end,
         "memory_peak_bytes": peak,
         "peak_measurement_fallback_used": peak_fallback_used,
+        "peak_poll_degraded": peak_poll_degraded,
+        "peak_poll_error": peak_poll_error,
         "mem_limit_bytes": args.mem_limit_bytes,
         "admission_wait_p95_seconds": final_metrics.admission_wait_p95_seconds,
         "gate": gate_result,

--- a/scripts/perf/embedding_capacity_harness.py
+++ b/scripts/perf/embedding_capacity_harness.py
@@ -48,9 +48,39 @@ DEFAULT_BASE_URL = "http://localhost:28080"
 DEFAULT_CORPUS_DIR = Path(__file__).resolve().parents[2]
 DEFAULT_RESULTS_DIR = Path(__file__).resolve().parent / "results"
 
+# Poll interval for the memory.current dense-poll fallback (BP-179 §2 corrected):
+# short for the seconds-scale measure/ramp burst, configurable and longer by
+# default for the hours-scale soak so a multi-hour run doesn't spawn a `docker
+# exec` every 50ms.
+BURST_POLL_INTERVAL_SECONDS = 0.05
+DEFAULT_SOAK_POLL_INTERVAL_SECONDS = 2.0
+
 
 def _timestamp() -> str:
     return time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+
+
+def _measure_peak_during(
+    reader: cgroup.DockerCgroupReader, coro, poll_interval_seconds: float
+):
+    """Run `coro` (an unawaited coroutine) and return `(result, peak_bytes, used_fallback)`.
+
+    Prefers a memory.peak reset before/read after (BP-179 §2); falls back to
+    dense-polling memory.current for the coro's duration when reset is
+    unsupported (kernel < 6.8 or a read-only cgroup — verified true on the
+    WSL2 6.6 target, BP-179 §2 corrected PM #387).
+    """
+    reset_ok = reader.try_reset_peak()
+    poller = None
+    if not reset_ok:
+        poller = cgroup.PeakPoller(reader, interval_seconds=poll_interval_seconds)
+        poller.start()
+    try:
+        result = asyncio.run(coro)
+    finally:
+        polled_peak = poller.stop() if poller is not None else None
+    peak = reader.read_peak() if reset_ok else polled_peak
+    return result, peak, not reset_ok
 
 
 def _add_common_args(parser: argparse.ArgumentParser) -> None:
@@ -70,7 +100,14 @@ def cmd_measure(args: argparse.Namespace) -> int:
     base_rss = reader.read_current()
     print(f"base_rss = {base_rss} bytes ({base_rss / 2**30:.3f} GiB)")
 
-    reader.reset_peak()
+    corpus_fallback_used = payloads.corpus_is_empty(args.corpus_dir, args.model)
+    if corpus_fallback_used:
+        print(
+            f"WARNING: corpus_dir={args.corpus_dir} has no matching files for "
+            f"model={args.model!r} — this run uses placeholder toy strings, NOT "
+            "representative of BP-179 §2 realistic payloads"
+        )
+
     dist = payloads.LengthDistribution(
         p50_chars=args.p50_chars, p99_chars=args.p99_chars
     )
@@ -80,22 +117,36 @@ def cmd_measure(args: argparse.Namespace) -> int:
         )
         for i in range(args.concurrency)
     ]
-    request_results = asyncio.run(
-        load.run_burst(args.base_url, request_batches, model=args.model)
+    request_results, peak, peak_fallback_used = _measure_peak_during(
+        reader,
+        load.run_burst(args.base_url, request_batches, model=args.model),
+        BURST_POLL_INTERVAL_SECONDS,
     )
-    peak = reader.read_peak()
-    per_req_peak = envelope.per_request_burst_peak(peak, base_rss, args.concurrency)
-
     failures = [r for r in request_results if r.status_code != 200]
-    print(f"memory.peak = {peak} bytes ({peak / 2**30:.3f} GiB)")
-    print(
-        f"per_request_burst_peak = {per_req_peak:.0f} bytes "
-        f"({per_req_peak / 2**20:.1f} MiB) over N={args.concurrency}"
+    successes = len(request_results) - len(failures)
+    # BP-179 §2's (peak-base)/N assumes all N concurrent requests actually
+    # drove load; a failed request may not have — annotate rather than
+    # silently dividing by the nominal concurrency when that assumption broke.
+    per_req_peak = (
+        envelope.per_request_burst_peak(peak, base_rss, args.concurrency)
+        if successes > 0
+        else None
     )
+
+    print(f"memory.peak = {peak} bytes ({peak / 2**30:.3f} GiB)")
+    if peak_fallback_used:
+        print("  (via memory.current dense-poll fallback — reset unsupported)")
+    if per_req_peak is not None:
+        print(
+            f"per_request_burst_peak = {per_req_peak:.0f} bytes "
+            f"({per_req_peak / 2**20:.1f} MiB) over N={args.concurrency}"
+        )
     if failures:
         print(
             f"WARNING: {len(failures)}/{len(request_results)} burst requests "
-            "did not return 200 — measured peak may understate the real burst"
+            "did not return 200 — measured peak may understate the real burst; "
+            "per_request_burst_peak divides by the nominal concurrency, not the "
+            "successful count"
         )
 
     data = {
@@ -106,9 +157,11 @@ def cmd_measure(args: argparse.Namespace) -> int:
         "model": args.model,
         "base_rss_bytes": base_rss,
         "memory_peak_bytes": peak,
+        "peak_measurement_fallback_used": peak_fallback_used,
         "per_request_burst_peak_bytes": per_req_peak,
         "request_count": len(request_results),
         "request_failures": len(failures),
+        "corpus_fallback_used": corpus_fallback_used,
     }
     out_path = args.output_dir / f"measure-{_timestamp()}.json"
     results.write_results_json(out_path, data)
@@ -120,47 +173,68 @@ def cmd_ramp(args: argparse.Namespace) -> int:
     reader = cgroup.DockerCgroupReader(args.container, args.cgroup_root)
     base_rss = reader.read_current()
     baseline_events = reader.read_events()
+    baseline_metrics = metrics_client.parse_metrics(
+        metrics_client.fetch_metrics_text(args.base_url)
+    )
+    baseline_shed = baseline_metrics.backpressure.get("shed", 0.0)
     dist = payloads.LengthDistribution(
         p50_chars=args.p50_chars, p99_chars=args.p99_chars
     )
 
+    corpus_fallback_used = payloads.corpus_is_empty(args.corpus_dir, args.model)
+    if corpus_fallback_used:
+        print(
+            f"WARNING: corpus_dir={args.corpus_dir} has no matching files for "
+            f"model={args.model!r} — this run uses placeholder toy strings, NOT "
+            "representative of BP-179 §2 realistic payloads"
+        )
+
     rounds: list[dict] = []
     concurrency = args.start_concurrency
-    ceiling = args.max_concurrency
     while concurrency <= args.max_concurrency:
-        reader.reset_peak()
         request_batches = [
             payloads.sample_texts(
                 args.corpus_dir, args.batch_size, dist, args.model, seed=i
             )
             for i in range(concurrency)
         ]
-        request_results = asyncio.run(
-            load.run_burst(args.base_url, request_batches, model=args.model)
+        request_results, peak, peak_fallback_used = _measure_peak_during(
+            reader,
+            load.run_burst(args.base_url, request_batches, model=args.model),
+            BURST_POLL_INTERVAL_SECONDS,
         )
-        peak = reader.read_peak()
         events = reader.read_events()
         oom_delta = events.get("oom_kill", 0) - baseline_events.get("oom_kill", 0)
         snapshot = metrics_client.parse_metrics(
             metrics_client.fetch_metrics_text(args.base_url)
         )
-        shed_total = snapshot.backpressure.get("shed", 0.0)
+        shed_delta = snapshot.backpressure.get("shed", 0.0) - baseline_shed
+        request_failures = sum(1 for r in request_results if r.status_code != 200)
+        validity = gate.evaluate_load_validity(
+            total_requests=len(request_results),
+            total_failures=request_failures,
+            memory_peak_bytes=peak,
+            base_rss_bytes=base_rss,
+        )
 
         round_data = {
             "concurrency": concurrency,
             "memory_peak_bytes": peak,
+            "peak_measurement_fallback_used": peak_fallback_used,
             "oom_kill_delta": oom_delta,
-            "backpressure_shed_total": shed_total,
-            "request_failures": sum(1 for r in request_results if r.status_code != 200),
+            "backpressure_shed_delta": shed_delta,
+            "request_failures": request_failures,
+            "load_valid": validity.valid,
+            "load_validity_detail": validity.detail,
         }
         rounds.append(round_data)
         print(
             f"concurrency={concurrency}: peak={peak / 2**30:.3f} GiB "
-            f"oom_kill_delta={oom_delta} shed_total={shed_total}"
+            f"oom_kill_delta={oom_delta} shed_delta={shed_delta} "
+            f"load_valid={validity.valid}"
         )
 
-        if oom_delta > 0 or shed_total > 0:
-            ceiling = max(args.start_concurrency, concurrency - args.step)
+        if oom_delta > 0 or shed_delta > 0:
             print(
                 f"ceiling reached: concurrency={concurrency} triggered oom_kill or shed"
             )
@@ -174,43 +248,68 @@ def cmd_ramp(args: argparse.Namespace) -> int:
     clean_rounds = [
         r
         for r in rounds
-        if r["oom_kill_delta"] == 0 and not r["backpressure_shed_total"]
+        if r["oom_kill_delta"] == 0
+        and not r["backpressure_shed_delta"]
+        and r["load_valid"]
     ]
     per_req_peak = None
     recommendation = None
+    ceiling_concurrency = None
+    ceiling_message = None
     if clean_rounds:
         last_clean = clean_rounds[-1]
+        ceiling_concurrency = last_clean["concurrency"]
         per_req_peak = envelope.per_request_burst_peak(
             last_clean["memory_peak_bytes"], base_rss, last_clean["concurrency"]
         )
         recommendation = envelope.recommend_envelope(
             base_rss, per_req_peak, args.safety_margin_ratio
         )
+    else:
+        ceiling_message = (
+            "no safe concurrency found — every round hit oom_kill, shed, or an "
+            "invalid load"
+        )
+        print(f"WARNING: {ceiling_message}")
 
     data = {
         "mode": "ramp",
         "container": args.container,
         "base_rss_bytes": base_rss,
         "rounds": rounds,
-        "ceiling_concurrency": ceiling,
+        "ceiling_concurrency": ceiling_concurrency,
+        "ceiling_message": ceiling_message,
         "per_request_burst_peak_bytes": per_req_peak,
         "recommendation": recommendation,
+        "corpus_fallback_used": corpus_fallback_used,
     }
     out_path = args.output_dir / f"ramp-{_timestamp()}.json"
     results.write_results_json(out_path, data)
     print(f"results written to {out_path}")
-    return 0
+    return 0 if ceiling_concurrency is not None else 1
 
 
 def cmd_soak(args: argparse.Namespace) -> int:
     reader = cgroup.DockerCgroupReader(args.container, args.cgroup_root)
+    # Pre-flight dmesg readability NOW, not hours into the soak (M2): raises
+    # CgroupAccessError immediately if unreadable, and its return value
+    # baselines the ring buffer so stale prior-run kills aren't re-reported.
+    dmesg_baseline_ts = cgroup.dmesg_baseline()
+
     baseline_events = reader.read_events()
     working_set_start = reader.read_current()
-    reader.reset_peak()
     baseline_metrics = metrics_client.parse_metrics(
         metrics_client.fetch_metrics_text(args.base_url)
     )
     baseline_shed = baseline_metrics.backpressure.get("shed", 0.0)
+
+    corpus_fallback_used = payloads.corpus_is_empty(args.corpus_dir, args.model)
+    if corpus_fallback_used:
+        print(
+            f"WARNING: corpus_dir={args.corpus_dir} has no matching files for "
+            f"model={args.model!r} — this run uses placeholder toy strings, NOT "
+            "representative of BP-179 §2 realistic payloads"
+        )
 
     dist = payloads.LengthDistribution(
         p50_chars=args.p50_chars, p99_chars=args.p99_chars
@@ -224,27 +323,33 @@ def cmd_soak(args: argparse.Namespace) -> int:
         f"soak starting: callers={n_callers} duration={args.duration_seconds:.0f}s "
         f"model={args.model} batch_size={args.batch_size}"
     )
-    caller_stats = asyncio.run(
+    caller_stats, peak, peak_fallback_used = _measure_peak_during(
+        reader,
         load.run_soak_callers(
             args.base_url,
             n_callers,
             args.duration_seconds,
             payload_fn,
             model=args.model,
-        )
+        ),
+        args.peak_poll_interval_seconds,
     )
 
     working_set_end = reader.read_current()
-    peak = reader.read_peak()
     final_events = reader.read_events()
     oom_kill_delta = final_events.get("oom_kill", 0) - baseline_events.get(
         "oom_kill", 0
     )
-    dmesg_lines = cgroup.scan_dmesg_oom()
+    dmesg_lines = cgroup.scan_dmesg_oom(since_timestamp=dmesg_baseline_ts)
     final_metrics = metrics_client.parse_metrics(
         metrics_client.fetch_metrics_text(args.base_url)
     )
     shed_delta = final_metrics.backpressure.get("shed", 0.0) - baseline_shed
+
+    total_requests = sum(c.requests_sent for c in caller_stats)
+    total_failures = sum(
+        1 for c in caller_stats for r in c.results if r.status_code != 200
+    )
 
     gate_result = gate.evaluate_gate(
         oom_kill_delta=oom_kill_delta,
@@ -257,18 +362,18 @@ def cmd_soak(args: argparse.Namespace) -> int:
         leak_tolerance_ratio=args.leak_tolerance_ratio,
         memory_peak_bytes=peak,
         mem_limit_bytes=args.mem_limit_bytes,
-    )
-
-    total_requests = sum(c.requests_sent for c in caller_stats)
-    total_failures = sum(
-        1 for c in caller_stats for r in c.results if r.status_code != 200
+        total_requests=total_requests,
+        total_failures=total_failures,
+        base_rss_bytes=working_set_start,
     )
 
     print(f"soak complete: {total_requests} requests sent, {total_failures} non-200")
+    if not gate_result.load_valid:
+        print(f"  LOAD INVALID: {gate_result.load_validity_detail}")
     for criterion in gate_result.criteria:
         status = "PASS" if criterion.passed else "FAIL"
         print(f"  [{status}] {criterion.name}: {criterion.detail}")
-    print(f"GATE: {'PASS' if gate_result.passed else 'FAIL'}")
+    print(f"GATE: {gate_result.outcome}")
 
     data = {
         "mode": "soak",
@@ -285,15 +390,20 @@ def cmd_soak(args: argparse.Namespace) -> int:
         "working_set_start_bytes": working_set_start,
         "working_set_end_bytes": working_set_end,
         "memory_peak_bytes": peak,
+        "peak_measurement_fallback_used": peak_fallback_used,
         "mem_limit_bytes": args.mem_limit_bytes,
         "admission_wait_p95_seconds": final_metrics.admission_wait_p95_seconds,
         "gate": gate_result,
+        "gate_outcome": gate_result.outcome,
         "gate_passed": gate_result.passed,
+        "corpus_fallback_used": corpus_fallback_used,
     }
     out_path = args.output_dir / f"soak-{_timestamp()}.json"
     results.write_results_json(out_path, data)
     print(f"results written to {out_path}")
-    return 0 if gate_result.passed else 1
+    if gate_result.outcome == "PASS":
+        return 0
+    return 2 if gate_result.outcome == "INVALID" else 1
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -327,6 +437,14 @@ def build_parser() -> argparse.ArgumentParser:
     p_soak.add_argument("--mem-limit-bytes", type=int, required=True)
     p_soak.add_argument("--read-timeout-seconds", type=float, default=30.0)
     p_soak.add_argument("--leak-tolerance-ratio", type=float, default=0.10)
+    p_soak.add_argument(
+        "--peak-poll-interval-seconds",
+        type=float,
+        default=DEFAULT_SOAK_POLL_INTERVAL_SECONDS,
+        help="memory.current poll interval for the dense-poll peak fallback "
+        "when memory.peak reset is unsupported (default: "
+        f"{DEFAULT_SOAK_POLL_INTERVAL_SECONDS}s)",
+    )
     p_soak.set_defaults(func=cmd_soak)
 
     return parser

--- a/scripts/perf/embedding_capacity_harness.py
+++ b/scripts/perf/embedding_capacity_harness.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Embedding capacity + soak harness — PLAN-030 Phase 2 (BP-179).
+
+Measures the real memory footprint of the ai-memory-embedding service under
+burst (measure), ramps concurrency to find the ceiling (ramp), and soaks a
+chosen envelope asserting the BP-179 §4 pass/fail gate (soak).
+
+This is a MEASUREMENT tool: it drives and observes the shipped resilience
+mechanism in docker/embedding/main.py (semaphore, AIMD, cgroup memory.events)
+over HTTP + `docker exec`; it never modifies the service or its defaults.
+
+Usage:
+    python scripts/perf/embedding_capacity_harness.py measure \\
+        --concurrency 4 --batch-size 30
+
+    python scripts/perf/embedding_capacity_harness.py ramp \\
+        --start-concurrency 1 --max-concurrency 8
+
+    python scripts/perf/embedding_capacity_harness.py soak \\
+        --duration-hours 4 --concurrency-ceiling 4 --waiters 4 \\
+        --mem-limit-bytes 6442450944
+
+See scripts/perf/runbook.md for the overnight measure -> size -> soak sequence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from embedding_capacity import (
+    cgroup,
+    envelope,
+    gate,
+    load,
+    metrics_client,
+    payloads,
+    results,
+)
+
+DEFAULT_CONTAINER = "ai-memory-embedding"
+DEFAULT_BASE_URL = "http://localhost:28080"
+DEFAULT_CORPUS_DIR = Path(__file__).resolve().parents[2]
+DEFAULT_RESULTS_DIR = Path(__file__).resolve().parent / "results"
+
+
+def _timestamp() -> str:
+    return time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+
+
+def _add_common_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--container", default=DEFAULT_CONTAINER)
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    parser.add_argument("--cgroup-root", default=cgroup.DEFAULT_CGROUP_ROOT)
+    parser.add_argument("--corpus-dir", type=Path, default=DEFAULT_CORPUS_DIR)
+    parser.add_argument("--model", choices=["en", "code"], default="en")
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_RESULTS_DIR)
+    parser.add_argument("--batch-size", type=int, default=30)
+    parser.add_argument("--p50-chars", type=int, default=800)
+    parser.add_argument("--p99-chars", type=int, default=2048)
+
+
+def cmd_measure(args: argparse.Namespace) -> int:
+    reader = cgroup.DockerCgroupReader(args.container, args.cgroup_root)
+    base_rss = reader.read_current()
+    print(f"base_rss = {base_rss} bytes ({base_rss / 2**30:.3f} GiB)")
+
+    reader.reset_peak()
+    dist = payloads.LengthDistribution(
+        p50_chars=args.p50_chars, p99_chars=args.p99_chars
+    )
+    request_batches = [
+        payloads.sample_texts(
+            args.corpus_dir, args.batch_size, dist, args.model, seed=i
+        )
+        for i in range(args.concurrency)
+    ]
+    request_results = asyncio.run(
+        load.run_burst(args.base_url, request_batches, model=args.model)
+    )
+    peak = reader.read_peak()
+    per_req_peak = envelope.per_request_burst_peak(peak, base_rss, args.concurrency)
+
+    failures = [r for r in request_results if r.status_code != 200]
+    print(f"memory.peak = {peak} bytes ({peak / 2**30:.3f} GiB)")
+    print(
+        f"per_request_burst_peak = {per_req_peak:.0f} bytes "
+        f"({per_req_peak / 2**20:.1f} MiB) over N={args.concurrency}"
+    )
+    if failures:
+        print(
+            f"WARNING: {len(failures)}/{len(request_results)} burst requests "
+            "did not return 200 — measured peak may understate the real burst"
+        )
+
+    data = {
+        "mode": "measure",
+        "container": args.container,
+        "concurrency": args.concurrency,
+        "batch_size": args.batch_size,
+        "model": args.model,
+        "base_rss_bytes": base_rss,
+        "memory_peak_bytes": peak,
+        "per_request_burst_peak_bytes": per_req_peak,
+        "request_count": len(request_results),
+        "request_failures": len(failures),
+    }
+    out_path = args.output_dir / f"measure-{_timestamp()}.json"
+    results.write_results_json(out_path, data)
+    print(f"results written to {out_path}")
+    return 1 if failures else 0
+
+
+def cmd_ramp(args: argparse.Namespace) -> int:
+    reader = cgroup.DockerCgroupReader(args.container, args.cgroup_root)
+    base_rss = reader.read_current()
+    baseline_events = reader.read_events()
+    dist = payloads.LengthDistribution(
+        p50_chars=args.p50_chars, p99_chars=args.p99_chars
+    )
+
+    rounds: list[dict] = []
+    concurrency = args.start_concurrency
+    ceiling = args.max_concurrency
+    while concurrency <= args.max_concurrency:
+        reader.reset_peak()
+        request_batches = [
+            payloads.sample_texts(
+                args.corpus_dir, args.batch_size, dist, args.model, seed=i
+            )
+            for i in range(concurrency)
+        ]
+        request_results = asyncio.run(
+            load.run_burst(args.base_url, request_batches, model=args.model)
+        )
+        peak = reader.read_peak()
+        events = reader.read_events()
+        oom_delta = events.get("oom_kill", 0) - baseline_events.get("oom_kill", 0)
+        snapshot = metrics_client.parse_metrics(
+            metrics_client.fetch_metrics_text(args.base_url)
+        )
+        shed_total = snapshot.backpressure.get("shed", 0.0)
+
+        round_data = {
+            "concurrency": concurrency,
+            "memory_peak_bytes": peak,
+            "oom_kill_delta": oom_delta,
+            "backpressure_shed_total": shed_total,
+            "request_failures": sum(1 for r in request_results if r.status_code != 200),
+        }
+        rounds.append(round_data)
+        print(
+            f"concurrency={concurrency}: peak={peak / 2**30:.3f} GiB "
+            f"oom_kill_delta={oom_delta} shed_total={shed_total}"
+        )
+
+        if oom_delta > 0 or shed_total > 0:
+            ceiling = max(args.start_concurrency, concurrency - args.step)
+            print(
+                f"ceiling reached: concurrency={concurrency} triggered oom_kill or shed"
+            )
+            break
+        concurrency += args.step
+    else:
+        print(
+            f"reached max_concurrency={args.max_concurrency} without hitting a ceiling"
+        )
+
+    clean_rounds = [
+        r
+        for r in rounds
+        if r["oom_kill_delta"] == 0 and not r["backpressure_shed_total"]
+    ]
+    per_req_peak = None
+    recommendation = None
+    if clean_rounds:
+        last_clean = clean_rounds[-1]
+        per_req_peak = envelope.per_request_burst_peak(
+            last_clean["memory_peak_bytes"], base_rss, last_clean["concurrency"]
+        )
+        recommendation = envelope.recommend_envelope(
+            base_rss, per_req_peak, args.safety_margin_ratio
+        )
+
+    data = {
+        "mode": "ramp",
+        "container": args.container,
+        "base_rss_bytes": base_rss,
+        "rounds": rounds,
+        "ceiling_concurrency": ceiling,
+        "per_request_burst_peak_bytes": per_req_peak,
+        "recommendation": recommendation,
+    }
+    out_path = args.output_dir / f"ramp-{_timestamp()}.json"
+    results.write_results_json(out_path, data)
+    print(f"results written to {out_path}")
+    return 0
+
+
+def cmd_soak(args: argparse.Namespace) -> int:
+    reader = cgroup.DockerCgroupReader(args.container, args.cgroup_root)
+    baseline_events = reader.read_events()
+    working_set_start = reader.read_current()
+    reader.reset_peak()
+    baseline_metrics = metrics_client.parse_metrics(
+        metrics_client.fetch_metrics_text(args.base_url)
+    )
+    baseline_shed = baseline_metrics.backpressure.get("shed", 0.0)
+
+    dist = payloads.LengthDistribution(
+        p50_chars=args.p50_chars, p99_chars=args.p99_chars
+    )
+
+    def payload_fn() -> list[str]:
+        return payloads.sample_texts(args.corpus_dir, args.batch_size, dist, args.model)
+
+    n_callers = args.callers or (args.concurrency_ceiling + args.waiters)
+    print(
+        f"soak starting: callers={n_callers} duration={args.duration_seconds:.0f}s "
+        f"model={args.model} batch_size={args.batch_size}"
+    )
+    caller_stats = asyncio.run(
+        load.run_soak_callers(
+            args.base_url,
+            n_callers,
+            args.duration_seconds,
+            payload_fn,
+            model=args.model,
+        )
+    )
+
+    working_set_end = reader.read_current()
+    peak = reader.read_peak()
+    final_events = reader.read_events()
+    oom_kill_delta = final_events.get("oom_kill", 0) - baseline_events.get(
+        "oom_kill", 0
+    )
+    dmesg_lines = cgroup.scan_dmesg_oom()
+    final_metrics = metrics_client.parse_metrics(
+        metrics_client.fetch_metrics_text(args.base_url)
+    )
+    shed_delta = final_metrics.backpressure.get("shed", 0.0) - baseline_shed
+
+    gate_result = gate.evaluate_gate(
+        oom_kill_delta=oom_kill_delta,
+        dmesg_oom_count=len(dmesg_lines),
+        shed_delta=shed_delta,
+        admission_wait_p95_seconds=final_metrics.admission_wait_p95_seconds,
+        client_read_timeout_seconds=args.read_timeout_seconds,
+        working_set_start_bytes=working_set_start,
+        working_set_end_bytes=working_set_end,
+        leak_tolerance_ratio=args.leak_tolerance_ratio,
+        memory_peak_bytes=peak,
+        mem_limit_bytes=args.mem_limit_bytes,
+    )
+
+    total_requests = sum(c.requests_sent for c in caller_stats)
+    total_failures = sum(
+        1 for c in caller_stats for r in c.results if r.status_code != 200
+    )
+
+    print(f"soak complete: {total_requests} requests sent, {total_failures} non-200")
+    for criterion in gate_result.criteria:
+        status = "PASS" if criterion.passed else "FAIL"
+        print(f"  [{status}] {criterion.name}: {criterion.detail}")
+    print(f"GATE: {'PASS' if gate_result.passed else 'FAIL'}")
+
+    data = {
+        "mode": "soak",
+        "container": args.container,
+        "duration_seconds": args.duration_seconds,
+        "callers": n_callers,
+        "total_requests": total_requests,
+        "total_failures": total_failures,
+        "baseline_events": baseline_events,
+        "final_events": final_events,
+        "oom_kill_delta": oom_kill_delta,
+        "dmesg_oom_lines": dmesg_lines,
+        "shed_delta": shed_delta,
+        "working_set_start_bytes": working_set_start,
+        "working_set_end_bytes": working_set_end,
+        "memory_peak_bytes": peak,
+        "mem_limit_bytes": args.mem_limit_bytes,
+        "admission_wait_p95_seconds": final_metrics.admission_wait_p95_seconds,
+        "gate": gate_result,
+        "gate_passed": gate_result.passed,
+    }
+    out_path = args.output_dir / f"soak-{_timestamp()}.json"
+    results.write_results_json(out_path, data)
+    print(f"results written to {out_path}")
+    return 0 if gate_result.passed else 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    sub = parser.add_subparsers(dest="mode", required=True)
+
+    p_measure = sub.add_parser(
+        "measure", help="Measure base_rss + per_request_burst_peak"
+    )
+    _add_common_args(p_measure)
+    p_measure.add_argument("--concurrency", type=int, default=4)
+    p_measure.set_defaults(func=cmd_measure)
+
+    p_ramp = sub.add_parser("ramp", help="Ramp concurrency to find the ceiling")
+    _add_common_args(p_ramp)
+    p_ramp.add_argument("--start-concurrency", type=int, default=1)
+    p_ramp.add_argument("--max-concurrency", type=int, default=8)
+    p_ramp.add_argument("--step", type=int, default=1)
+    p_ramp.add_argument("--safety-margin-ratio", type=float, default=0.15)
+    p_ramp.set_defaults(func=cmd_ramp)
+
+    p_soak = sub.add_parser("soak", help="Soak the chosen envelope and assert the gate")
+    _add_common_args(p_soak)
+    p_soak.add_argument("--duration-seconds", type=float, default=None)
+    p_soak.add_argument("--duration-hours", type=float, default=None)
+    p_soak.add_argument("--callers", type=int, default=0)
+    p_soak.add_argument("--concurrency-ceiling", type=int, default=4)
+    p_soak.add_argument("--waiters", type=int, default=4)
+    p_soak.add_argument("--mem-limit-bytes", type=int, required=True)
+    p_soak.add_argument("--read-timeout-seconds", type=float, default=30.0)
+    p_soak.add_argument("--leak-tolerance-ratio", type=float, default=0.10)
+    p_soak.set_defaults(func=cmd_soak)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.mode == "soak":
+        if args.duration_seconds is None and args.duration_hours is None:
+            parser.error("soak requires --duration-seconds or --duration-hours")
+        if args.duration_seconds is None:
+            args.duration_seconds = args.duration_hours * 3600
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/perf/runbook.md
+++ b/scripts/perf/runbook.md
@@ -118,10 +118,19 @@ python scripts/perf/embedding_capacity_harness.py soak \
 - The harness snapshots `memory.events` **before** the run and reports
   deltas — a baseline is mandatory per BP-179 §4; without it, pre-existing
   kills would be misattributed to this soak.
-- Exit code is `0` only if **all 6** gate criteria pass; any single failure
-  fails the whole gate (BP-179 §4 "assert all", not majority).
+- The gate has three possible outcomes — exit code **0** (`PASS`, all 6
+  criteria pass), **1** (`FAIL`, at least one criterion failed), or **2**
+  (`INVALID`, the load-validity guard tripped before the 6 criteria were
+  even meaningful). `INVALID` fires when either too few requests succeeded
+  (success ratio below the floor) or the measured peak never rose
+  meaningfully above the base RSS — both indicate the burst/soak load never
+  actually landed (e.g. wrong port, all-503s, not-ready container), so a
+  trivial all-PASS on the 6 criteria wouldn't certify anything. On
+  `INVALID`, fix why the load didn't land (check `--base-url`/`--container`,
+  confirm the target is warm and serving) and re-run — it is not a capacity
+  verdict either way.
 - Results land in `scripts/perf/results/soak-<timestamp>.json` plus a
-  human-readable PASS/FAIL line per criterion on stdout.
+  human-readable PASS/FAIL/INVALID line per criterion on stdout.
 
 ## Reading a soak failure
 
@@ -131,7 +140,17 @@ python scripts/perf/embedding_capacity_harness.py soak \
 | `backpressure_shed_zero` | A request was dropped (lost memory), not just delayed. | `embedding_backpressure_total{action="shed"}` on `:28080/metrics` |
 | `admission_wait_p95_within_timeout` | Clients would time out and retry-storm under this envelope. | `embedding_admission_wait_seconds` histogram |
 | `no_working_set_climb` | Possible slow leak/fragmentation drift (BUG-324 axis). | Compare `working_set_start_bytes`/`working_set_end_bytes` in the results JSON |
-| `peak_under_mem_limit` | `memory.peak` reached or exceeded the cap even without a kill — no safety margin left. | `memory.peak` in the results JSON vs `--mem-limit-bytes` |
+| `peak_under_mem_limit` | The measured peak reached or exceeded the cap even without a kill — no safety margin left. | `memory_peak_bytes` in the results JSON vs `--mem-limit-bytes` |
+
+The `memory_peak_bytes` value is the polled `memory.current` max (dense-poll
+fallback on kernels < 6.8 or a read-only cgroup mount — the case on the
+WSL2 6.6 target), not `memory.peak` directly; check
+`peak_measurement_fallback_used` in the results JSON to confirm which path
+was used. If `peak_poll_degraded` is `true`, the poller lost its `docker
+exec` read partway through the run — `peak_poll_error` has the detail, and
+`memory_peak_bytes` is a floor (last value observed before the failure),
+not a confirmed max; treat a `peak_under_mem_limit` PASS on a degraded run
+with less confidence and consider re-running.
 
 A failed soak means: go back to Step 1/2 with a lower `max_concurrency` or
 apply BP-175 §5 footprint knobs and re-measure — do not raise `mem_limit`

--- a/scripts/perf/runbook.md
+++ b/scripts/perf/runbook.md
@@ -21,12 +21,18 @@ separate, deliberate follow-up decision.
   works from this host before scheduling the run — if it errors, stop and
   fix cgroup access first (see BLOCKER PROTOCOL in the dispatch brief; do not
   guess a value).
+- `memory.peak` **reset** needs Linux >= 6.8 AND a writable cgroup mount; on
+  the WSL2 6.6 target it is `-r--r--r--` (read-only), so reset fails. The
+  harness detects this automatically (`try_reset_peak()`) and falls back to
+  dense-polling `memory.current` for the burst/soak duration instead
+  (BP-179 §2 corrected) — every result JSON records whether the fallback was
+  used via `peak_measurement_fallback_used`. No manual smoke-check needed.
 - Confirm `dmesg` is readable (no `Operation not permitted`) — it is one of
   the two authoritative OOM signals (BP-179 §3) and the harness raises
   `CgroupAccessError` rather than silently treating a permission failure as
-  "zero kills".
+  "zero kills". `soak` does this pre-flight automatically at start.
 - Install harness dependencies: `pip install -e .[dev]` from the repo root
-  (adds `httpx`, `prometheus-client`, `psutil`, already in `dev`).
+  (adds `httpx`, `prometheus-client`, already in `dev`).
 
 All commands below assume `cwd` is the repo root and the stack is already
 running (`docker/stack.sh` up, embedding service healthy on `:28080`).
@@ -39,7 +45,7 @@ concurrency (BP-179 §2). Run once per model (`en`, `code`) you care about.
 ```bash
 python scripts/perf/embedding_capacity_harness.py measure \
     --concurrency 4 --batch-size 30 --model en \
-    --corpus-dir docs
+    --corpus-dir /mnt/e/projects/dev-ai-memory/ai-memory/docs
 ```
 
 - `--corpus-dir` should point at real prose (`docs/`) for `--model en` or a
@@ -63,7 +69,8 @@ table.
 ```bash
 python scripts/perf/embedding_capacity_harness.py ramp \
     --start-concurrency 1 --max-concurrency 8 --step 1 \
-    --batch-size 30 --model en --corpus-dir docs
+    --batch-size 30 --model en \
+    --corpus-dir /mnt/e/projects/dev-ai-memory/ai-memory/docs
 ```
 
 - Stops the moment `memory.events:oom_kill` increments or backpressure
@@ -97,7 +104,7 @@ python scripts/perf/embedding_capacity_harness.py soak \
     --duration-hours 8 \
     --concurrency-ceiling 4 --waiters 4 \
     --mem-limit-bytes 6442450944 \
-    --model en --corpus-dir docs \
+    --model en --corpus-dir /mnt/e/projects/dev-ai-memory/ai-memory/docs \
     --read-timeout-seconds 30
 ```
 

--- a/scripts/perf/runbook.md
+++ b/scripts/perf/runbook.md
@@ -1,0 +1,138 @@
+# Embedding Capacity/Soak Harness — Overnight Runbook
+
+Companion to `scripts/perf/embedding_capacity_harness.py` (PLAN-030 Phase 2,
+BP-179, BUG-329). This harness **measures and recommends**; it never modifies
+`docker/embedding/main.py` or the shipped `EMBEDDING_MEMORY_LIMIT` /
+`EMBEDDING_MAX_CONCURRENCY` defaults. Applying a recommended pair is a
+separate, deliberate follow-up decision.
+
+## Before you start
+
+- The `ai-memory-embedding` container is shared across every project on the
+  host (BP-179 applicability check). A capacity-ramp or soak run deliberately
+  drives it to its OOM ceiling — **notify anyone else relying on the shared
+  stack before running ramp or soak**, and prefer an off-hours window.
+- **Pause this project's own memory capture for the window** so the soak's
+  synthetic load isn't recorded as real project activity and doesn't compete
+  with the harness's own embed calls: run the `aim-pause-updates` skill (or
+  toggle `auto_update_enabled` off) before starting, and re-enable it after
+  the soak completes.
+- Confirm `docker exec ai-memory-embedding cat /sys/fs/cgroup/memory.current`
+  works from this host before scheduling the run — if it errors, stop and
+  fix cgroup access first (see BLOCKER PROTOCOL in the dispatch brief; do not
+  guess a value).
+- Confirm `dmesg` is readable (no `Operation not permitted`) — it is one of
+  the two authoritative OOM signals (BP-179 §3) and the harness raises
+  `CgroupAccessError` rather than silently treating a permission failure as
+  "zero kills".
+- Install harness dependencies: `pip install -e .[dev]` from the repo root
+  (adds `httpx`, `prometheus-client`, `psutil`, already in `dev`).
+
+All commands below assume `cwd` is the repo root and the stack is already
+running (`docker/stack.sh` up, embedding service healthy on `:28080`).
+
+## Step 1 — Measure (`measure`)
+
+Establishes `base_rss` and `per_request_burst_peak` at your current
+concurrency (BP-179 §2). Run once per model (`en`, `code`) you care about.
+
+```bash
+python scripts/perf/embedding_capacity_harness.py measure \
+    --concurrency 4 --batch-size 30 --model en \
+    --corpus-dir docs
+```
+
+- `--corpus-dir` should point at real prose (`docs/`) for `--model en` or a
+  code tree (`src/`) for `--model code` — the harness slices real file
+  content into batches, never toy strings (BP-179 §2).
+- Read the printed `per_request_burst_peak`. If it is far above the ~0.2
+  GiB/slot nominal in MEMORY.md, that gap is expected (BP-179 §6) — it is
+  *why* you are measuring instead of trusting the nominal figure.
+
+**Optional: re-measure after footprint knobs.** If BP-175's footprint
+mitigations (`MALLOC_ARENA_MAX=2`, lower `OMP_NUM_THREADS`) are applied to
+the container, restart it and re-run `measure` to get the *post-mitigation*
+`per_request_burst_peak` before sizing the envelope in Step 2 — sizing off
+the pre-mitigation number leaves headroom on the table.
+
+## Step 2 — Capacity-ramp (`ramp`)
+
+Finds the real ceiling and emits a recommended `(mem_limit, max_concurrency)`
+table.
+
+```bash
+python scripts/perf/embedding_capacity_harness.py ramp \
+    --start-concurrency 1 --max-concurrency 8 --step 1 \
+    --batch-size 30 --model en --corpus-dir docs
+```
+
+- Stops the moment `memory.events:oom_kill` increments or backpressure
+  sheds — this **will** attempt to OOM the container by design; that is the
+  ceiling-finding mechanism (BP-179 §4, capacity test).
+- The results JSON (`scripts/perf/results/ramp-<timestamp>.json`) includes a
+  `recommendation` table: one `(max_concurrency, mem_limit_bytes)` candidate
+  per concurrency level, each satisfying
+  `base + max_concurrency × per_req_peak + 15% safety ≤ mem_limit`. Pick the
+  row matching your RAM budget vs. throughput tradeoff (BP-179 §1: prefer
+  lowering concurrency over raising the cap).
+- If the container crash-loops or the host visibly thrashes, stop the ramp
+  (Ctrl-C) — you already have the ceiling from the last successful round.
+
+## Step 3 — Apply the envelope (manual, out of harness scope)
+
+Update `EMBEDDING_MEMORY_LIMIT` and `EMBEDDING_MAX_CONCURRENCY` in the
+deployment's `.env` per the chosen row from Step 2, then
+`docker/stack.sh restart` to pick up the new container memory limit (image
+changes need a restart; `install.sh` alone won't recreate the container —
+`feedback_stack_restart_required_for_image_changes`). This is a deliberate,
+reviewed decision — not something the harness does automatically.
+
+## Step 4 — Soak (`soak`)
+
+Validates the chosen envelope survives sustained, burst-shaped, genuine
+multi-caller load and asserts all 6 BP-179 §4 gate criteria. Run overnight.
+
+```bash
+python scripts/perf/embedding_capacity_harness.py soak \
+    --duration-hours 8 \
+    --concurrency-ceiling 4 --waiters 4 \
+    --mem-limit-bytes 6442450944 \
+    --model en --corpus-dir docs \
+    --read-timeout-seconds 30
+```
+
+- `--concurrency-ceiling` + `--waiters` sets the caller count (defaults to
+  their sum unless `--callers` is given explicitly) — BP-179 §4 point 1
+  requires concurrency **at or above** the envelope ceiling plus waiters, so
+  the backpressure queue is genuinely exercised, not just the semaphore.
+- `--mem-limit-bytes` must match whatever `EMBEDDING_MEMORY_LIMIT` is
+  actually set to on the container right now (Step 3) — the gate's
+  `peak_under_mem_limit` criterion is meaningless against the wrong number.
+- The harness snapshots `memory.events` **before** the run and reports
+  deltas — a baseline is mandatory per BP-179 §4; without it, pre-existing
+  kills would be misattributed to this soak.
+- Exit code is `0` only if **all 6** gate criteria pass; any single failure
+  fails the whole gate (BP-179 §4 "assert all", not majority).
+- Results land in `scripts/perf/results/soak-<timestamp>.json` plus a
+  human-readable PASS/FAIL line per criterion on stdout.
+
+## Reading a soak failure
+
+| Failing criterion | What it means | Where to look |
+|---|---|---|
+| `oom_kill_delta_zero` / `dmesg_oom_zero` | The envelope is unsafe — the primary gate. | `docker exec ai-memory-embedding cat /sys/fs/cgroup/memory.events`, `dmesg` |
+| `backpressure_shed_zero` | A request was dropped (lost memory), not just delayed. | `embedding_backpressure_total{action="shed"}` on `:28080/metrics` |
+| `admission_wait_p95_within_timeout` | Clients would time out and retry-storm under this envelope. | `embedding_admission_wait_seconds` histogram |
+| `no_working_set_climb` | Possible slow leak/fragmentation drift (BUG-324 axis). | Compare `working_set_start_bytes`/`working_set_end_bytes` in the results JSON |
+| `peak_under_mem_limit` | `memory.peak` reached or exceeded the cap even without a kill — no safety margin left. | `memory.peak` in the results JSON vs `--mem-limit-bytes` |
+
+A failed soak means: go back to Step 1/2 with a lower `max_concurrency` or
+apply BP-175 §5 footprint knobs and re-measure — do not raise `mem_limit`
+alone (BP-179 §1, lever 3 is last-resort).
+
+## After the run
+
+- Re-enable project memory capture (`aim-pause-updates` toggle back on).
+- Archive the `scripts/perf/results/*.json` files you want to keep — they
+  are gitignored by default (see `.gitignore`); commit selected results
+  explicitly if they should be preserved as evidence for a decision record.

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -1,0 +1,6 @@
+"""Puts scripts/perf on sys.path so tests can import embedding_capacity.* directly."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "perf"))

--- a/tests/perf/test_cgroup.py
+++ b/tests/perf/test_cgroup.py
@@ -200,6 +200,40 @@ def test_peak_poller_stops_cleanly_when_never_started():
     assert poller.stop() == 0
 
 
+def test_peak_poller_surfaces_transient_read_failure(capsys):
+    # A transient docker exec failure mid-poll must not be silently
+    # swallowed: the loop stops, the last-seen max is kept as a floor, and
+    # `degraded` plus a warning surface the failure (round-2 LOW fix).
+    call_count = {"n": 0}
+
+    def exec_fn(container, *cmd):
+        call_count["n"] += 1
+        if call_count["n"] <= 2:
+            return "1000"
+        raise cgroup.CgroupAccessError("docker exec: container not responding")
+
+    reader = cgroup.DockerCgroupReader("c1", exec_fn=exec_fn)
+    poller = cgroup.PeakPoller(reader, interval_seconds=0.01)
+    poller.start()
+    time.sleep(0.1)
+    peak = poller.stop()
+
+    assert peak == 1000
+    assert poller.degraded is True
+    assert "container not responding" in str(poller._poll_error)
+    assert "WARNING" in capsys.readouterr().out
+
+
+def test_peak_poller_not_degraded_on_clean_run():
+    reader = cgroup.DockerCgroupReader("c1", exec_fn=lambda *a: "1000")
+    poller = cgroup.PeakPoller(reader, interval_seconds=0.01)
+    poller.start()
+    time.sleep(0.05)
+    poller.stop()
+
+    assert poller.degraded is False
+
+
 def test_dmesg_baseline_returns_latest_timestamp(monkeypatch):
     class _Result:
         returncode = 0

--- a/tests/perf/test_cgroup.py
+++ b/tests/perf/test_cgroup.py
@@ -1,0 +1,159 @@
+"""Unit tests for scripts/perf/embedding_capacity/cgroup.py — cgroup-v2 access.
+
+Fully mocked at the exec_fn / subprocess.run boundary (BP-179 §2/§3 logic under
+test, never a live container).
+"""
+
+import pytest
+from embedding_capacity import cgroup
+
+
+def _stub_exec(responses):
+    def exec_fn(container, *cmd):
+        key = " ".join(cmd)
+        if key not in responses:
+            raise AssertionError(f"unexpected exec command: {key!r}")
+        return responses[key]
+
+    return exec_fn
+
+
+def test_read_current_parses_int():
+    reader = cgroup.DockerCgroupReader(
+        "c1", exec_fn=_stub_exec({"cat /sys/fs/cgroup/memory.current": "123456\n"})
+    )
+    assert reader.read_current() == 123456
+
+
+def test_read_peak_parses_int():
+    reader = cgroup.DockerCgroupReader(
+        "c1", exec_fn=_stub_exec({"cat /sys/fs/cgroup/memory.peak": "6710886400\n"})
+    )
+    assert reader.read_peak() == 6710886400
+
+
+def test_read_max_handles_literal_max():
+    reader = cgroup.DockerCgroupReader(
+        "c1", exec_fn=_stub_exec({"cat /sys/fs/cgroup/memory.max": "max\n"})
+    )
+    assert reader.read_max() is None
+
+
+def test_read_max_parses_int():
+    reader = cgroup.DockerCgroupReader(
+        "c1", exec_fn=_stub_exec({"cat /sys/fs/cgroup/memory.max": "6442450944\n"})
+    )
+    assert reader.read_max() == 6442450944
+
+
+def test_read_events_parses_multiple_keys():
+    raw = "low 0\nhigh 3\nmax 92979\noom 0\noom_kill 0\noom_group_kill 0\n"
+    reader = cgroup.DockerCgroupReader(
+        "c1", exec_fn=_stub_exec({"cat /sys/fs/cgroup/memory.events": raw})
+    )
+    assert reader.read_events() == {
+        "low": 0,
+        "high": 3,
+        "max": 92979,
+        "oom": 0,
+        "oom_kill": 0,
+        "oom_group_kill": 0,
+    }
+
+
+def test_oom_kill_count_reads_from_events():
+    reader = cgroup.DockerCgroupReader(
+        "c1",
+        exec_fn=_stub_exec({"cat /sys/fs/cgroup/memory.events": "oom_kill 45\n"}),
+    )
+    assert reader.oom_kill_count() == 45
+
+
+def test_oom_kill_count_defaults_to_zero_when_absent():
+    reader = cgroup.DockerCgroupReader(
+        "c1", exec_fn=_stub_exec({"cat /sys/fs/cgroup/memory.events": "low 0\n"})
+    )
+    assert reader.oom_kill_count() == 0
+
+
+def test_reset_peak_writes_zero_to_the_peak_file():
+    calls = []
+
+    def exec_fn(container, *cmd):
+        calls.append(cmd)
+        return ""
+
+    reader = cgroup.DockerCgroupReader("c1", exec_fn=exec_fn)
+    reader.reset_peak()
+    assert calls == [("sh", "-c", "echo 0 > /sys/fs/cgroup/memory.peak")]
+
+
+def test_custom_cgroup_root_is_used_in_paths():
+    calls = []
+
+    def exec_fn(container, *cmd):
+        calls.append(cmd)
+        return "0\n"
+
+    reader = cgroup.DockerCgroupReader(
+        "c1", cgroup_root="/custom/root", exec_fn=exec_fn
+    )
+    reader.read_current()
+    assert calls == [("cat", "/custom/root/memory.current")]
+
+
+def test_read_int_raises_on_garbage():
+    reader = cgroup.DockerCgroupReader(
+        "c1",
+        exec_fn=_stub_exec({"cat /sys/fs/cgroup/memory.current": "not-a-number\n"}),
+    )
+    with pytest.raises(cgroup.CgroupAccessError):
+        reader.read_current()
+
+
+def test_docker_exec_raises_cgroup_access_error_on_nonzero_exit(monkeypatch):
+    class _Result:
+        returncode = 1
+        stdout = ""
+        stderr = "Error: No such container: missing"
+
+    monkeypatch.setattr(cgroup.subprocess, "run", lambda *a, **k: _Result())
+    with pytest.raises(cgroup.CgroupAccessError):
+        cgroup._docker_exec("missing", "cat", "/x")
+
+
+def test_scan_dmesg_oom_filters_by_pattern(monkeypatch):
+    class _Result:
+        returncode = 0
+        stdout = (
+            "[100.0] some unrelated line\n"
+            "[101.0] Out of memory: Killed process 123 (python) total-vm:...\n"
+            "[102.0] Killed process 456 (other-proc)\n"
+        )
+        stderr = ""
+
+    monkeypatch.setattr(cgroup.subprocess, "run", lambda *a, **k: _Result())
+    lines = cgroup.scan_dmesg_oom(process_pattern="python")
+    assert len(lines) == 1
+    assert "python" in lines[0]
+
+
+def test_scan_dmesg_oom_returns_empty_when_no_kills(monkeypatch):
+    class _Result:
+        returncode = 0
+        stdout = "[100.0] unrelated boot message\n"
+        stderr = ""
+
+    monkeypatch.setattr(cgroup.subprocess, "run", lambda *a, **k: _Result())
+    assert cgroup.scan_dmesg_oom() == []
+
+
+def test_scan_dmesg_oom_raises_on_permission_denied(monkeypatch):
+    class _Result:
+        returncode = 1
+        stdout = ""
+        stderr = "dmesg: read kernel buffer failed: Operation not permitted"
+
+    monkeypatch.setattr(cgroup.subprocess, "run", lambda *a, **k: _Result())
+    with pytest.raises(cgroup.CgroupAccessError):
+        cgroup.scan_dmesg_oom()

--- a/tests/perf/test_cgroup.py
+++ b/tests/perf/test_cgroup.py
@@ -4,6 +4,8 @@ Fully mocked at the exec_fn / subprocess.run boundary (BP-179 §2/§3 logic unde
 test, never a live container).
 """
 
+import time
+
 import pytest
 from embedding_capacity import cgroup
 
@@ -157,3 +159,101 @@ def test_scan_dmesg_oom_raises_on_permission_denied(monkeypatch):
     monkeypatch.setattr(cgroup.subprocess, "run", lambda *a, **k: _Result())
     with pytest.raises(cgroup.CgroupAccessError):
         cgroup.scan_dmesg_oom()
+
+
+def test_try_reset_peak_returns_true_on_success():
+    reader = cgroup.DockerCgroupReader("c1", exec_fn=lambda *a: "")
+    assert reader.try_reset_peak() is True
+
+
+def test_try_reset_peak_returns_false_when_reset_unsupported():
+    # BP-179 §2 corrected: kernel 6.6 / read-only cgroup -> reset raises.
+    def exec_fn(container, *cmd):
+        raise cgroup.CgroupAccessError("Read-only file system")
+
+    reader = cgroup.DockerCgroupReader("c1", exec_fn=exec_fn)
+    assert reader.try_reset_peak() is False
+
+
+def test_peak_poller_tracks_max_current_over_time():
+    # First 2 reads return a low baseline value, every read after that returns
+    # a higher value forever — regardless of exact thread-scheduling timing,
+    # any run long enough to poll more than twice must observe the higher max.
+    call_count = {"n": 0}
+
+    def exec_fn(container, *cmd):
+        call_count["n"] += 1
+        return "1000" if call_count["n"] <= 2 else "5000"
+
+    reader = cgroup.DockerCgroupReader("c1", exec_fn=exec_fn)
+    poller = cgroup.PeakPoller(reader, interval_seconds=0.01)
+    poller.start()
+    time.sleep(0.1)
+    peak = poller.stop()
+
+    assert peak == 5000
+
+
+def test_peak_poller_stops_cleanly_when_never_started():
+    reader = cgroup.DockerCgroupReader("c1", exec_fn=lambda *a: "1000")
+    poller = cgroup.PeakPoller(reader)
+    assert poller.stop() == 0
+
+
+def test_dmesg_baseline_returns_latest_timestamp(monkeypatch):
+    class _Result:
+        returncode = 0
+        stdout = "[10.0] boot\n[55.5] some other line\n[30.0] middle\n"
+        stderr = ""
+
+    monkeypatch.setattr(cgroup.subprocess, "run", lambda *a, **k: _Result())
+    assert cgroup.dmesg_baseline() == 55.5
+
+
+def test_dmesg_baseline_returns_zero_when_no_timestamps(monkeypatch):
+    class _Result:
+        returncode = 0
+        stdout = "no timestamps here\n"
+        stderr = ""
+
+    monkeypatch.setattr(cgroup.subprocess, "run", lambda *a, **k: _Result())
+    assert cgroup.dmesg_baseline() == 0.0
+
+
+def test_dmesg_baseline_raises_on_permission_denied(monkeypatch):
+    class _Result:
+        returncode = 1
+        stdout = ""
+        stderr = "dmesg: read kernel buffer failed: Operation not permitted"
+
+    monkeypatch.setattr(cgroup.subprocess, "run", lambda *a, **k: _Result())
+    with pytest.raises(cgroup.CgroupAccessError):
+        cgroup.dmesg_baseline()
+
+
+def test_scan_dmesg_oom_excludes_lines_at_or_before_baseline(monkeypatch):
+    class _Result:
+        returncode = 0
+        stdout = (
+            "[100.0] Out of memory: Killed process 1 (python) stale kill\n"
+            "[200.0] Out of memory: Killed process 2 (python) fresh kill\n"
+        )
+        stderr = ""
+
+    monkeypatch.setattr(cgroup.subprocess, "run", lambda *a, **k: _Result())
+    lines = cgroup.scan_dmesg_oom(process_pattern="python", since_timestamp=100.0)
+
+    assert len(lines) == 1
+    assert "fresh kill" in lines[0]
+
+
+def test_scan_dmesg_oom_keeps_lines_with_unparseable_timestamp(monkeypatch):
+    class _Result:
+        returncode = 0
+        stdout = "Out of memory: Killed process 1 (python) no bracket timestamp\n"
+        stderr = ""
+
+    monkeypatch.setattr(cgroup.subprocess, "run", lambda *a, **k: _Result())
+    lines = cgroup.scan_dmesg_oom(process_pattern="python", since_timestamp=500.0)
+
+    assert len(lines) == 1

--- a/tests/perf/test_envelope.py
+++ b/tests/perf/test_envelope.py
@@ -1,0 +1,84 @@
+"""Unit tests for scripts/perf/embedding_capacity/envelope.py — BP-179 §0/§1 math."""
+
+import pytest
+from embedding_capacity import envelope
+
+GIB = 2**30
+
+
+def test_per_request_burst_peak_divides_by_concurrency():
+    # BP-179 §6 worked example: (6.25 - 2.0) GiB / 4 ~= 1.0625 GiB/slot
+    peak = int(6.25 * GIB)
+    base = int(2.0 * GIB)
+    result = envelope.per_request_burst_peak(peak, base, 4)
+    assert result == pytest.approx((6.25 - 2.0) * GIB / 4)
+
+
+def test_per_request_burst_peak_rejects_zero_concurrency():
+    with pytest.raises(ValueError):
+        envelope.per_request_burst_peak(100, 50, 0)
+
+
+def test_projected_peak_is_base_plus_concurrency_times_per_request():
+    result = envelope.projected_peak(
+        base_rss=2.0 * GIB, max_concurrency=4, per_request_peak=1.0 * GIB
+    )
+    assert result == pytest.approx(6.0 * GIB)
+
+
+def test_required_mem_limit_adds_safety_margin():
+    projected = 6.0 * GIB
+    result = envelope.required_mem_limit(
+        base_rss=2.0 * GIB,
+        per_request_peak=1.0 * GIB,
+        max_concurrency=4,
+        safety_margin_ratio=0.15,
+    )
+    assert result == pytest.approx(projected * 1.15, rel=1e-6)
+
+
+def test_max_concurrency_for_limit_floors_at_one():
+    # Budget too small for even one slot at the given per-request peak.
+    concurrency = envelope.max_concurrency_for_limit(
+        base_rss=5.9 * GIB,
+        per_request_peak=1.0 * GIB,
+        mem_limit=6.0 * GIB,
+        safety_margin_ratio=0.15,
+    )
+    assert concurrency == 1
+
+
+def test_max_concurrency_for_limit_rejects_non_positive_peak():
+    with pytest.raises(ValueError):
+        envelope.max_concurrency_for_limit(
+            base_rss=2.0 * GIB, per_request_peak=0, mem_limit=6.0 * GIB
+        )
+
+
+def test_max_concurrency_for_limit_is_inverse_of_required_mem_limit():
+    # required_mem_limit rounds to the nearest byte, so the round-trip can be off
+    # by one at the margin; the load-bearing invariant is that the mem_limit it
+    # produces for a target concurrency actually admits that concurrency.
+    base_rss = 2.0 * GIB
+    per_request_peak = 0.5 * GIB
+    for target_concurrency in range(1, 6):
+        mem_limit = envelope.required_mem_limit(
+            base_rss, per_request_peak, target_concurrency
+        )
+        recovered = envelope.max_concurrency_for_limit(
+            base_rss, per_request_peak, mem_limit
+        )
+        assert abs(recovered - target_concurrency) <= 1
+
+
+def test_recommend_envelope_returns_one_candidate_per_concurrency_level():
+    candidates = envelope.recommend_envelope(
+        base_rss=2.0 * GIB,
+        per_request_peak=1.0 * GIB,
+        safety_margin_ratio=0.15,
+        candidate_concurrencies=range(1, 5),
+    )
+    assert [c.max_concurrency for c in candidates] == [1, 2, 3, 4]
+    # Higher concurrency must require a larger (or equal) mem_limit — monotonic.
+    mem_limits = [c.mem_limit_bytes for c in candidates]
+    assert mem_limits == sorted(mem_limits)

--- a/tests/perf/test_envelope.py
+++ b/tests/perf/test_envelope.py
@@ -37,40 +37,6 @@ def test_required_mem_limit_adds_safety_margin():
     assert result == pytest.approx(projected * 1.15, rel=1e-6)
 
 
-def test_max_concurrency_for_limit_floors_at_one():
-    # Budget too small for even one slot at the given per-request peak.
-    concurrency = envelope.max_concurrency_for_limit(
-        base_rss=5.9 * GIB,
-        per_request_peak=1.0 * GIB,
-        mem_limit=6.0 * GIB,
-        safety_margin_ratio=0.15,
-    )
-    assert concurrency == 1
-
-
-def test_max_concurrency_for_limit_rejects_non_positive_peak():
-    with pytest.raises(ValueError):
-        envelope.max_concurrency_for_limit(
-            base_rss=2.0 * GIB, per_request_peak=0, mem_limit=6.0 * GIB
-        )
-
-
-def test_max_concurrency_for_limit_is_inverse_of_required_mem_limit():
-    # required_mem_limit rounds to the nearest byte, so the round-trip can be off
-    # by one at the margin; the load-bearing invariant is that the mem_limit it
-    # produces for a target concurrency actually admits that concurrency.
-    base_rss = 2.0 * GIB
-    per_request_peak = 0.5 * GIB
-    for target_concurrency in range(1, 6):
-        mem_limit = envelope.required_mem_limit(
-            base_rss, per_request_peak, target_concurrency
-        )
-        recovered = envelope.max_concurrency_for_limit(
-            base_rss, per_request_peak, mem_limit
-        )
-        assert abs(recovered - target_concurrency) <= 1
-
-
 def test_recommend_envelope_returns_one_candidate_per_concurrency_level():
     candidates = envelope.recommend_envelope(
         base_rss=2.0 * GIB,

--- a/tests/perf/test_gate.py
+++ b/tests/perf/test_gate.py
@@ -18,12 +18,16 @@ BASE_KWARGS = {
     "leak_tolerance_ratio": 0.10,
     "memory_peak_bytes": 5_500_000_000,
     "mem_limit_bytes": 6_000_000_000,
+    "total_requests": 100,
+    "total_failures": 0,
+    "base_rss_bytes": 2_000_000_000,
 }
 
 
 def test_all_criteria_pass_gate_passes():
     result = gate.evaluate_gate(**BASE_KWARGS)
     assert result.passed
+    assert result.outcome == "PASS"
     assert len(result.criteria) == 6
     assert all(c.passed for c in result.criteria)
 
@@ -116,3 +120,46 @@ def test_single_failing_criterion_fails_the_whole_gate():
     passing = [c for c in result.criteria if c.passed]
     assert len(passing) == 5
     assert not result.passed
+    assert result.outcome == "FAIL"
+
+
+def test_load_never_landed_is_invalid_not_pass():
+    # All requests failed (e.g. wrong port) — every criterion trivially holds
+    # (0 oom, 0 shed, no working-set climb) but the run proved nothing.
+    kwargs = {
+        **BASE_KWARGS,
+        "total_requests": 100,
+        "total_failures": 100,
+        "memory_peak_bytes": 2_000_000_100,  # never rose above base_rss
+    }
+    result = gate.evaluate_gate(**kwargs)
+    assert result.outcome == "INVALID"
+    assert not result.passed
+    assert "load may not have landed" in result.load_validity_detail
+
+
+def test_peak_never_rose_above_base_is_invalid():
+    kwargs = {
+        **BASE_KWARGS,
+        "memory_peak_bytes": 2_000_000_000,  # == base_rss, no burst landed
+    }
+    result = gate.evaluate_gate(**kwargs)
+    assert result.outcome == "INVALID"
+    assert "burst may not have landed" in result.load_validity_detail
+
+
+def test_zero_requests_is_invalid():
+    kwargs = {**BASE_KWARGS, "total_requests": 0, "total_failures": 0}
+    result = gate.evaluate_gate(**kwargs)
+    assert result.outcome == "INVALID"
+    assert "no requests were sent" in result.load_validity_detail
+
+
+def test_evaluate_load_validity_passes_with_healthy_run():
+    validity = gate.evaluate_load_validity(
+        total_requests=100,
+        total_failures=2,
+        memory_peak_bytes=5_500_000_000,
+        base_rss_bytes=2_000_000_000,
+    )
+    assert validity.valid

--- a/tests/perf/test_gate.py
+++ b/tests/perf/test_gate.py
@@ -1,0 +1,118 @@
+"""Unit tests for scripts/perf/embedding_capacity/gate.py — BP-179 §4 pass/fail gate.
+
+Each of the 6 criteria is tested independently for its failure case, plus the
+overall pass case, matching the "assert ALL" requirement (a single failing
+criterion must fail the whole gate).
+"""
+
+from embedding_capacity import gate
+
+BASE_KWARGS = {
+    "oom_kill_delta": 0,
+    "dmesg_oom_count": 0,
+    "shed_delta": 0.0,
+    "admission_wait_p95_seconds": 0.5,
+    "client_read_timeout_seconds": 30.0,
+    "working_set_start_bytes": 2_000_000_000,
+    "working_set_end_bytes": 2_050_000_000,
+    "leak_tolerance_ratio": 0.10,
+    "memory_peak_bytes": 5_500_000_000,
+    "mem_limit_bytes": 6_000_000_000,
+}
+
+
+def test_all_criteria_pass_gate_passes():
+    result = gate.evaluate_gate(**BASE_KWARGS)
+    assert result.passed
+    assert len(result.criteria) == 6
+    assert all(c.passed for c in result.criteria)
+
+
+def test_oom_kill_delta_nonzero_fails_gate():
+    kwargs = {**BASE_KWARGS, "oom_kill_delta": 1}
+    result = gate.evaluate_gate(**kwargs)
+    assert not result.passed
+    assert not next(
+        c for c in result.criteria if c.name == "oom_kill_delta_zero"
+    ).passed
+
+
+def test_dmesg_oom_count_nonzero_fails_gate():
+    kwargs = {**BASE_KWARGS, "dmesg_oom_count": 3}
+    result = gate.evaluate_gate(**kwargs)
+    assert not result.passed
+    assert not next(c for c in result.criteria if c.name == "dmesg_oom_zero").passed
+
+
+def test_shed_delta_nonzero_fails_gate():
+    kwargs = {**BASE_KWARGS, "shed_delta": 2.0}
+    result = gate.evaluate_gate(**kwargs)
+    assert not result.passed
+    assert not next(
+        c for c in result.criteria if c.name == "backpressure_shed_zero"
+    ).passed
+
+
+def test_admission_wait_p95_over_timeout_fails_gate():
+    kwargs = {**BASE_KWARGS, "admission_wait_p95_seconds": 45.0}
+    result = gate.evaluate_gate(**kwargs)
+    assert not result.passed
+    assert not next(
+        c for c in result.criteria if c.name == "admission_wait_p95_within_timeout"
+    ).passed
+
+
+def test_admission_wait_p95_none_fails_gate_not_silently_passes():
+    kwargs = {**BASE_KWARGS, "admission_wait_p95_seconds": None}
+    result = gate.evaluate_gate(**kwargs)
+    assert not result.passed
+    criterion = next(
+        c for c in result.criteria if c.name == "admission_wait_p95_within_timeout"
+    )
+    assert not criterion.passed
+    assert "unavailable" in criterion.detail
+
+
+def test_working_set_climb_beyond_tolerance_fails_gate():
+    kwargs = {
+        **BASE_KWARGS,
+        "working_set_start_bytes": 2_000_000_000,
+        "working_set_end_bytes": 3_000_000_000,  # 50% climb, tolerance is 10%
+    }
+    result = gate.evaluate_gate(**kwargs)
+    assert not result.passed
+    assert not next(
+        c for c in result.criteria if c.name == "no_working_set_climb"
+    ).passed
+
+
+def test_working_set_within_tolerance_passes():
+    kwargs = {
+        **BASE_KWARGS,
+        "working_set_start_bytes": 2_000_000_000,
+        "working_set_end_bytes": 2_100_000_000,  # 5% climb, within 10% tolerance
+    }
+    result = gate.evaluate_gate(**kwargs)
+    assert next(c for c in result.criteria if c.name == "no_working_set_climb").passed
+
+
+def test_peak_at_or_over_mem_limit_fails_gate():
+    kwargs = {
+        **BASE_KWARGS,
+        "memory_peak_bytes": 6_000_000_000,
+        "mem_limit_bytes": 6_000_000_000,
+    }
+    result = gate.evaluate_gate(**kwargs)
+    assert not result.passed
+    assert not next(
+        c for c in result.criteria if c.name == "peak_under_mem_limit"
+    ).passed
+
+
+def test_single_failing_criterion_fails_the_whole_gate():
+    # 5 of 6 pass; the gate must still fail (assert ALL, not majority).
+    kwargs = {**BASE_KWARGS, "oom_kill_delta": 1}
+    result = gate.evaluate_gate(**kwargs)
+    passing = [c for c in result.criteria if c.passed]
+    assert len(passing) == 5
+    assert not result.passed

--- a/tests/perf/test_harness_orchestrator.py
+++ b/tests/perf/test_harness_orchestrator.py
@@ -1,0 +1,187 @@
+"""Edge-case tests for scripts/perf/embedding_capacity_harness.py's CLI modes.
+
+Fully mocked at the `subprocess.run` / `load.run_*` boundaries (never a live
+container or service) — covers the three orchestrator gaps that let B2/M1/M3
+slip through the round-1 review: the reset-unsupported fallback path, an
+empty-clean-rounds ramp, and an all-failed soak.
+"""
+
+import json
+
+import embedding_capacity_harness as harness
+from embedding_capacity import load
+
+
+class _FakeResult:
+    def __init__(self, returncode, stdout, stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _fake_subprocess_run(responses, default=(0, "0\n", "")):
+    """`responses` maps a command key to either a static (rc, stdout, stderr)
+    tuple, or a list of such tuples consumed in call order (for a command
+    invoked more than once with a different answer each time, e.g. a
+    baseline vs. a later read of the same file)."""
+    counters: dict[str, int] = {}
+
+    def run(cmd, **kwargs):
+        key = " ".join(cmd[3:]) if cmd[0] == "docker" else " ".join(cmd)
+        entry = responses.get(key, default)
+        if isinstance(entry, list):
+            idx = counters.get(key, 0)
+            counters[key] = idx + 1
+            rc, out, err = entry[min(idx, len(entry) - 1)]
+        else:
+            rc, out, err = entry
+        return _FakeResult(rc, out, err)
+
+    return run
+
+
+async def _fake_run_burst(base_url, requests, model="en", timeout=60.0, client=None):
+    return [load.RequestResult(status_code=200, elapsed_seconds=0.01) for _ in requests]
+
+
+def test_cmd_measure_falls_back_to_dense_poll_when_reset_unsupported(
+    tmp_path, monkeypatch
+):
+    # B2: kernel 6.6 / read-only cgroup -> memory.peak reset fails; the burst
+    # peak must still be measured via the memory.current dense-poll fallback,
+    # not a crash or a guessed value.
+    responses = {
+        "cat /sys/fs/cgroup/memory.current": (0, "3221225472\n", ""),
+        "sh -c echo 0 > /sys/fs/cgroup/memory.peak": (1, "", "Read-only file system"),
+    }
+    monkeypatch.setattr(
+        harness.cgroup.subprocess, "run", _fake_subprocess_run(responses)
+    )
+    monkeypatch.setattr(harness.load, "run_burst", _fake_run_burst)
+    (tmp_path / "notes.md").write_text("real corpus content " * 50)
+
+    args = harness.build_parser().parse_args(
+        [
+            "measure",
+            "--concurrency",
+            "2",
+            "--batch-size",
+            "5",
+            "--corpus-dir",
+            str(tmp_path),
+            "--output-dir",
+            str(tmp_path),
+        ]
+    )
+    rc = harness.cmd_measure(args)
+
+    assert rc == 0
+    out_files = list(tmp_path.glob("measure-*.json"))
+    assert len(out_files) == 1
+    data = json.loads(out_files[0].read_text())
+    assert data["peak_measurement_fallback_used"] is True
+    assert data["memory_peak_bytes"] == 3221225472
+
+
+def test_cmd_ramp_reports_null_ceiling_when_every_round_fails(tmp_path, monkeypatch):
+    # M1: the very first round OOMs -> there is no safe concurrency at all.
+    # The old code reported start_concurrency as the "ceiling" even though
+    # that level itself triggered the failure; it must now report null.
+    responses = {
+        "cat /sys/fs/cgroup/memory.current": (0, "1000000000\n", ""),
+        "sh -c echo 0 > /sys/fs/cgroup/memory.peak": (0, "", ""),
+        "cat /sys/fs/cgroup/memory.peak": (0, "1000000000\n", ""),
+        "cat /sys/fs/cgroup/memory.events": [
+            (0, "oom_kill 0\n", ""),  # baseline
+            (0, "oom_kill 1\n", ""),  # after round 1 -> delta 1
+        ],
+    }
+    monkeypatch.setattr(
+        harness.cgroup.subprocess, "run", _fake_subprocess_run(responses)
+    )
+    monkeypatch.setattr(harness.load, "run_burst", _fake_run_burst)
+    monkeypatch.setattr(
+        harness.metrics_client, "fetch_metrics_text", lambda *a, **k: ""
+    )
+    (tmp_path / "notes.md").write_text("real corpus content " * 50)
+
+    args = harness.build_parser().parse_args(
+        [
+            "ramp",
+            "--start-concurrency",
+            "1",
+            "--max-concurrency",
+            "1",
+            "--corpus-dir",
+            str(tmp_path),
+            "--output-dir",
+            str(tmp_path),
+        ]
+    )
+    rc = harness.cmd_ramp(args)
+
+    assert rc == 1
+    out_files = list(tmp_path.glob("ramp-*.json"))
+    data = json.loads(out_files[0].read_text())
+    assert data["ceiling_concurrency"] is None
+    assert "no safe concurrency found" in data["ceiling_message"]
+
+
+async def _fake_run_soak_callers_all_fail(
+    base_url, n_callers, duration_seconds, payload_fn, model="en", **kwargs
+):
+    return [
+        load.CallerStats(
+            caller_id=i,
+            requests_sent=5,
+            results=[load.RequestResult(503, 0.01) for _ in range(5)],
+        )
+        for i in range(n_callers)
+    ]
+
+
+def test_cmd_soak_all_failed_requests_is_invalid_not_pass(tmp_path, monkeypatch):
+    # M3: every request 503s (e.g. wrong port) -> oom==0, shed==0, no climb —
+    # every criterion trivially "passes", but the load never landed. The gate
+    # must report INVALID, not PASS.
+    responses = {
+        "cat /sys/fs/cgroup/memory.current": (0, "1000000000\n", ""),
+        "sh -c echo 0 > /sys/fs/cgroup/memory.peak": (0, "", ""),
+        "cat /sys/fs/cgroup/memory.peak": (0, "1000000000\n", ""),
+        "cat /sys/fs/cgroup/memory.events": (0, "oom_kill 0\n", ""),
+        "dmesg": (0, "", ""),
+    }
+    monkeypatch.setattr(
+        harness.cgroup.subprocess, "run", _fake_subprocess_run(responses)
+    )
+    monkeypatch.setattr(
+        harness.load, "run_soak_callers", _fake_run_soak_callers_all_fail
+    )
+    monkeypatch.setattr(
+        harness.metrics_client, "fetch_metrics_text", lambda *a, **k: ""
+    )
+
+    args = harness.build_parser().parse_args(
+        [
+            "soak",
+            "--duration-seconds",
+            "1",
+            "--callers",
+            "2",
+            "--mem-limit-bytes",
+            "6442450944",
+            "--corpus-dir",
+            str(tmp_path),
+            "--output-dir",
+            str(tmp_path),
+        ]
+    )
+    rc = harness.cmd_soak(args)
+
+    assert rc == 2
+    out_files = list(tmp_path.glob("soak-*.json"))
+    data = json.loads(out_files[0].read_text())
+    assert data["gate_outcome"] == "INVALID"
+    assert data["gate_passed"] is False
+    assert data["total_requests"] == 10
+    assert data["total_failures"] == 10

--- a/tests/perf/test_load.py
+++ b/tests/perf/test_load.py
@@ -1,0 +1,117 @@
+"""Unit tests for scripts/perf/embedding_capacity/load.py — async load generation.
+
+Uses httpx.MockTransport so these run fully offline against a fake embedding
+endpoint — no live service or Docker needed.
+"""
+
+import asyncio
+
+import httpx
+import pytest
+from embedding_capacity import load
+
+pytestmark = pytest.mark.asyncio
+
+
+def _client_with_handler(handler):
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+async def test_run_burst_returns_one_result_per_request():
+    async def handler(request):
+        return httpx.Response(
+            200, json={"embeddings": [[0.1]], "model": "en", "dimensions": 1}
+        )
+
+    client = _client_with_handler(handler)
+    requests = [["text a"], ["text b"], ["text c"]]
+    results = await load.run_burst("http://fake", requests, model="en", client=client)
+    await client.aclose()
+
+    assert len(results) == 3
+    assert all(r.status_code == 200 for r in results)
+
+
+async def test_run_burst_fires_all_requests_concurrently():
+    active = 0
+    max_active = 0
+    lock = asyncio.Lock()
+
+    async def handler(request):
+        nonlocal active, max_active
+        async with lock:
+            active += 1
+            max_active = max(max_active, active)
+        await asyncio.sleep(0.05)
+        async with lock:
+            active -= 1
+        return httpx.Response(
+            200, json={"embeddings": [], "model": "en", "dimensions": 1}
+        )
+
+    client = _client_with_handler(handler)
+    requests = [["t"] for _ in range(5)]
+    await load.run_burst("http://fake", requests, model="en", client=client)
+    await client.aclose()
+
+    # All 5 requests must be in flight simultaneously — a serialized loop would
+    # peak at max_active == 1, which is exactly the under-stress trap BP-179 §4
+    # warns against for the measure/ramp burst.
+    assert max_active == 5
+
+
+async def test_run_burst_records_error_on_transport_failure():
+    def handler(request):
+        raise httpx.ConnectError("connection refused", request=request)
+
+    client = _client_with_handler(handler)
+    results = await load.run_burst("http://fake", [["t"]], model="en", client=client)
+    await client.aclose()
+
+    assert results[0].status_code == 0
+    assert results[0].error is not None
+
+
+async def test_run_soak_callers_each_caller_sends_multiple_requests():
+    call_count = 0
+
+    async def handler(request):
+        nonlocal call_count
+        call_count += 1
+        return httpx.Response(
+            200, json={"embeddings": [], "model": "en", "dimensions": 1}
+        )
+
+    stats = await load.run_soak_callers(
+        "http://fake",
+        n_callers=3,
+        duration_seconds=0.2,
+        payload_fn=lambda: ["t"],
+        transport=httpx.MockTransport(handler),
+        jitter_seconds=(0.01, 0.02),
+    )
+
+    assert len(stats) == 3
+    assert all(s.requests_sent >= 1 for s in stats)
+    assert sum(s.requests_sent for s in stats) == call_count
+
+
+async def test_run_soak_callers_stops_at_duration():
+    async def handler(request):
+        return httpx.Response(
+            200, json={"embeddings": [], "model": "en", "dimensions": 1}
+        )
+
+    start = asyncio.get_event_loop().time()
+    await load.run_soak_callers(
+        "http://fake",
+        n_callers=2,
+        duration_seconds=0.15,
+        payload_fn=lambda: ["t"],
+        transport=httpx.MockTransport(handler),
+        jitter_seconds=(0.01, 0.02),
+    )
+    elapsed = asyncio.get_event_loop().time() - start
+
+    # Loop exits once the stop deadline passes, not indefinitely.
+    assert elapsed < 1.0

--- a/tests/perf/test_metrics_client.py
+++ b/tests/perf/test_metrics_client.py
@@ -1,0 +1,82 @@
+"""Unit tests for scripts/perf/embedding_capacity/metrics_client.py — /metrics parsing.
+
+Works entirely off raw exposition text, matching what a live embedding
+container's `/metrics` endpoint returns (BP-179 §6) — no live service needed.
+"""
+
+import pytest
+from embedding_capacity import metrics_client
+
+SAMPLE_METRICS = """
+# HELP embedding_backpressure Backpressure actions
+# TYPE embedding_backpressure counter
+embedding_backpressure_total{action="waited"} 12.0
+embedding_backpressure_total{action="shed"} 0.0
+embedding_backpressure_total{action="over_envelope_reject"} 3.0
+# HELP embedding_effective_concurrency_limit AIMD effective limit
+# TYPE embedding_effective_concurrency_limit gauge
+embedding_effective_concurrency_limit 4.0
+# HELP embedding_admission_wait_seconds Admission wait
+# TYPE embedding_admission_wait_seconds histogram
+embedding_admission_wait_seconds_bucket{le="0.01"} 0.0
+embedding_admission_wait_seconds_bucket{le="0.1"} 2.0
+embedding_admission_wait_seconds_bucket{le="0.5"} 8.0
+embedding_admission_wait_seconds_bucket{le="1"} 10.0
+embedding_admission_wait_seconds_bucket{le="2"} 10.0
+embedding_admission_wait_seconds_bucket{le="+Inf"} 10.0
+embedding_admission_wait_seconds_sum 3.2
+embedding_admission_wait_seconds_count 10.0
+"""
+
+
+def test_parse_metrics_backpressure_by_action():
+    snapshot = metrics_client.parse_metrics(SAMPLE_METRICS)
+    assert snapshot.backpressure == {
+        "waited": 12.0,
+        "shed": 0.0,
+        "over_envelope_reject": 3.0,
+    }
+
+
+def test_parse_metrics_effective_concurrency_limit():
+    snapshot = metrics_client.parse_metrics(SAMPLE_METRICS)
+    assert snapshot.effective_concurrency_limit == 4.0
+
+
+def test_parse_metrics_histogram_p95_interpolates():
+    snapshot = metrics_client.parse_metrics(SAMPLE_METRICS)
+    # target = 0.95 * 10 = 9.5, falls between le=0.5 (count 8) and le=1 (count 10)
+    expected = 0.5 + (9.5 - 8) / (10 - 8) * (1 - 0.5)
+    assert snapshot.admission_wait_p95_seconds == pytest.approx(expected)
+
+
+def test_parse_metrics_histogram_count_and_sum():
+    snapshot = metrics_client.parse_metrics(SAMPLE_METRICS)
+    assert snapshot.admission_wait_count == 10.0
+    assert snapshot.admission_wait_sum == 3.2
+
+
+def test_parse_metrics_missing_metrics_return_defaults():
+    snapshot = metrics_client.parse_metrics("# empty\n")
+    assert snapshot.backpressure == {}
+    assert snapshot.effective_concurrency_limit is None
+    assert snapshot.admission_wait_p95_seconds is None
+
+
+def test_histogram_quantile_at_exact_bucket_boundary():
+    buckets = {0.1: 5.0, 0.5: 10.0, 1.0: 10.0}
+    # q=0.5 * total(10) = 5, matches the first bucket exactly
+    assert metrics_client._histogram_quantile(buckets, total_count=10.0, q=0.5) == 0.1
+
+
+def test_histogram_quantile_beyond_finite_buckets_returns_none():
+    # Highest finite bucket's cumulative count (5) never reaches the q=0.99
+    # target (9.9 of 10) — the quantile falls in the (unbounded) +Inf bucket.
+    buckets = {0.1: 2.0, 0.5: 5.0}
+    assert metrics_client._histogram_quantile(buckets, total_count=10.0, q=0.99) is None
+
+
+def test_histogram_quantile_zero_total_count_returns_none():
+    assert (
+        metrics_client._histogram_quantile({0.1: 0.0}, total_count=0.0, q=0.95) is None
+    )

--- a/tests/perf/test_payloads.py
+++ b/tests/perf/test_payloads.py
@@ -5,6 +5,9 @@ module slices genuine corpus content (given a real directory) and only falls
 back to a clearly-marked placeholder when the corpus is empty.
 """
 
+import warnings
+
+import pytest
 from embedding_capacity import payloads
 
 
@@ -38,10 +41,37 @@ def test_sample_texts_respects_model_glob_pattern(tmp_path):
 
 def test_sample_texts_falls_back_to_marked_placeholder_when_corpus_empty(tmp_path):
     dist = payloads.LengthDistribution(p50_chars=100, p99_chars=500)
-    texts = payloads.sample_texts(tmp_path, n=3, distribution=dist, model="en", seed=1)
+    with pytest.warns(UserWarning, match="falling back to placeholder"):
+        texts = payloads.sample_texts(
+            tmp_path, n=3, distribution=dist, model="en", seed=1
+        )
 
     assert len(texts) == 3
     assert all("harness-smoke-placeholder-corpus-empty" in text for text in texts)
+
+
+def test_sample_texts_does_not_warn_when_corpus_has_content(tmp_path):
+    (tmp_path / "notes.md").write_text("word " * 5000)
+    dist = payloads.LengthDistribution(p50_chars=100, p99_chars=500)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        payloads.sample_texts(tmp_path, n=3, distribution=dist, model="en", seed=1)
+
+
+def test_corpus_is_empty_true_when_no_matching_files(tmp_path):
+    assert payloads.corpus_is_empty(tmp_path, model="en") is True
+
+
+def test_corpus_is_empty_false_when_matching_files_present(tmp_path):
+    (tmp_path / "notes.md").write_text("some content")
+    assert payloads.corpus_is_empty(tmp_path, model="en") is False
+
+
+def test_corpus_is_empty_respects_model_glob(tmp_path):
+    (tmp_path / "code.py").write_text("def f():\n    return 1\n")
+    assert payloads.corpus_is_empty(tmp_path, model="en") is True
+    assert payloads.corpus_is_empty(tmp_path, model="code") is False
 
 
 def test_sample_texts_is_deterministic_with_seed(tmp_path):

--- a/tests/perf/test_payloads.py
+++ b/tests/perf/test_payloads.py
@@ -1,0 +1,70 @@
+"""Unit tests for scripts/perf/embedding_capacity/payloads.py — realistic payload sampling.
+
+BP-179 §2 requires realistic payloads, NOT toy strings; these tests verify the
+module slices genuine corpus content (given a real directory) and only falls
+back to a clearly-marked placeholder when the corpus is empty.
+"""
+
+from embedding_capacity import payloads
+
+
+def test_sample_texts_slices_real_corpus_content(tmp_path):
+    corpus = tmp_path / "notes.md"
+    corpus.write_text("word " * 5000)  # 25000 chars of real (if repetitive) content
+    dist = payloads.LengthDistribution(p50_chars=100, p99_chars=500)
+
+    texts = payloads.sample_texts(tmp_path, n=10, distribution=dist, model="en", seed=1)
+
+    assert len(texts) == 10
+    assert all(text.strip() for text in texts)
+    assert not any("harness-smoke-placeholder" in text for text in texts)
+
+
+def test_sample_texts_respects_model_glob_pattern(tmp_path):
+    (tmp_path / "prose.md").write_text("prose content " * 1000)
+    (tmp_path / "code.py").write_text("def f():\n    return 1\n" * 1000)
+    dist = payloads.LengthDistribution(p50_chars=50, p99_chars=200)
+
+    en_texts = payloads.sample_texts(
+        tmp_path, n=5, distribution=dist, model="en", seed=1
+    )
+    code_texts = payloads.sample_texts(
+        tmp_path, n=5, distribution=dist, model="code", seed=1
+    )
+
+    assert all("prose content" in t for t in en_texts)
+    assert all("def f" in t or "return 1" in t for t in code_texts)
+
+
+def test_sample_texts_falls_back_to_marked_placeholder_when_corpus_empty(tmp_path):
+    dist = payloads.LengthDistribution(p50_chars=100, p99_chars=500)
+    texts = payloads.sample_texts(tmp_path, n=3, distribution=dist, model="en", seed=1)
+
+    assert len(texts) == 3
+    assert all("harness-smoke-placeholder-corpus-empty" in text for text in texts)
+
+
+def test_sample_texts_is_deterministic_with_seed(tmp_path):
+    corpus = tmp_path / "notes.md"
+    corpus.write_text("some deterministic content " * 500)
+    dist = payloads.LengthDistribution(p50_chars=100, p99_chars=300)
+
+    first = payloads.sample_texts(tmp_path, n=5, distribution=dist, model="en", seed=42)
+    second = payloads.sample_texts(
+        tmp_path, n=5, distribution=dist, model="en", seed=42
+    )
+
+    assert first == second
+
+
+def test_length_distribution_sample_is_near_p50_to_p99_range():
+    dist = payloads.LengthDistribution(p50_chars=800, p99_chars=2048)
+    import random
+
+    rng = random.Random(7)
+    samples = [dist.sample(rng) for _ in range(500)]
+    # Almost all draws should land within [p50, p99] * generous slack for the ~1% tail.
+    within_range = sum(
+        1 for s in samples if dist.p50_chars <= s <= dist.p99_chars * 1.5
+    )
+    assert within_range / len(samples) > 0.95

--- a/tests/perf/test_results.py
+++ b/tests/perf/test_results.py
@@ -26,6 +26,9 @@ def test_write_results_json_serializes_nested_dataclasses(tmp_path):
         leak_tolerance_ratio=0.10,
         memory_peak_bytes=5000,
         mem_limit_bytes=6000,
+        total_requests=100,
+        total_failures=0,
+        base_rss_bytes=1000,
     )
     out_path = tmp_path / "soak.json"
     results.write_results_json(

--- a/tests/perf/test_results.py
+++ b/tests/perf/test_results.py
@@ -1,0 +1,38 @@
+"""Unit tests for scripts/perf/embedding_capacity/results.py — machine-readable output."""
+
+import json
+
+from embedding_capacity import gate, results
+
+
+def test_write_results_json_creates_parent_dirs_and_valid_json(tmp_path):
+    out_path = tmp_path / "nested" / "measure.json"
+    results.write_results_json(out_path, {"mode": "measure", "base_rss_bytes": 123})
+
+    assert out_path.exists()
+    data = json.loads(out_path.read_text())
+    assert data == {"mode": "measure", "base_rss_bytes": 123}
+
+
+def test_write_results_json_serializes_nested_dataclasses(tmp_path):
+    gate_result = gate.evaluate_gate(
+        oom_kill_delta=0,
+        dmesg_oom_count=0,
+        shed_delta=0.0,
+        admission_wait_p95_seconds=0.5,
+        client_read_timeout_seconds=30.0,
+        working_set_start_bytes=1000,
+        working_set_end_bytes=1010,
+        leak_tolerance_ratio=0.10,
+        memory_peak_bytes=5000,
+        mem_limit_bytes=6000,
+    )
+    out_path = tmp_path / "soak.json"
+    results.write_results_json(
+        out_path, {"gate": gate_result, "gate_passed": gate_result.passed}
+    )
+
+    data = json.loads(out_path.read_text())
+    assert data["gate_passed"] is True
+    assert len(data["gate"]["criteria"]) == 6
+    assert data["gate"]["criteria"][0]["name"] == "oom_kill_delta_zero"


### PR DESCRIPTION
## Summary
- Adds `scripts/perf/embedding_capacity_harness.py` (measure / ramp / soak CLI) that measures the ai-memory-embedding service's real per-request memory burst peak, ramps concurrency to find its OOM ceiling, and soaks a chosen envelope against BP-179's six-criterion pass/fail gate.
- OOM detection uses cgroup `memory.events:oom_kill` + `dmesg` only (BP-179 §3/§5) — never the Docker `OOMKilled` flag or the app's own gauge, both of which are blind to worker-level kills (BUG-329).
- Measurement-only: drives and observes the resilience mechanism already shipped in `docker/embedding/main.py` (semaphore, AIMD, cgroup reads) over HTTP + `docker exec`. Does not modify the service or its shipped defaults.
- Adds `scripts/perf/runbook.md` for the overnight measure → size → soak sequence, including pausing project memory capture during the window.

## Test plan
- [x] `black`, `ruff`, `isort` clean on `scripts/perf/` and `tests/perf/`
- [x] `pytest tests/perf/` — 52 unit tests, all passing (envelope math, gate logic, cgroup/metrics parsing, mocked load generation — no live service required)
- [x] CLI `--help` verified for all three subcommands (`measure`, `ramp`, `soak`)
- [x] Confirmed pre-existing `tests/test_cross_project_best_practices.py` collection error reproduces identically on `origin/main` with no harness files present — unrelated to this change
- [ ] Live measure → ramp → soak run against the real container (separate overnight step per the dispatch brief; out of scope for this PR)