### PR TITLE
Fix in-container Qdrant gRPC connectivity: container port override + retry-drain preflight

### DIFF
--- a/docker/docker-compose.langfuse.yml
+++ b/docker/docker-compose.langfuse.yml
@@ -392,6 +392,7 @@ services:
       # any future MemoryConfig.qdrant_port read from this service.
       - QDRANT_HOST=qdrant                            # container-internal hostname
       - QDRANT_PORT=6333                               # container-internal port
+      - QDRANT_GRPC_PORT=6334                          # container-internal gRPC port
       - LANGFUSE_ENABLED=true
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:?Run langfuse_setup.sh first to generate API keys}
       - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY:?Run langfuse_setup.sh first to generate API keys}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -173,6 +173,7 @@ services:
       # Service-specific overrides — all other config comes from env_file: (BP-152 §3.2/3.3)
       - QDRANT_HOST=qdrant       # container-internal hostname (not localhost)
       - QDRANT_PORT=6333         # container-internal port (not host port QDRANT_PORT)
+      - QDRANT_GRPC_PORT=6334                          # container-internal gRPC port
       - VECTOR_DIMENSIONS=768    # hardcoded — not user-tunable via .env
     depends_on:
       qdrant:
@@ -409,6 +410,7 @@ services:
       # Service-specific overrides — all other config comes from env_file: (BP-152 §3.2/3.3)
       - QDRANT_HOST=qdrant                             # container-internal hostname
       - QDRANT_PORT=6333                               # container-internal port
+      - QDRANT_GRPC_PORT=6334                          # container-internal gRPC port
       - QDRANT_EXTERNAL_PORT=26350                     # hardcoded external reference for UI links
       - EMBEDDING_SERVICE_URL=http://embedding:8080    # container-internal URL
       - AI_MEMORY_INSTALL_DIR=/app                     # container path override
@@ -461,6 +463,7 @@ services:
       # Service-specific overrides — all other config comes from env_file: (BP-152 §3.2/3.3)
       - QDRANT_HOST=qdrant                            # container-internal hostname
       - QDRANT_PORT=6333                              # container-internal port
+      - QDRANT_GRPC_PORT=6334                          # container-internal gRPC port
       - PUSHGATEWAY_URL=pushgateway:9091              # container-internal URL
       - LANGFUSE_BASE_URL=http://langfuse-web:3000    # container-internal URL
       # BUG-150: LANGFUSE_TRACING_ENABLED mirrors LANGFUSE_ENABLED — Docker-only alias,
@@ -531,6 +534,7 @@ services:
       # Service-specific overrides — all other config comes from env_file: (BP-152 §3.2/3.3)
       - QDRANT_HOST=qdrant                            # container-internal hostname
       - QDRANT_PORT=6333                              # container-internal port
+      - QDRANT_GRPC_PORT=6334                          # container-internal gRPC port
       - EMBEDDING_HOST=embedding                      # container-internal hostname
       - EMBEDDING_PORT=8080                           # container-internal port
       - PUSHGATEWAY_URL=pushgateway:9091              # container-internal URL
@@ -603,6 +607,7 @@ services:
       # Service-specific overrides — all other config comes from env_file: (BP-152 §3.2/3.3)
       - QDRANT_HOST=qdrant                            # container-internal hostname
       - QDRANT_PORT=6333                              # container-internal port
+      - QDRANT_GRPC_PORT=6334                          # container-internal gRPC port
       - EMBEDDING_HOST=embedding                      # container-internal hostname
       - EMBEDDING_PORT=8080                           # container-internal port
       - PUSHGATEWAY_URL=pushgateway:9091              # container-internal URL

--- a/scripts/memory/retry_drain_scheduler.py
+++ b/scripts/memory/retry_drain_scheduler.py
@@ -17,13 +17,18 @@ Usage:
     python scripts/memory/retry_drain_scheduler.py
 
 Environment:
-    RETRY_DRAIN_INTERVAL_SECONDS   Seconds between drains (default: 900 = 15 min)
-    RETRY_DRAIN_LIMIT              Max entries per drain cycle (default: 100)
-    AI_MEMORY_LOG_LEVEL           Log level (default: INFO)
+    RETRY_DRAIN_INTERVAL_SECONDS         Seconds between drains (default: 900 = 15 min)
+    RETRY_DRAIN_LIMIT                    Max entries per drain cycle (default: 100)
+    RETRY_DRAIN_GRPC_PREFLIGHT_MAX_ATTEMPTS  Max gRPC-readiness probe attempts at
+                                          startup before falling through (default: 30)
+    RETRY_DRAIN_GRPC_PREFLIGHT_SLEEP_SECONDS  Seconds between preflight probe
+                                          attempts (default: 2)
+    AI_MEMORY_LOG_LEVEL                  Log level (default: INFO)
 
 Reference:
 - BP-181 (WSL2 periodic execution), BP-180 (durable retry queue), BUG-522
 - DEC-110 (standalone scheduler container pattern)
+- TD-777 (bounded gRPC-readiness preflight)
 """
 
 import logging
@@ -43,6 +48,9 @@ sys.path.insert(0, os.path.join(INSTALL_DIR, "src"))
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from process_retry_queue import drain_lock, process_queue  # noqa: E402
+from qdrant_client import QdrantClient  # noqa: E402
+
+from memory.config import get_config  # noqa: E402
 
 HEALTH_FILE = Path("/tmp/retry-queue-drain.health")
 
@@ -50,6 +58,13 @@ HEALTH_FILE = Path("/tmp/retry-queue-drain.health")
 # recovery latency and load for a durable queue.
 DEFAULT_INTERVAL_SECONDS = 900
 DEFAULT_LIMIT = 100
+
+# TD-777: qdrant's compose `service_healthy` gate is the HTTP probe, which
+# passes before the gRPC listener accepts connections. These bound the
+# gRPC-readiness preflight (see _wait_for_grpc_ready) so the daemon never
+# hangs waiting for gRPC — it just falls through to normal operation.
+DEFAULT_GRPC_PREFLIGHT_MAX_ATTEMPTS = 30
+DEFAULT_GRPC_PREFLIGHT_SLEEP_SECONDS = 2
 
 logging.basicConfig(
     level=os.environ.get("AI_MEMORY_LOG_LEVEL", "INFO"),
@@ -104,6 +119,65 @@ def _positive_int_env(name: str, default: int) -> int:
     return value
 
 
+def _wait_for_grpc_ready() -> None:
+    """Bounded preflight: poll Qdrant gRPC readiness with a THROWAWAY client.
+
+    TD-777: docker-compose's qdrant `service_healthy` gate is an HTTP probe
+    that passes before the gRPC listener (container :6334 / host :26351)
+    accepts connections. If the daemon's first process_queue() call reaches
+    get_qdrant_client() while gRPC is still unready, that function falls back
+    to HTTP and CACHES the HTTP-only client for the process lifetime
+    (src/memory/qdrant_client.py:107-135). This preflight never calls
+    get_qdrant_client() — it probes with a disposable raw QdrantClient so the
+    real client is only built (and cached) once gRPC is actually reachable.
+
+    Bounded by RETRY_DRAIN_GRPC_PREFLIGHT_MAX_ATTEMPTS attempts, sleeping
+    RETRY_DRAIN_GRPC_PREFLIGHT_SLEEP_SECONDS between them. If the budget
+    expires, logs a warning and falls through to normal operation — never
+    raises, never crashes the daemon.
+    """
+    max_attempts = _positive_int_env(
+        "RETRY_DRAIN_GRPC_PREFLIGHT_MAX_ATTEMPTS", DEFAULT_GRPC_PREFLIGHT_MAX_ATTEMPTS
+    )
+    sleep_seconds = _positive_int_env(
+        "RETRY_DRAIN_GRPC_PREFLIGHT_SLEEP_SECONDS",
+        DEFAULT_GRPC_PREFLIGHT_SLEEP_SECONDS,
+    )
+
+    config = get_config()
+    grpc_port = int(os.getenv("QDRANT_GRPC_PORT", "6334"))
+    api_key = (
+        config.qdrant_api_key.get_secret_value() if config.qdrant_api_key else None
+    )
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            probe = QdrantClient(
+                host=config.qdrant_host,
+                port=config.qdrant_port,
+                api_key=api_key,
+                https=config.qdrant_use_https,
+                timeout=config.qdrant_timeout,
+                prefer_grpc=True,
+                grpc_port=grpc_port,
+                check_compatibility=False,
+            )
+            probe.get_collections()
+            logger.info("grpc_preflight_ready attempt=%d", attempt)
+            return
+        except Exception as exc:
+            logger.debug("grpc_preflight_not_ready attempt=%d error=%s", attempt, exc)
+            if attempt < max_attempts and not _shutdown_requested:
+                time.sleep(sleep_seconds)
+
+    logger.warning(
+        "grpc_preflight_budget_exhausted attempts=%d — proceeding without "
+        "confirmed gRPC readiness; first process_queue() may cache an "
+        "HTTP-only client",
+        max_attempts,
+    )
+
+
 def run_scheduler() -> None:
     """Main drain loop: drain, heartbeat, sleep — until shutdown is requested."""
     interval = _positive_int_env(
@@ -118,6 +192,9 @@ def run_scheduler() -> None:
     # Touch health file on startup so the Docker healthcheck passes immediately
     # (do not wait until the first drain completes — BUG-045 pattern).
     _touch_health_file()
+
+    # TD-777: bounded gRPC-readiness preflight — see _wait_for_grpc_ready.
+    _wait_for_grpc_ready()
 
     while not _shutdown_requested:
         try:

--- a/scripts/memory/retry_drain_scheduler.py
+++ b/scripts/memory/retry_drain_scheduler.py
@@ -126,10 +126,11 @@ def _wait_for_grpc_ready() -> None:
     that passes before the gRPC listener (container :6334 / host :26351)
     accepts connections. If the daemon's first process_queue() call reaches
     get_qdrant_client() while gRPC is still unready, that function falls back
-    to HTTP and CACHES the HTTP-only client for the process lifetime
-    (src/memory/qdrant_client.py:107-135). This preflight never calls
-    get_qdrant_client() — it probes with a disposable raw QdrantClient so the
-    real client is only built (and cached) once gRPC is actually reachable.
+    to HTTP and CACHES the HTTP-only client for the process lifetime — see
+    get_qdrant_client()'s gRPC-fallback/HTTP-cache behavior. This preflight
+    never calls get_qdrant_client() — it probes with a disposable raw
+    QdrantClient so the real client is only built (and cached) once gRPC is
+    actually reachable.
 
     Bounded by RETRY_DRAIN_GRPC_PREFLIGHT_MAX_ATTEMPTS attempts, sleeping
     RETRY_DRAIN_GRPC_PREFLIGHT_SLEEP_SECONDS between them. If the budget
@@ -144,13 +145,18 @@ def _wait_for_grpc_ready() -> None:
         DEFAULT_GRPC_PREFLIGHT_SLEEP_SECONDS,
     )
 
-    config = get_config()
-    grpc_port = int(os.getenv("QDRANT_GRPC_PORT", "6334"))
-    api_key = (
-        config.qdrant_api_key.get_secret_value() if config.qdrant_api_key else None
-    )
+    try:
+        config = get_config()
+        grpc_port = int(os.getenv("QDRANT_GRPC_PORT", "6334"))
+        api_key = (
+            config.qdrant_api_key.get_secret_value() if config.qdrant_api_key else None
+        )
+    except Exception as exc:
+        logger.warning("grpc_preflight_config_error error=%s", exc)
+        return
 
     for attempt in range(1, max_attempts + 1):
+        probe = None
         try:
             probe = QdrantClient(
                 host=config.qdrant_host,
@@ -167,8 +173,16 @@ def _wait_for_grpc_ready() -> None:
             return
         except Exception as exc:
             logger.debug("grpc_preflight_not_ready attempt=%d error=%s", attempt, exc)
-            if attempt < max_attempts and not _shutdown_requested:
+            if _shutdown_requested:
+                logger.info(
+                    "grpc_preflight_interrupted_by_shutdown attempt=%d", attempt
+                )
+                return
+            if attempt < max_attempts:
                 time.sleep(sleep_seconds)
+        finally:
+            if probe is not None:
+                probe.close()
 
     logger.warning(
         "grpc_preflight_budget_exhausted attempts=%d — proceeding without "

--- a/scripts/memory/retry_drain_scheduler.py
+++ b/scripts/memory/retry_drain_scheduler.py
@@ -182,7 +182,10 @@ def _wait_for_grpc_ready() -> None:
                 time.sleep(sleep_seconds)
         finally:
             if probe is not None:
-                probe.close()
+                try:
+                    probe.close()
+                except Exception:
+                    logger.debug("grpc_preflight_probe_close_failed", exc_info=True)
 
     logger.warning(
         "grpc_preflight_budget_exhausted attempts=%d — proceeding without "

--- a/tests/unit/test_retry_drain_scheduler.py
+++ b/tests/unit/test_retry_drain_scheduler.py
@@ -121,6 +121,51 @@ class TestGrpcPreflightRetry:
 
         assert qc_module._client_cache == {}
 
+    def test_shutdown_during_preflight_aborts_promptly(self, monkeypatch):
+        """Shutdown requested while the probe loop is failing — the preflight
+        must return promptly instead of draining the full attempt budget."""
+        mod = _load_scheduler()
+        mod._shutdown_requested = True
+        monkeypatch.setenv("RETRY_DRAIN_GRPC_PREFLIGHT_MAX_ATTEMPTS", "30")
+        monkeypatch.setenv("RETRY_DRAIN_GRPC_PREFLIGHT_SLEEP_SECONDS", "1")
+
+        call_count = [0]
+
+        def always_fail(**kwargs):
+            call_count[0] += 1
+            raise ConnectionError("grpc not ready")
+
+        with (
+            patch.object(mod, "QdrantClient", side_effect=always_fail),
+            patch.object(mod, "get_config", return_value=_make_config()),
+            patch.object(mod, "time") as mock_time,
+        ):
+            mod._wait_for_grpc_ready()
+
+        # Bounded to a single probe attempt, not the full 30-attempt budget.
+        assert call_count[0] == 1
+        mock_time.sleep.assert_not_called()
+
+    def test_config_error_falls_through_without_raising(self, monkeypatch):
+        """get_config() raising must not crash the daemon — the preflight
+        logs a warning and returns."""
+        mod = _load_scheduler()
+        mod._shutdown_requested = False
+        monkeypatch.setenv("RETRY_DRAIN_GRPC_PREFLIGHT_MAX_ATTEMPTS", "5")
+        monkeypatch.setenv("RETRY_DRAIN_GRPC_PREFLIGHT_SLEEP_SECONDS", "1")
+
+        def broken_config():
+            raise ValueError("bad qdrant config")
+
+        with (
+            patch.object(mod, "QdrantClient") as mock_client,
+            patch.object(mod, "get_config", side_effect=broken_config),
+        ):
+            # Must not raise — daemon falls through to normal operation.
+            mod._wait_for_grpc_ready()
+
+        mock_client.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Test: run_scheduler() calls the preflight before the first process_queue()

--- a/tests/unit/test_retry_drain_scheduler.py
+++ b/tests/unit/test_retry_drain_scheduler.py
@@ -73,6 +73,7 @@ class TestGrpcPreflightRetry:
 
         assert call_count[0] == 3
         succeed_client.get_collections.assert_called_once()
+        succeed_client.close.assert_called_once()
         # Slept after attempt 1 and attempt 2 (both failures); no sleep after success.
         assert mock_time.sleep.call_count == 2
 

--- a/tests/unit/test_retry_drain_scheduler.py
+++ b/tests/unit/test_retry_drain_scheduler.py
@@ -1,0 +1,161 @@
+"""Unit tests for TD-777: bounded gRPC-readiness preflight in the retry-drain daemon.
+
+Tests:
+- Preflight retries the gRPC probe on failure, then proceeds once it succeeds.
+- Preflight bounds out past its attempt budget WITHOUT raising/crashing.
+- Preflight never poisons get_qdrant_client's module-level client cache.
+- run_scheduler() invokes the preflight before the first process_queue() call.
+"""
+
+import importlib.util
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Module loader helper (mirrors test_evaluator_scheduler.py)
+# ---------------------------------------------------------------------------
+
+_SCHEDULER_PATH = (
+    Path(__file__).parent.parent.parent / "scripts/memory/retry_drain_scheduler.py"
+)
+
+
+def _load_scheduler():
+    """Load retry_drain_scheduler module via importlib (not on sys.path as a package)."""
+    spec = importlib.util.spec_from_file_location(
+        "retry_drain_scheduler", _SCHEDULER_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_config():
+    """Build a MagicMock MemoryConfig with just the fields _wait_for_grpc_ready reads."""
+    cfg = MagicMock()
+    cfg.qdrant_host = "qdrant"
+    cfg.qdrant_port = 26350
+    cfg.qdrant_use_https = False
+    cfg.qdrant_timeout = 5
+    cfg.qdrant_api_key = None
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Test: _wait_for_grpc_ready retry + bounded-out behavior
+# ---------------------------------------------------------------------------
+
+
+class TestGrpcPreflightRetry:
+    def test_retries_then_succeeds(self, monkeypatch):
+        """Probe fails twice then succeeds — preflight retries and proceeds."""
+        mod = _load_scheduler()
+        mod._shutdown_requested = False
+        monkeypatch.setenv("RETRY_DRAIN_GRPC_PREFLIGHT_MAX_ATTEMPTS", "5")
+        monkeypatch.setenv("RETRY_DRAIN_GRPC_PREFLIGHT_SLEEP_SECONDS", "1")
+
+        call_count = [0]
+        succeed_client = MagicMock()
+
+        def fake_qdrant_client(**kwargs):
+            call_count[0] += 1
+            if call_count[0] < 3:
+                raise ConnectionError("grpc not ready")
+            return succeed_client
+
+        with (
+            patch.object(mod, "QdrantClient", side_effect=fake_qdrant_client),
+            patch.object(mod, "get_config", return_value=_make_config()),
+            patch.object(mod, "time") as mock_time,
+        ):
+            mod._wait_for_grpc_ready()
+
+        assert call_count[0] == 3
+        succeed_client.get_collections.assert_called_once()
+        # Slept after attempt 1 and attempt 2 (both failures); no sleep after success.
+        assert mock_time.sleep.call_count == 2
+
+    def test_budget_exhausted_falls_through_without_raising(self, monkeypatch):
+        """Probe fails on every attempt — preflight bounds out and does NOT raise."""
+        mod = _load_scheduler()
+        mod._shutdown_requested = False
+        monkeypatch.setenv("RETRY_DRAIN_GRPC_PREFLIGHT_MAX_ATTEMPTS", "3")
+        monkeypatch.setenv("RETRY_DRAIN_GRPC_PREFLIGHT_SLEEP_SECONDS", "1")
+
+        def always_fail(**kwargs):
+            raise ConnectionError("grpc never ready")
+
+        with (
+            patch.object(mod, "QdrantClient", side_effect=always_fail),
+            patch.object(mod, "get_config", return_value=_make_config()),
+            patch.object(mod, "time") as mock_time,
+        ):
+            # Must not raise — daemon falls through to normal operation.
+            mod._wait_for_grpc_ready()
+
+        # 3 attempts total; sleeps between attempt 1->2 and 2->3, none after the last.
+        assert mock_time.sleep.call_count == 2
+
+    def test_preflight_never_poisons_client_cache(self, monkeypatch):
+        """The preflight probes with a THROWAWAY client — get_qdrant_client's
+        module-level cache must remain untouched regardless of outcome."""
+        from memory import qdrant_client as qc_module
+
+        mod = _load_scheduler()
+        mod._shutdown_requested = False
+        monkeypatch.setenv("RETRY_DRAIN_GRPC_PREFLIGHT_MAX_ATTEMPTS", "2")
+        monkeypatch.setenv("RETRY_DRAIN_GRPC_PREFLIGHT_SLEEP_SECONDS", "1")
+
+        qc_module._client_cache.clear()
+
+        def always_fail(**kwargs):
+            raise ConnectionError("grpc never ready")
+
+        with (
+            patch.object(mod, "QdrantClient", side_effect=always_fail),
+            patch.object(mod, "get_config", return_value=_make_config()),
+            patch.object(mod, "time"),
+        ):
+            mod._wait_for_grpc_ready()
+
+        assert qc_module._client_cache == {}
+
+
+# ---------------------------------------------------------------------------
+# Test: run_scheduler() calls the preflight before the first process_queue()
+# ---------------------------------------------------------------------------
+
+
+class TestRunSchedulerPreflightOrdering:
+    def test_preflight_runs_before_first_process_queue(self):
+        mod = _load_scheduler()
+        mod._shutdown_requested = False
+
+        call_order = []
+
+        def fake_preflight():
+            call_order.append("preflight")
+
+        def fake_process_queue(limit):
+            call_order.append("process_queue")
+            return {"processed": 0, "success": 0, "failed": 0, "moved_to_dlq": 0}
+
+        def fake_sleep(seconds, chunk=5.0):
+            # Shut down after the first cycle so the loop exits.
+            mod._shutdown_requested = True
+
+        @contextmanager
+        def fake_drain_lock():
+            yield True
+
+        with (
+            patch.object(mod, "_wait_for_grpc_ready", side_effect=fake_preflight),
+            patch.object(mod, "process_queue", side_effect=fake_process_queue),
+            patch.object(mod, "drain_lock", fake_drain_lock),
+            patch.object(mod, "_interruptible_sleep", side_effect=fake_sleep),
+            patch.object(mod, "_touch_health_file"),
+        ):
+            mod.run_scheduler()
+
+        assert call_order == ["preflight", "process_queue"]


### PR DESCRIPTION
## Summary

Two related fixes so the in-stack services actually use Qdrant gRPC instead of silently falling back to HTTP.

### 1. Container-internal `QDRANT_GRPC_PORT` override (compose)
In-container services inherited `QDRANT_GRPC_PORT=26351` (the host-mapped gRPC port) from `.env`, but Qdrant's gRPC listener inside the Docker network is on `6334`. The compose files already override `QDRANT_PORT → 6333` per service but never added the parallel gRPC override, so every in-network gRPC connect was refused and fell back to HTTP across the whole stack. Adds `QDRANT_GRPC_PORT=6334` to the six in-container Qdrant clients (monitoring-api, streamlit, classifier-worker, retry-queue-drain, github-sync, evaluator-scheduler). `.env` is unchanged — `26351` remains correct for host-side hook clients.

### 2. Bounded gRPC-readiness preflight (retry-drain daemon)
The retry-drain daemon's compose `service_healthy` gate passes on Qdrant's HTTP probe, which comes up before the gRPC listener accepts. Its first `process_queue()` would then build and cache an HTTP-only client for the process lifetime. Adds a bounded preflight that polls gRPC readiness with a throwaway client (never touching the shared client cache) before the first drain cycle; bounded and non-crashing, with graceful fall-through if the budget expires or shutdown is requested.

## Verification
- Unit tests for the preflight (retry/success, budget-exhaust fall-through, shutdown-abort, cache-not-poisoned, probe-close).
- Live-tested on the runtime: all six services resolve `QDRANT_GRPC_PORT=6334`; retry-drain logs `grpc_preflight_ready`; zero gRPC→HTTP fallbacks stack-wide.