### PR TITLE
Bound embedding memory: single-request and byte-aware admission envelope

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -373,6 +373,13 @@ EMBEDDING_CLIENT_SUBBATCH=128
 # The embedding server enforces the same envelope directly — a lone request whose
 # work-units exceed it is rejected with HTTP 413.
 EMBEDDING_SAFE_INFLIGHT_TEXTS=48
+# TD-783 (PM #390): byte/superlinear-aware companion to the count envelope above. Bounds
+# the SUM of in-flight CHARS across concurrent slots, so peak memory tracks byte-work
+# rather than text count (48 texts is safe at 2 KB/text but OOM'd the 10 GiB cap at
+# 8 KB/text = 393,216 chars). 200,000 chars -> ~5.6 GiB transient -> ~7.95 GiB peak,
+# ~20% headroom under 10 GiB. The count envelope stays as the client-mirrored contract;
+# this is the binding memory bound under large-text bursts.
+EMBEDDING_SAFE_INFLIGHT_CHARS=200000
 # TD-774: per-request read timeout for the en model (seconds; default 15s).
 # CPU mode typical: 10-15s. GPU mode: <2s. Increase for underpowered hardware.
 EMBEDDING_READ_TIMEOUT=15.0
@@ -402,18 +409,27 @@ EMBEDDING_MAX_WAITERS=64
 # Retry-After seconds returned on a last-resort shed (503), honoured by the client.
 EMBEDDING_RETRY_AFTER=5
 # Reject oversized payloads up front with HTTP 413 (single-request OOM guard):
-# max texts per request, and max total input characters per request.
+# max texts per request, max total input chars per request, and max chars per single text.
 EMBEDDING_MAX_BATCH_TEXTS=256
-EMBEDDING_MAX_INPUT_CHARS=1000000
+# TD-795 (PM #390): shrunk from 1,000,000. At 1M chars one request could reach ~28 GiB
+# (~122 texts x 235 MiB) and OOM the 10 GiB cap regardless of concurrency. 200,000 chars
+# peaks at ~5.6 GiB transient (+~2.35 GiB warm base = ~7.95 GiB). Keep <= SAFE_INFLIGHT_CHARS.
+EMBEDDING_MAX_INPUT_CHARS=200000
+# TD-795: per-TEXT char cap. Per-text memory is super-linear (~O(L^2)), so one huge text
+# costs far more than the same chars split across texts. 8192 pins the worst per-char cost
+# to the measured 235 MiB / 8 KB anchor and is >=3x the largest legit chunk (~2.4 KB).
+EMBEDDING_MAX_TEXT_CHARS=8192
 # BUG-324 footprint controls (shrink anon-RSS under concurrent inference; conservative
 # defaults, tune under the sizing soak):
 # Cap glibc malloc arenas — biggest easy win against allocator-fragmentation overshoot.
 MALLOC_ARENA_MAX=2
 # Bound OpenMP thread pools (BLAS / OpenMP-built ONNX kernels).
-OMP_NUM_THREADS=2
+# TD-794 (PM #390 X1): 2->4, the measured throughput sweet-spot (monotonic 2->3->4 gain,
+# no extra memory). Kept in lockstep with EMBEDDING_INFERENCE_THREADS below.
+OMP_NUM_THREADS=4
 # Bound the onnxruntime intra-op thread pool (the effective lever on a non-OpenMP
-# build; OMP_NUM_THREADS alone won't cap it). Fewer threads = lower per-request peak.
-EMBEDDING_INFERENCE_THREADS=2
+# build; OMP_NUM_THREADS alone won't cap it). TD-794: 4 = measured sweet-spot.
+EMBEDDING_INFERENCE_THREADS=4
 # BUG-324 Phase 2 memory-aware AIMD self-throttle (the OOM-loop fix). The controller
 # reads cgroup-v2 memory signals and collapses effective concurrency toward 1 under
 # pressure, recovering when healthy. Conservative defaults; tune under the soak.
@@ -421,10 +437,15 @@ EMBEDDING_INFERENCE_THREADS=2
 EMBEDDING_PRESSURE_INTERVAL=1.0
 # PSI memory.pressure full avg10 above this (percent) = under pressure -> shrink.
 EMBEDDING_PSI_THRESHOLD=10.0
-# memory.current/limit ratio above this = under pressure (PSI-unavailable fallback).
-EMBEDDING_MEMORY_HIGH_RATIO=0.9
+# memory.current/limit ratio above this = under pressure -> shrink concurrency.
+# TD-793/X5 (PM #390): lowered 0.9->0.80 as the PORTABLE memory.high fix. The kernel
+# cgroup memory.high is not settable via Docker/compose (mem_reservation->memory.low,
+# mem_limit->memory.max) and the in-container cgroup is read-only, so this app-level ratio
+# IS the throttle threshold. AIMD now sheds at ~8 GiB of the 10 GiB cap (was ~9 GiB).
+EMBEDDING_MEMORY_HIGH_RATIO=0.80
 # Ratio below which the service is considered healthy enough to grow concurrency again.
-EMBEDDING_MEMORY_OK_RATIO=0.75
+# Lowered 0.75->0.65 in lockstep to preserve the 0.15 hysteresis gap (recover at ~6.5 GiB).
+EMBEDDING_MEMORY_OK_RATIO=0.65
 
 # --- 4.12 Evaluator (LLM-as-Judge) ---
 # Only needed if using provider=custom in evaluator_config.yaml

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -354,12 +354,12 @@ MODEL_NAME_EN=jinaai/jina-embeddings-v2-base-en
 MODEL_NAME_CODE=jinaai/jina-embeddings-v2-base-code
 EMBEDDING_MODEL_DENSE_EN=jinaai/jina-embeddings-v2-base-en
 EMBEDDING_MODEL_DENSE_CODE=jinaai/jina-embeddings-v2-base-code
-# Container memory limit. Default 6G for multi-project shared deployments: the
-# embedding service is shared across ALL projects on one install, and real mixed
-# payloads drive anon-RSS well above the ~3GB model footprint (glibc arena
-# retention). 4G OOM-loops a multi-project install. Size by concurrent-project
-# count — see docs/EMBEDDING-SIZING.md. (Provisional pending the BUG-324 soak.)
-EMBEDDING_MEMORY_LIMIT=6G
+# Container memory limit. Default 10G (BUG-329 / DEC-PM386-D4 + PM #390): this is the
+# design basis of the byte-aware envelope below — warm base ~2.35 GiB + ~5.6 GiB in-flight
+# char budget = ~7.95 GiB peak, ~2 GiB headroom. The envelope (EMBEDDING_SAFE_INFLIGHT_CHARS
+# etc.) is sized against THIS limit, so it must stay in lockstep — shipping a smaller limit
+# would OOM a fresh install. Size by concurrent-project count — see docs/EMBEDDING-SIZING.md.
+EMBEDDING_MEMORY_LIMIT=10G
 EMBEDDING_MAX_RETRIES=2
 EMBEDDING_BACKOFF_BASE=1.0
 EMBEDDING_BACKOFF_CAP=15.0

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -122,23 +122,36 @@ services:
       - EMBEDDING_RETRY_AFTER=${EMBEDDING_RETRY_AFTER:-5}
       - EMBEDDING_MAX_BATCH_TEXTS=${EMBEDDING_MAX_BATCH_TEXTS:-256}
       - EMBEDDING_SAFE_INFLIGHT_TEXTS=${EMBEDDING_SAFE_INFLIGHT_TEXTS:-48}
-      - EMBEDDING_MAX_INPUT_CHARS=${EMBEDDING_MAX_INPUT_CHARS:-1000000}
+      # TD-783/795 (PM #390): byte/superlinear-aware caps. MAX_INPUT_CHARS shrunk from 1M
+      # (one request could reach ~28 GiB) to 200K; MAX_TEXT_CHARS caps a single super-linear
+      # text at the 8 KB measured anchor (~235 MiB); SAFE_INFLIGHT_CHARS bounds concurrent
+      # in-flight chars so peak memory tracks byte-work, not text count (10 GiB cap sizing).
+      - EMBEDDING_MAX_INPUT_CHARS=${EMBEDDING_MAX_INPUT_CHARS:-200000}
+      - EMBEDDING_MAX_TEXT_CHARS=${EMBEDDING_MAX_TEXT_CHARS:-8192}
+      - EMBEDDING_SAFE_INFLIGHT_CHARS=${EMBEDDING_SAFE_INFLIGHT_CHARS:-200000}
       # BUG-324 Phase 2: memory-aware AIMD self-throttle (the OOM-loop fix). The
       # controller reads cgroup-v2 memory signals and collapses effective concurrency
       # toward 1 under pressure. Thresholds are conservative; tune under the soak.
       - EMBEDDING_PRESSURE_INTERVAL=${EMBEDDING_PRESSURE_INTERVAL:-1.0}
       - EMBEDDING_PSI_THRESHOLD=${EMBEDDING_PSI_THRESHOLD:-10.0}
-      - EMBEDDING_MEMORY_HIGH_RATIO=${EMBEDDING_MEMORY_HIGH_RATIO:-0.9}
-      - EMBEDDING_MEMORY_OK_RATIO=${EMBEDDING_MEMORY_OK_RATIO:-0.75}
+      # TD-793/X5 (PM #390): lowered 0.9->0.80 as the PORTABLE memory.high fix (kernel
+      # memory.high is not settable via Docker/compose; the app-level ratio is the throttle
+      # threshold). AIMD sheds at ~8 GiB of the 10 GiB cap; OK_RATIO lowered in lockstep to
+      # keep the 0.15 hysteresis gap (recover at ~6.5 GiB).
+      - EMBEDDING_MEMORY_HIGH_RATIO=${EMBEDDING_MEMORY_HIGH_RATIO:-0.80}
+      - EMBEDDING_MEMORY_OK_RATIO=${EMBEDDING_MEMORY_OK_RATIO:-0.65}
       # BUG-324 (footprint): shrink anon-RSS under concurrent inference. MALLOC_ARENA_MAX
       # caps glibc malloc arenas (fragmentation is the prime suspect for the >cap anon-rss
       # overshoot); OMP_NUM_THREADS bounds OpenMP thread pools. Conservative defaults
       # (also baked into the image); tune under the sizing soak.
       - MALLOC_ARENA_MAX=${MALLOC_ARENA_MAX:-2}
-      - OMP_NUM_THREADS=${OMP_NUM_THREADS:-2}
+      # TD-794 (PM #390 X1): 2->4 — the measured throughput sweet-spot (monotonic gain
+      # 2->3->4, no extra memory). OMP_NUM_THREADS and EMBEDDING_INFERENCE_THREADS kept in
+      # lockstep (the latter is the effective lever on a non-OpenMP onnxruntime build).
+      - OMP_NUM_THREADS=${OMP_NUM_THREADS:-4}
       # Bound the onnxruntime intra-op thread pool (effective lever on a non-OpenMP
       # onnxruntime build, where OMP_NUM_THREADS alone won't cap it).
-      - EMBEDDING_INFERENCE_THREADS=${EMBEDDING_INFERENCE_THREADS:-2}
+      - EMBEDDING_INFERENCE_THREADS=${EMBEDDING_INFERENCE_THREADS:-4}
       # Set fastembed cache to persistent volume location
       - FASTEMBED_CACHE_PATH=/home/embedding/.cache/fastembed
     restart: unless-stopped

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -164,11 +164,13 @@ services:
     deploy:
       resources:
         limits:
-          # SPEC-010 / BUG-324: 6G default for multi-project shared deployments. The
-          # shared service climbs well past the ~3GB model footprint under real mixed
-          # load (arena retention); 4G OOM-loops. Tune by concurrent-project count —
-          # see docs/EMBEDDING-SIZING.md. (Provisional pending the BUG-324 soak.)
-          memory: ${EMBEDDING_MEMORY_LIMIT:-6G}
+          # BUG-329 / DEC-PM386-D4 + PM #390: 10G is the design basis of the byte-aware
+          # envelope above — it is the denominator of the whole sizing (warm base ~2.35 GiB
+          # + ~5.6 GiB in-flight char budget = ~7.95 GiB peak, ~2 GiB headroom). Shipping the
+          # old 6G default under this envelope is a latent OOM on a fresh install (base +
+          # budget >> 6G), so the committed default must equal the sizing basis. Tune by
+          # concurrent-project count — see docs/EMBEDDING-SIZING.md.
+          memory: ${EMBEDDING_MEMORY_LIMIT:-10G}
 
   monitoring-api:
     build:

--- a/docker/embedding/Dockerfile
+++ b/docker/embedding/Dockerfile
@@ -60,9 +60,11 @@ ENV PYTHONUNBUFFERED=1 \
 # biggest easy win against that fragmentation. OMP_NUM_THREADS bounds OpenMP-governed
 # pools (BLAS, any OpenMP-built ONNX kernels), trading per-request throughput for a
 # lower, more predictable peak — acceptable since "process slowly" is the explicit goal.
-# Conservative image defaults; overridable via the compose env block / soak sizing.
+# TD-794 (PM #390 X1): 4 = the measured throughput sweet-spot (monotonic 2->3->4 gain, no
+# extra memory). This is the image fallback; compose overrides it via the env block, but
+# the baked default is kept in lockstep so the third thread-config location cannot drift.
 ENV MALLOC_ARENA_MAX=2 \
-    OMP_NUM_THREADS=2
+    OMP_NUM_THREADS=4
 
 # Install only runtime dependencies (curl for compose healthcheck)
 RUN apt-get update && \

--- a/docker/embedding/main.py
+++ b/docker/embedding/main.py
@@ -538,7 +538,7 @@ async def run_inference_async(operation, work_units=1, work_chars=0):
         raise HTTPException(status_code=503, detail="embedding_inference_failed") from e
 
 
-def _enforce_payload_limits(texts: list[str]) -> None:
+def _enforce_payload_limits(texts: list[str], per_text_cap: bool = True) -> None:
     """Reject oversized embed payloads with HTTP 413 before any model work (TD-670).
 
     Bounds three dimensions, closing the single-request OOM vector before the batch is
@@ -550,9 +550,18 @@ def _enforce_payload_limits(texts: list[str]) -> None:
       super-linear (~O(L^2)), so one huge text costs far more than the same chars spread
       across texts; a total-chars bound alone is blind to that distribution.
 
+    Args:
+        texts: the texts about to be embedded.
+        per_text_cap: enforce the per-text char cap. Defaults True. Set False ONLY for the
+            ``/embed/chunked`` document CONTAINER (``texts[0]`` is a whole document that the
+            endpoint then splits by offsets into in-cap chunks — the per-text cap must apply
+            to those resulting chunks, not to the pre-split document, or it would false-reject
+            a legitimately large document that will never be embedded whole). Every path that
+            embeds a text DIRECTLY keeps the cap on.
+
     Raises:
-        HTTPException: 413 if the batch has too many texts, too many total chars, or any
-        single text exceeds the per-text cap.
+        HTTPException: 413 if the batch has too many texts, too many total chars, or (when
+        ``per_text_cap``) any single text exceeds the per-text cap.
     """
     if len(texts) > EMBEDDING_MAX_BATCH_TEXTS:
         raise HTTPException(
@@ -560,15 +569,16 @@ def _enforce_payload_limits(texts: list[str]) -> None:
             detail=f"Too many texts: {len(texts)} > max {EMBEDDING_MAX_BATCH_TEXTS}",
         )
     # TD-795: per-text cap first — a single super-linear text is the worst-case OOM driver.
-    for i, t in enumerate(texts):
-        if len(t) > EMBEDDING_MAX_TEXT_CHARS:
-            raise HTTPException(
-                status_code=413,
-                detail=(
-                    f"Text {i} too large: {len(t)} chars > "
-                    f"max {EMBEDDING_MAX_TEXT_CHARS} per text"
-                ),
-            )
+    if per_text_cap:
+        for i, t in enumerate(texts):
+            if len(t) > EMBEDDING_MAX_TEXT_CHARS:
+                raise HTTPException(
+                    status_code=413,
+                    detail=(
+                        f"Text {i} too large: {len(t)} chars > "
+                        f"max {EMBEDDING_MAX_TEXT_CHARS} per text"
+                    ),
+                )
     total_chars = sum(len(t) for t in texts)
     if total_chars > EMBEDDING_MAX_INPUT_CHARS:
         raise HTTPException(
@@ -1088,15 +1098,20 @@ async def embed_chunked(request: EmbedWithOffsetsRequest):
     """
     if not request.texts:
         raise HTTPException(status_code=400, detail="No texts provided")
-    # Only texts[0] is used as the document; this count check is a conservative
-    # oversized-payload guard — the char-length check below is the operative limit.
-    _enforce_payload_limits(request.texts)
+    # texts[0] is a whole DOCUMENT this endpoint splits by offsets into in-cap chunks, so
+    # the per-text cap must NOT apply to the pre-split document (that would false-reject a
+    # legitimately large document — TD-795 friction 4); it is enforced on the resulting
+    # chunks below. Batch-count + total-char bounds still apply to the container.
+    _enforce_payload_limits(request.texts, per_text_cap=False)
 
     document = request.texts[0]
     model = MODEL_REGISTRY["en"]
 
     if not request.chunk_offsets:
-        # No offsets — embed whole document as single vector
+        # No offsets — embed the whole document as a single vector. Here the document IS the
+        # embedded text, so the per-text cap DOES apply (a huge whole-document embed is the
+        # O(L^2) OOM vector); a >cap document must be sent WITH offsets so it is split.
+        _enforce_payload_limits([document])
         embeddings = await run_inference_async(
             lambda: list(model.embed([document])),
             work_units=1,

--- a/docker/embedding/main.py
+++ b/docker/embedding/main.py
@@ -146,11 +146,14 @@ EMBEDDING_SAFE_INFLIGHT_TEXTS = int(os.getenv("EMBEDDING_SAFE_INFLIGHT_TEXTS", "
 # TD-783 (PM #390 X2): byte/superlinear-aware in-flight envelope. The count-only
 # EMBEDDING_SAFE_INFLIGHT_TEXTS above is byte-BLIND — 48 in-flight texts is ~96 KiB of
 # work at 2 KB/text but ~384 KB at 8 KB/text, and the latter OOM-killed the 10 GiB cap
-# (48 x 8 KB = 393,216 chars -> ~10.37 GiB, X2). This bounds the SUM of in-flight CHARS
-# across all slots holding an inference slot, so peak memory tracks real byte-work, not
-# text count. It COMPLEMENTS (does not replace) the count envelope: the count stays as the
-# cross-deploy contract the client mirrors (storage._embedding_inflight_envelope), while
-# this char budget is the binding memory bound for large-text bursts.
+# (48 x 8 KB = 393,216 chars -> ~10.37 GiB, X2). This bounds the SUM of in-flight PADDED
+# chars (see _padded_chars: rows x max_len, the real onnx working set — fastembed pads the
+# batch to its longest sequence) across all slots holding an inference slot, so peak memory
+# tracks real byte-work, not text count. It COMPLEMENTS (does not replace) the count
+# envelope: the count stays as the cross-deploy contract the client mirrors
+# (storage._embedding_inflight_envelope), while this char budget is the binding memory bound
+# for large-text bursts AND for skewed batches (one long text + many tiny), whose padded
+# footprint the char SUM would miss (reviewer MEDIUM: batch padding).
 #   Sizing (10 GiB cap, ~2.35 GiB warm base): budget the transient at cap - base - margin
 #   ~= 10 - 2.35 - ~1.5 (fragmentation/overshoot; X2 overshot the cap by ~0.37 GiB) ~=
 #   6.15 GiB. With per-text capped at 8 KB the worst per-char cost is 235 MiB / 8192 =
@@ -177,6 +180,25 @@ if EMBEDDING_MAX_WAITERS < 1:
         extra={"configured": EMBEDDING_MAX_WAITERS, "floored_to": 1},
     )
     EMBEDDING_MAX_WAITERS = 1
+
+# Memory invariant (reviewer MEDIUM): EMBEDDING_MAX_INPUT_CHARS must never exceed
+# EMBEDDING_SAFE_INFLIGHT_CHARS. A lone request is ALWAYS admitted (deadlock prevention),
+# so its whole payload — up to EMBEDDING_MAX_INPUT_CHARS — can sit in flight by itself; if
+# that ceiling is above the concurrent char envelope, a single always-admitted request
+# breaches the memory envelope the whole design rests on. The sizing docs invite per-install
+# tuning of EMBEDDING_MAX_INPUT_CHARS, so an operator can raise it past
+# EMBEDDING_SAFE_INFLIGHT_CHARS without realizing the coupling. Clamp it down at load (with a
+# warning) so the invariant holds by construction rather than only in the test suite —
+# mirrors the EMBEDDING_MAX_WAITERS floor-with-warning above.
+if EMBEDDING_MAX_INPUT_CHARS > EMBEDDING_SAFE_INFLIGHT_CHARS:
+    logger.warning(
+        "embedding_max_input_chars_clamped",
+        extra={
+            "configured": EMBEDDING_MAX_INPUT_CHARS,
+            "clamped_to": EMBEDDING_SAFE_INFLIGHT_CHARS,
+        },
+    )
+    EMBEDDING_MAX_INPUT_CHARS = EMBEDDING_SAFE_INFLIGHT_CHARS
 
 
 def _make_metric(factory, name, *args, **kwargs):
@@ -275,9 +297,10 @@ _waiting_count = 0
 # its release (no await in that window), so a plain int needs no lock.
 _inflight_work = 0
 
-# TD-783: byte twin of _inflight_work — sum of INPUT CHARS of requests currently holding
-# an inference slot. Bounded by EMBEDDING_SAFE_INFLIGHT_CHARS at admission. Same
-# single-event-loop mutation window as _inflight_work, so a plain int needs no lock.
+# TD-783: byte twin of _inflight_work — sum of PADDED chars (_padded_chars: rows x max_len)
+# of requests currently holding an inference slot. Bounded by EMBEDDING_SAFE_INFLIGHT_CHARS
+# at admission. Same single-event-loop mutation window as _inflight_work, so a plain int
+# needs no lock.
 _inflight_chars = 0
 
 # BUG-324 Phase 2: the AIMD controller shrinks the EFFECTIVE limit below the static max
@@ -337,11 +360,14 @@ async def run_inference_async(operation, work_units=1, work_chars=0):
             ``work_units=len(texts)`` — the count envelope and the 413 gate are only correct
             if this equals the number of texts ``operation`` will embed. A wrong value
             silently under- or over-counts in-flight work and defeats the memory bound.
-        work_chars: This request's total input size in chars (``sum(len(t) for t in
-            texts)``); the unit the byte envelope (``EMBEDDING_SAFE_INFLIGHT_CHARS``)
-            bounds (TD-783). Defaults to 0 (byte gate inert) for callers that do not
-            embed text. CONTRACT: text-embedding callers MUST pass the real char total —
-            it is the memory-proportional quantity the byte envelope caps.
+        work_chars: This request's PADDED working set in chars — ``_padded_chars(texts)``
+            = ``len(texts) * max_text_len`` (NOT the char sum); the unit the byte envelope
+            (``EMBEDDING_SAFE_INFLIGHT_CHARS``) bounds (TD-783 + reviewer MEDIUM batch
+            padding). fastembed pads the batch to its longest sequence, so the padded
+            rectangle — not the char sum — is the memory-proportional quantity; for a
+            uniform batch the two are equal. Defaults to 0 (byte gate inert) for callers
+            that do not embed text. CONTRACT: text-embedding callers MUST pass
+            ``_padded_chars(texts)``.
 
     Returns:
         Whatever ``operation`` returns.
@@ -450,12 +476,13 @@ async def run_inference_async(operation, work_units=1, work_chars=0):
             headers={"Retry-After": str(EMBEDDING_RETRY_AFTER)},
         )
 
-    # TD-783 byte/superlinear-aware gate. Same shape as the count gate above but on CHARS:
-    # if admitting this request's chars would push the concurrent in-flight char total over
-    # EMBEDDING_SAFE_INFLIGHT_CHARS, shed (giving the slot back). This is the binding memory
-    # bound under large-text bursts, where the count gate is byte-blind (48 texts is safe at
-    # 2 KB but OOMs at 8 KB). A lone request is always admitted — its chars are already
-    # bounded to <= EMBEDDING_MAX_INPUT_CHARS (<= EMBEDDING_SAFE_INFLIGHT_CHARS) by
+    # TD-783 byte/superlinear-aware gate. Same shape as the count gate above but on PADDED
+    # CHARS (rows x max_len): if admitting this request's padded work would push the
+    # concurrent in-flight padded total over EMBEDDING_SAFE_INFLIGHT_CHARS, shed (giving the
+    # slot back). This is the binding memory bound under large-text bursts AND skewed batches,
+    # where the count gate is byte-blind (48 texts is safe at 2 KB but OOMs at 8 KB) and a
+    # char-SUM gate is padding-blind. A lone request is always admitted — its padded rectangle
+    # is already bounded to <= EMBEDDING_MAX_INPUT_CHARS (<= EMBEDDING_SAFE_INFLIGHT_CHARS) by
     # _enforce_payload_limits — so this never starves it and cannot deadlock.
     if (
         _inflight_chars > 0
@@ -538,10 +565,36 @@ async def run_inference_async(operation, work_units=1, work_chars=0):
         raise HTTPException(status_code=503, detail="embedding_inference_failed") from e
 
 
+def _padded_chars(texts: list[str]) -> int:
+    """The padded-batch working-set proxy in chars: ``len(texts) * max_text_len``.
+
+    fastembed embeds a request as onnx batches of ``batch_size`` (default 256; the service
+    passes no ``batch_size`` and ``parallel=None``, so a whole request up to
+    ``EMBEDDING_MAX_BATCH_TEXTS`` is a single batch) and its tokenizer pads with
+    ``enable_padding()`` and NO fixed length — i.e. ``BatchLongest``: every row is padded to
+    the LONGEST sequence in the batch (truncated at the model's 8192-token max). Verified in
+    the fastembed source (``common/preprocessor_utils.py`` load_tokenizer +
+    ``text/onnx_text_model.py`` _embed_documents/onnx_embed); this padding+batching shape is
+    long-standing across fastembed 0.7.x/0.8.x.
+
+    ``rows * max_len`` is a conservative UPPER bound on the true padded onnx work for ANY
+    internal ``batch_size``: sub-batching can only pad to a per-sub-batch max <= the global
+    max and processes one sub-batch at a time, so the peak never exceeds this rectangle. The
+    bound therefore holds regardless of the exact pinned fastembed version.
+
+    Consequence: peak memory tracks the padded RECTANGLE ``rows * max_len``, not
+    ``sum(len)``. A skewed batch — one text at the per-text cap plus many tiny ones — has a
+    small char sum yet a large padded rectangle (its transient cost is ~ effective_batch x
+    max_len^2), so a ``sum(chars)`` bound alone is byte-blind to it. This function is the
+    quantity the char envelope must actually bound. Empty batch -> 0.
+    """
+    return len(texts) * max((len(t) for t in texts), default=0)
+
+
 def _enforce_payload_limits(texts: list[str], per_text_cap: bool = True) -> None:
     """Reject oversized embed payloads with HTTP 413 before any model work (TD-670).
 
-    Bounds three dimensions, closing the single-request OOM vector before the batch is
+    Bounds four dimensions, closing the single-request OOM vector before the batch is
     materialized into vectors:
 
     - number of texts (``EMBEDDING_MAX_BATCH_TEXTS``) — vectors materialized;
@@ -549,6 +602,14 @@ def _enforce_payload_limits(texts: list[str], per_text_cap: bool = True) -> None
     - size of any single text (``EMBEDDING_MAX_TEXT_CHARS``, TD-795) — per-text memory is
       super-linear (~O(L^2)), so one huge text costs far more than the same chars spread
       across texts; a total-chars bound alone is blind to that distribution.
+    - padded rectangle ``len(texts) * max_text_len`` (``EMBEDDING_MAX_INPUT_CHARS``, reviewer
+      MEDIUM) — fastembed pads the batch to its longest sequence (see ``_padded_chars``), so
+      a SKEWED batch (one text at the per-text cap + many tiny) has a tiny char sum yet a
+      huge padded footprint that the total-chars bound misses. Bounding the padded rectangle
+      to ``EMBEDDING_MAX_INPUT_CHARS`` (which the load-time invariant keeps
+      ``<= EMBEDDING_SAFE_INFLIGHT_CHARS``) makes a lone (always-admitted) request's padded
+      batch memory-safe; for a uniform batch the rectangle equals the char sum, so this only
+      catches skew.
 
     Args:
         texts: the texts about to be embedded.
@@ -560,8 +621,9 @@ def _enforce_payload_limits(texts: list[str], per_text_cap: bool = True) -> None
             embeds a text DIRECTLY keeps the cap on.
 
     Raises:
-        HTTPException: 413 if the batch has too many texts, too many total chars, or (when
-        ``per_text_cap``) any single text exceeds the per-text cap.
+        HTTPException: 413 if the batch has too many texts, too many total chars, (when
+        ``per_text_cap``) any single text exceeds the per-text cap, or the padded rectangle
+        exceeds the input-char budget.
     """
     if len(texts) > EMBEDDING_MAX_BATCH_TEXTS:
         raise HTTPException(
@@ -586,6 +648,22 @@ def _enforce_payload_limits(texts: list[str], per_text_cap: bool = True) -> None
             detail=(
                 f"Input too large: {total_chars} chars > "
                 f"max {EMBEDDING_MAX_INPUT_CHARS}"
+            ),
+        )
+    # Reviewer MEDIUM (batch padding): bound the padded rectangle, not just the char sum. A
+    # skewed batch passes the total-chars cap but pads to len(texts) x max_len; capping that
+    # at the same input-char budget keeps a lone request's padded batch within the concurrent
+    # envelope (the load-time invariant guarantees MAX_INPUT_CHARS <= SAFE_INFLIGHT_CHARS).
+    # Checked after the total-chars cap so a plain oversized batch still reports "Input too
+    # large" (a uniform batch has padded == sum, so this fires only on genuine skew).
+    padded_chars = _padded_chars(texts)
+    if padded_chars > EMBEDDING_MAX_INPUT_CHARS:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                f"Batch padding too large: {len(texts)} texts x "
+                f"{max((len(t) for t in texts), default=0)} max chars = {padded_chars} "
+                f"> max {EMBEDDING_MAX_INPUT_CHARS}"
             ),
         )
 
@@ -1060,7 +1138,7 @@ async def embed_dense(request: EmbedDenseRequest) -> EmbedDenseResponse:
     embeddings = await run_inference_async(
         lambda: list(model.embed(request.texts)),
         work_units=len(request.texts),
-        work_chars=sum(len(t) for t in request.texts),
+        work_chars=_padded_chars(request.texts),
     )
     return EmbedDenseResponse(
         embeddings=[e.tolist() for e in embeddings],
@@ -1135,7 +1213,7 @@ async def embed_chunked(request: EmbedWithOffsetsRequest):
     embeddings = await run_inference_async(
         lambda: list(model.embed(chunk_texts)),
         work_units=len(chunk_texts),
-        work_chars=sum(len(t) for t in chunk_texts),
+        work_chars=_padded_chars(chunk_texts),
     )
     return EmbedResponse(
         embeddings=[e.tolist() for e in embeddings],
@@ -1156,7 +1234,7 @@ async def embed_sparse(request: EmbedSparseRequest):
     results = await run_inference_async(
         lambda: list(model.embed(request.texts)),
         work_units=len(request.texts),
-        work_chars=sum(len(t) for t in request.texts),
+        work_chars=_padded_chars(request.texts),
     )
     return EmbedSparseResponse(
         embeddings=[
@@ -1182,7 +1260,7 @@ async def embed_late(request: EmbedLateRequest):
     results = await run_inference_async(
         lambda: list(model.embed(request.texts)),
         work_units=len(request.texts),
-        work_chars=sum(len(t) for t in request.texts),
+        work_chars=_padded_chars(request.texts),
     )
     return EmbedLateResponse(
         embeddings=[LateEmbeddingResult(embeddings=r.tolist()) for r in results],

--- a/docker/embedding/main.py
+++ b/docker/embedding/main.py
@@ -230,13 +230,14 @@ embedding_inflight_work = _make_metric(
     "embedding_inflight_work",
     "Sum of in-flight batch sizes (work-units) across slots held; bounded by the envelope",
 )
-# TD-783: the byte dimension of in-flight work — the SUM of in-flight CHARS across slots
-# held, bounded by EMBEDDING_SAFE_INFLIGHT_CHARS. Exposed so live load-verification can
-# watch the real memory-proportional quantity (bytes), not just the text count.
+# TD-783: the byte dimension of in-flight work — the SUM of in-flight PADDED chars
+# (_padded_chars: rows x max_len) across slots held, bounded by EMBEDDING_SAFE_INFLIGHT_CHARS.
+# Exposed so live load-verification can watch the real memory-proportional quantity (bytes),
+# not just the text count.
 embedding_inflight_chars = _make_metric(
     Gauge,
     "embedding_inflight_chars",
-    "Sum of in-flight input chars across slots held; bounded by the byte envelope",
+    "Sum of in-flight PADDED chars (rows x max_len) across slots held; bounded by the byte envelope",
 )
 embedding_queue_depth = _make_metric(
     Gauge,
@@ -656,13 +657,14 @@ def _enforce_payload_limits(texts: list[str], per_text_cap: bool = True) -> None
     # envelope (the load-time invariant guarantees MAX_INPUT_CHARS <= SAFE_INFLIGHT_CHARS).
     # Checked after the total-chars cap so a plain oversized batch still reports "Input too
     # large" (a uniform batch has padded == sum, so this fires only on genuine skew).
-    padded_chars = _padded_chars(texts)
+    max_len = max((len(t) for t in texts), default=0)
+    padded_chars = len(texts) * max_len
     if padded_chars > EMBEDDING_MAX_INPUT_CHARS:
         raise HTTPException(
             status_code=413,
             detail=(
                 f"Batch padding too large: {len(texts)} texts x "
-                f"{max((len(t) for t in texts), default=0)} max chars = {padded_chars} "
+                f"{max_len} max chars = {padded_chars} "
                 f"> max {EMBEDDING_MAX_INPUT_CHARS}"
             ),
         )

--- a/docker/embedding/main.py
+++ b/docker/embedding/main.py
@@ -46,9 +46,12 @@ LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 # onnxruntime build OMP_NUM_THREADS does NOT cap intra-op parallelism (it defaults to
 # all cores), so fastembed's threads= is the effective lever. Fewer threads => smaller
 # per-request peak and less CPU contention on the shared low-RAM host, trading
-# throughput for survivability ("process slowly"). Conservative default; tune under the
-# soak.
-EMBEDDING_INFERENCE_THREADS = int(os.getenv("EMBEDDING_INFERENCE_THREADS", "2"))
+# throughput for survivability ("process slowly").
+# TD-794 (PM #390 X1 thread sweep): a 5-run-median sweep found throughput monotonically
+# rising 2→3→4 threads (7.87→9.27→9.56 txt/s aggregate; large-text 28.5→19.4 s) with NO
+# extra memory, so 4 is the measured sweet-spot on this host. Keep OMP_NUM_THREADS aligned
+# to this in compose.
+EMBEDDING_INFERENCE_THREADS = int(os.getenv("EMBEDDING_INFERENCE_THREADS", "4"))
 
 # TD-670 / BUG-324: Bound concurrent model inference with a single service-global gate.
 # FastAPI ran the sync handlers in the anyio threadpool (~40 threads), so without a real
@@ -77,17 +80,38 @@ EMBEDDING_RETRY_AFTER = int(os.getenv("EMBEDDING_RETRY_AFTER", "5"))
 EMBEDDING_CGROUP_PATH = os.getenv("EMBEDDING_CGROUP_PATH", "/sys/fs/cgroup")
 EMBEDDING_PRESSURE_INTERVAL = float(os.getenv("EMBEDDING_PRESSURE_INTERVAL", "1.0"))
 EMBEDDING_PSI_THRESHOLD = float(os.getenv("EMBEDDING_PSI_THRESHOLD", "10.0"))
-EMBEDDING_MEMORY_HIGH_RATIO = float(os.getenv("EMBEDDING_MEMORY_HIGH_RATIO", "0.9"))
-EMBEDDING_MEMORY_OK_RATIO = float(os.getenv("EMBEDDING_MEMORY_OK_RATIO", "0.75"))
+# TD-793/X5 (PM #390): lowered from 0.9 as the PORTABLE primary memory.high fix. The
+# kernel cgroup memory.high is not settable from Docker/compose (mem_reservation maps to
+# memory.low, mem_limit to memory.max), and the in-container cgroup is read-only (X5) — so
+# the app-level ratio IS the portable throttle threshold. At 0.80 the AIMD controller
+# starts shedding at ~8 GiB of the 10 GiB cap (vs 9 GiB before), giving ~2 GiB to react
+# before the OOM ceiling instead of the previous thin ~1 GiB margin (X3). OK_RATIO lowered
+# in lockstep to 0.65 to preserve the 0.15 hysteresis gap (recover at ~6.5 GiB), just
+# below the ~7.95 GiB designed envelope peak, so recovery is not chattery.
+EMBEDDING_MEMORY_HIGH_RATIO = float(os.getenv("EMBEDDING_MEMORY_HIGH_RATIO", "0.80"))
+EMBEDDING_MEMORY_OK_RATIO = float(os.getenv("EMBEDDING_MEMORY_OK_RATIO", "0.65"))
 
 # TD-670: Reject oversized payloads up front so a single huge request cannot drive the
 # worker into an OS-level OOM SIGKILL (which the 503 fault-isolation in
-# run_inference_async cannot catch). Bound both the batch size (number of texts ->
-# number of vectors materialized) and the total input size (chars -> model working
-# memory). Defaults are provisional and meant to be tuned against real saturation
-# behaviour during the soak.
+# run_inference_async cannot catch). Bound the batch size (number of texts -> number of
+# vectors materialized), the total input size (chars), AND the size of any single text.
 EMBEDDING_MAX_BATCH_TEXTS = int(os.getenv("EMBEDDING_MAX_BATCH_TEXTS", "256"))
-EMBEDDING_MAX_INPUT_CHARS = int(os.getenv("EMBEDDING_MAX_INPUT_CHARS", "1000000"))
+# TD-795 (P0, PM #390 X2): the old 1,000,000-char total let ONE request reach ~28 GiB and
+# OOM the 10 GiB cap regardless of concurrency (1,000,000 / 8192 = ~122 texts x 235 MiB =
+# ~28 GiB). Sized from the measured slope + cap: with per-text bounded to the 8 KB anchor
+# (below), the worst per-char transient cost is 235 MiB / 8192 = ~0.0287 MiB/char, so a
+# 200,000-char request peaks at ~5.6 GiB transient (+2.35 GiB warm base = ~7.95 GiB), well
+# under the 10 GiB cap. This is also the per-request ceiling for a lone (always-admitted)
+# request, so it must stay <= EMBEDDING_SAFE_INFLIGHT_CHARS.
+EMBEDDING_MAX_INPUT_CHARS = int(os.getenv("EMBEDDING_MAX_INPUT_CHARS", "200000"))
+# TD-795 (P0): per-TEXT char cap. Because per-text memory is super-linear (~O(L^2), the
+# transformer attention term), one very large text costs far more than the same chars
+# spread across many texts — a total-chars bound alone is byte-blind to the distribution.
+# Capping each text at the 8 KB measurement anchor pins the worst per-char rate to the
+# directly-measured 235 MiB / 8192 chars (no O(L^2) extrapolation) and bounds a single
+# text to ~235 MiB. 8192 is >=3x the largest legitimate chunk (256-512 tok ~= 2.4 KB), so
+# it never rejects real sub-batched traffic; it only catches a pathological lone text.
+EMBEDDING_MAX_TEXT_CHARS = int(os.getenv("EMBEDDING_MAX_TEXT_CHARS", "8192"))
 
 # BUG-326: PROACTIVE pre-admission envelope on the worst-case concurrent transient
 # footprint. With the BUG-324 arena-off retention fix in place, the service still admits
@@ -118,6 +142,23 @@ EMBEDDING_MAX_INPUT_CHARS = int(os.getenv("EMBEDDING_MAX_INPUT_CHARS", "1000000"
 #     work level and why live verification governs the final value. Per-request total
 #     chars remain separately bounded by EMBEDDING_MAX_INPUT_CHARS.
 EMBEDDING_SAFE_INFLIGHT_TEXTS = int(os.getenv("EMBEDDING_SAFE_INFLIGHT_TEXTS", "48"))
+
+# TD-783 (PM #390 X2): byte/superlinear-aware in-flight envelope. The count-only
+# EMBEDDING_SAFE_INFLIGHT_TEXTS above is byte-BLIND — 48 in-flight texts is ~96 KiB of
+# work at 2 KB/text but ~384 KB at 8 KB/text, and the latter OOM-killed the 10 GiB cap
+# (48 x 8 KB = 393,216 chars -> ~10.37 GiB, X2). This bounds the SUM of in-flight CHARS
+# across all slots holding an inference slot, so peak memory tracks real byte-work, not
+# text count. It COMPLEMENTS (does not replace) the count envelope: the count stays as the
+# cross-deploy contract the client mirrors (storage._embedding_inflight_envelope), while
+# this char budget is the binding memory bound for large-text bursts.
+#   Sizing (10 GiB cap, ~2.35 GiB warm base): budget the transient at cap - base - margin
+#   ~= 10 - 2.35 - ~1.5 (fragmentation/overshoot; X2 overshot the cap by ~0.37 GiB) ~=
+#   6.15 GiB. With per-text capped at 8 KB the worst per-char cost is 235 MiB / 8192 =
+#   ~0.0287 MiB/char, so 200,000 chars -> ~5.6 GiB transient -> ~7.95 GiB peak, leaving
+#   ~2 GiB (~20%) headroom. The exact 393,216-char kill-load is shed down to <= 200,000.
+EMBEDDING_SAFE_INFLIGHT_CHARS = int(
+    os.getenv("EMBEDDING_SAFE_INFLIGHT_CHARS", "200000")
+)
 
 # Configure logging
 logging.basicConfig(
@@ -166,6 +207,14 @@ embedding_inflight_work = _make_metric(
     Gauge,
     "embedding_inflight_work",
     "Sum of in-flight batch sizes (work-units) across slots held; bounded by the envelope",
+)
+# TD-783: the byte dimension of in-flight work — the SUM of in-flight CHARS across slots
+# held, bounded by EMBEDDING_SAFE_INFLIGHT_CHARS. Exposed so live load-verification can
+# watch the real memory-proportional quantity (bytes), not just the text count.
+embedding_inflight_chars = _make_metric(
+    Gauge,
+    "embedding_inflight_chars",
+    "Sum of in-flight input chars across slots held; bounded by the byte envelope",
 )
 embedding_queue_depth = _make_metric(
     Gauge,
@@ -226,6 +275,11 @@ _waiting_count = 0
 # its release (no await in that window), so a plain int needs no lock.
 _inflight_work = 0
 
+# TD-783: byte twin of _inflight_work — sum of INPUT CHARS of requests currently holding
+# an inference slot. Bounded by EMBEDDING_SAFE_INFLIGHT_CHARS at admission. Same
+# single-event-loop mutation window as _inflight_work, so a plain int needs no lock.
+_inflight_chars = 0
+
 # BUG-324 Phase 2: the AIMD controller shrinks the EFFECTIVE limit below the static max
 # by *parking* permits on the semaphore (acquiring without releasing) — so a collapse to
 # 1 simply drains as in-flight requests finish. effective = max - parked.
@@ -239,7 +293,7 @@ _blind_hold_logged = False
 embedding_effective_concurrency_limit.set(_effective_limit)
 
 
-async def run_inference_async(operation, work_units=1):
+async def run_inference_async(operation, work_units=1, work_chars=0):
     """Run a model inference under the service-global backpressure gate (BUG-324).
 
     Admission is BLOCK-not-drop: the caller waits up to ``EMBEDDING_ACQUIRE_TIMEOUT`` for
@@ -279,10 +333,15 @@ async def run_inference_async(operation, work_units=1):
     Args:
         operation: Zero-arg callable performing the (blocking) model inference.
         work_units: This request's batch size (number of texts to embed); the unit the
-            envelope bounds. Defaults to 1. CONTRACT: callers MUST pass
-            ``work_units=len(texts)`` — the envelope and the 413 gate are only correct if
-            this equals the number of texts ``operation`` will embed. A wrong value
+            count envelope bounds. Defaults to 1. CONTRACT: callers MUST pass
+            ``work_units=len(texts)`` — the count envelope and the 413 gate are only correct
+            if this equals the number of texts ``operation`` will embed. A wrong value
             silently under- or over-counts in-flight work and defeats the memory bound.
+        work_chars: This request's total input size in chars (``sum(len(t) for t in
+            texts)``); the unit the byte envelope (``EMBEDDING_SAFE_INFLIGHT_CHARS``)
+            bounds (TD-783). Defaults to 0 (byte gate inert) for callers that do not
+            embed text. CONTRACT: text-embedding callers MUST pass the real char total —
+            it is the memory-proportional quantity the byte envelope caps.
 
     Returns:
         Whatever ``operation`` returns.
@@ -293,7 +352,7 @@ async def run_inference_async(operation, work_units=1):
             limits, if admitting would breach the in-flight-work envelope, or if the
             inference call raises any non-HTTPException error.
     """
-    global _waiting_count, _inflight_work
+    global _waiting_count, _inflight_work, _inflight_chars
 
     # BUG-327: permanent 413 for a request whose own batch exceeds the envelope. Checked
     # before queueing/acquiring a slot (independent of concurrency) — it is the work-unit
@@ -391,9 +450,38 @@ async def run_inference_async(operation, work_units=1):
             headers={"Retry-After": str(EMBEDDING_RETRY_AFTER)},
         )
 
+    # TD-783 byte/superlinear-aware gate. Same shape as the count gate above but on CHARS:
+    # if admitting this request's chars would push the concurrent in-flight char total over
+    # EMBEDDING_SAFE_INFLIGHT_CHARS, shed (giving the slot back). This is the binding memory
+    # bound under large-text bursts, where the count gate is byte-blind (48 texts is safe at
+    # 2 KB but OOMs at 8 KB). A lone request is always admitted — its chars are already
+    # bounded to <= EMBEDDING_MAX_INPUT_CHARS (<= EMBEDDING_SAFE_INFLIGHT_CHARS) by
+    # _enforce_payload_limits — so this never starves it and cannot deadlock.
+    if (
+        _inflight_chars > 0
+        and _inflight_chars + work_chars > EMBEDDING_SAFE_INFLIGHT_CHARS
+    ):
+        _inference_semaphore.release()
+        embedding_backpressure_total.labels(action="shed").inc()
+        logger.warning(
+            "embedding_admission_over_char_envelope",
+            extra={
+                "inflight_chars": _inflight_chars,
+                "work_chars": work_chars,
+                "envelope": EMBEDDING_SAFE_INFLIGHT_CHARS,
+            },
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="embedding_admission_over_char_envelope",
+            headers={"Retry-After": str(EMBEDDING_RETRY_AFTER)},
+        )
+
     _inflight_work += work_units
+    _inflight_chars += work_chars
     embedding_inflight.inc()
     embedding_inflight_work.set(_inflight_work)
+    embedding_inflight_chars.set(_inflight_chars)
     # M1 (BUG-324): release the slot EXACTLY ONCE and ONLY when the executor thread truly
     # completes. A client disconnect raises asyncio.CancelledError (a BaseException) out of
     # the await below; releasing in the request-coroutine ``finally`` would free the
@@ -408,10 +496,12 @@ async def run_inference_async(operation, work_units=1):
     loop = asyncio.get_running_loop()
 
     def _release_slot():
-        global _inflight_work
+        global _inflight_work, _inflight_chars
         _inflight_work -= work_units
+        _inflight_chars -= work_chars
         embedding_inflight.dec()
         embedding_inflight_work.set(_inflight_work)
+        embedding_inflight_chars.set(_inflight_chars)
         _inference_semaphore.release()
 
     # If submit() raises (executor shutdown -> RuntimeError; or BrokenThreadPool after a
@@ -451,19 +541,34 @@ async def run_inference_async(operation, work_units=1):
 def _enforce_payload_limits(texts: list[str]) -> None:
     """Reject oversized embed payloads with HTTP 413 before any model work (TD-670).
 
-    Bounds both the number of texts in the batch and the total input size in
-    characters, closing the single-request OOM vector by refusing a huge batch before
-    it is materialized into vectors. Limits are configured via
-    ``EMBEDDING_MAX_BATCH_TEXTS`` and ``EMBEDDING_MAX_INPUT_CHARS``.
+    Bounds three dimensions, closing the single-request OOM vector before the batch is
+    materialized into vectors:
+
+    - number of texts (``EMBEDDING_MAX_BATCH_TEXTS``) — vectors materialized;
+    - total input chars (``EMBEDDING_MAX_INPUT_CHARS``) — the whole-request working set;
+    - size of any single text (``EMBEDDING_MAX_TEXT_CHARS``, TD-795) — per-text memory is
+      super-linear (~O(L^2)), so one huge text costs far more than the same chars spread
+      across texts; a total-chars bound alone is blind to that distribution.
 
     Raises:
-        HTTPException: 413 if the batch has too many texts or too many total chars.
+        HTTPException: 413 if the batch has too many texts, too many total chars, or any
+        single text exceeds the per-text cap.
     """
     if len(texts) > EMBEDDING_MAX_BATCH_TEXTS:
         raise HTTPException(
             status_code=413,
             detail=f"Too many texts: {len(texts)} > max {EMBEDDING_MAX_BATCH_TEXTS}",
         )
+    # TD-795: per-text cap first — a single super-linear text is the worst-case OOM driver.
+    for i, t in enumerate(texts):
+        if len(t) > EMBEDDING_MAX_TEXT_CHARS:
+            raise HTTPException(
+                status_code=413,
+                detail=(
+                    f"Text {i} too large: {len(t)} chars > "
+                    f"max {EMBEDDING_MAX_TEXT_CHARS} per text"
+                ),
+            )
     total_chars = sum(len(t) for t in texts)
     if total_chars > EMBEDDING_MAX_INPUT_CHARS:
         raise HTTPException(
@@ -943,7 +1048,9 @@ async def embed_dense(request: EmbedDenseRequest) -> EmbedDenseResponse:
 
     model = MODEL_REGISTRY[request.model]
     embeddings = await run_inference_async(
-        lambda: list(model.embed(request.texts)), work_units=len(request.texts)
+        lambda: list(model.embed(request.texts)),
+        work_units=len(request.texts),
+        work_chars=sum(len(t) for t in request.texts),
     )
     return EmbedDenseResponse(
         embeddings=[e.tolist() for e in embeddings],
@@ -991,7 +1098,9 @@ async def embed_chunked(request: EmbedWithOffsetsRequest):
     if not request.chunk_offsets:
         # No offsets — embed whole document as single vector
         embeddings = await run_inference_async(
-            lambda: list(model.embed([document])), work_units=1
+            lambda: list(model.embed([document])),
+            work_units=1,
+            work_chars=len(document),
         )
         return EmbedResponse(
             embeddings=[e.tolist() for e in embeddings],
@@ -1009,7 +1118,9 @@ async def embed_chunked(request: EmbedWithOffsetsRequest):
     _enforce_payload_limits(chunk_texts)
 
     embeddings = await run_inference_async(
-        lambda: list(model.embed(chunk_texts)), work_units=len(chunk_texts)
+        lambda: list(model.embed(chunk_texts)),
+        work_units=len(chunk_texts),
+        work_chars=sum(len(t) for t in chunk_texts),
     )
     return EmbedResponse(
         embeddings=[e.tolist() for e in embeddings],
@@ -1028,7 +1139,9 @@ async def embed_sparse(request: EmbedSparseRequest):
     _enforce_payload_limits(request.texts)
     model = SPARSE_REGISTRY["bm25"]
     results = await run_inference_async(
-        lambda: list(model.embed(request.texts)), work_units=len(request.texts)
+        lambda: list(model.embed(request.texts)),
+        work_units=len(request.texts),
+        work_chars=sum(len(t) for t in request.texts),
     )
     return EmbedSparseResponse(
         embeddings=[
@@ -1052,7 +1165,9 @@ async def embed_late(request: EmbedLateRequest):
     _enforce_payload_limits(request.texts)
     model = LATE_REGISTRY["colbert"]
     results = await run_inference_async(
-        lambda: list(model.embed(request.texts)), work_units=len(request.texts)
+        lambda: list(model.embed(request.texts)),
+        work_units=len(request.texts),
+        work_chars=sum(len(t) for t in request.texts),
     )
     return EmbedLateResponse(
         embeddings=[LateEmbeddingResult(embeddings=r.tolist()) for r in results],

--- a/docs/EMBEDDING-SIZING.md
+++ b/docs/EMBEDDING-SIZING.md
@@ -2,7 +2,7 @@
 
 The embedding service is **shared across every project on one install**. All projects (and any co-tenant such as a document-ingest pipeline) send their embed requests to the same container, so its memory limit must be sized for your **combined** load, not a single project.
 
-> **Status: provisional.** The numbers below are sized from observed live behaviour, now including the BUG-324 idle-watch diagnostic (2026-06-21). Treat them as safe starting points, not final tuning — the active-release fix that would let a 6G cap hold indefinitely under sustained load is a tracked follow-up (see *Memory footprint reality*).
+> **Status: provisional.** The numbers below are sized from observed live behaviour, now including the BUG-324 idle-watch diagnostic (2026-06-21). Treat them as safe starting points, not final tuning — the active-release fix that would let the memory cap hold indefinitely under sustained load is a tracked follow-up (see *Memory footprint reality*).
 
 ## How the service behaves under load
 
@@ -23,13 +23,14 @@ Because the residue only releases on a recycle today, an **active-release lever*
 
 ## Sizing guidance
 
-Set `EMBEDDING_MEMORY_LIMIT` (in `docker/.env`) by how many projects embed **concurrently** on this install:
+`EMBEDDING_MEMORY_LIMIT` (in `docker/.env`) ships at **`10G`, and 10G is also the floor** — it is the design basis of the byte-aware admission envelope, not a value to trim. The envelope is sized against a 10 GiB cap: warm base ~2.35 GiB + ~5.6 GiB in-flight char budget = ~7.95 GiB worst-case peak, leaving ~2 GiB headroom. Shipping (or shrinking to) a smaller cap puts the envelope's designed peak above the limit and re-introduces the exact OOM this sizing prevents, so `EMBEDDING_MAX_INPUT_CHARS` / `EMBEDDING_SAFE_INFLIGHT_CHARS` and the cap must move together.
+
+Raise the cap by how many projects embed **concurrently** on this install:
 
 | Concurrent projects on the install | `EMBEDDING_MEMORY_LIMIT` | Notes |
 |---|---|---|
-| 1, light/uniform load | `6G` (floor — `4G` not viable) | Even a single light project sits at a ~3.10 GiB loaded-idle baseline, so `4G` leaves <0.9 GiB for load + arena growth and will OOM under sustained load. Do not drop below 6G. |
-| 2–3 (multi-repo shared, incl. a doc-ingest co-tenant) | **`6G` (default)** | Survives observed real mixed load **when paired with active release** (a tracked follow-up — see *Memory footprint reality*); expect AIMD to throttle toward serial under bursts. |
-| Many / heavy / large code files | `8G`+ **or isolate** | Either raise the cap, or run a dedicated embedding service per heavy project. |
+| 1–3 (typical multi-repo shared, incl. a doc-ingest co-tenant) | **`10G` (default — the envelope basis, and the floor)** | The admission envelope is sized against this cap (peak ~7.95 GiB, ~2 GiB headroom). Do not drop below `10G` without lowering the char envelope in lockstep, or the designed peak exceeds the cap. |
+| Many / heavy / large code files | `12G`+ **or isolate** | Either raise the cap (and the char envelope with it), or run a dedicated embedding service per heavy project. |
 
 If you routinely see `embedding_effective_concurrency_limit` pinned at `1` and `embedding_memory_headroom_bytes` near zero (Prometheus), the cap is too low for your load — raise it or reduce `EMBEDDING_MAX_CONCURRENCY`.
 

--- a/tests/test_embedding_service.py
+++ b/tests/test_embedding_service.py
@@ -17,6 +17,7 @@ import asyncio
 import importlib.util
 import logging
 import os
+import re
 import sys
 import threading
 import time
@@ -138,10 +139,14 @@ def _restore_global_state():
         "EMBEDDING_ACQUIRE_TIMEOUT",
         "EMBEDDING_MAX_BATCH_TEXTS",
         "EMBEDDING_MAX_INPUT_CHARS",
+        "EMBEDDING_MAX_TEXT_CHARS",
         "EMBEDDING_MAX_WAITERS",
         "EMBEDDING_RETRY_AFTER",
         "EMBEDDING_INFERENCE_THREADS",
         "EMBEDDING_SAFE_INFLIGHT_TEXTS",
+        "EMBEDDING_SAFE_INFLIGHT_CHARS",
+        "EMBEDDING_MEMORY_HIGH_RATIO",
+        "EMBEDDING_MEMORY_OK_RATIO",
     )
     saved_modules = {k: sys.modules.get(k) for k in module_keys}
     saved_env = {k: os.environ.get(k) for k in env_keys}
@@ -649,6 +654,235 @@ def test_over_envelope_413_is_endpoint_agnostic():
     status, headers = asyncio.run(_drive())
     assert status == 413
     assert "retry-after" not in {k.lower() for k in headers}
+
+
+# --- TD-795: single-request per-text cap ---
+
+
+def test_oversized_single_text_returns_413():
+    """TD-795: a lone text exceeding EMBEDDING_MAX_TEXT_CHARS is rejected with 413, even
+    when the batch count and total-char budgets would pass — the super-linear per-text
+    memory driver is capped independently of the total-chars bound."""
+    service = _load_service(4)
+    service.EMBEDDING_MAX_TEXT_CHARS = 10
+    service.EMBEDDING_MAX_INPUT_CHARS = (
+        10_000  # total budget is NOT the binding limit here
+    )
+    client = TestClient(service.app)
+
+    resp = client.post("/embed/dense", json={"texts": ["x" * 50], "model": "en"})
+    assert resp.status_code == 413
+    assert "per text" in resp.json()["detail"]
+
+
+def test_per_text_cap_fires_before_total_char_cap():
+    """A batch whose TOTAL chars fit but which contains one over-cap text is rejected on the
+    per-text cap (TD-795) — the distribution matters, not just the sum."""
+    service = _load_service(4)
+    service.EMBEDDING_MAX_TEXT_CHARS = 10
+    service.EMBEDDING_MAX_INPUT_CHARS = 10_000  # sum (2 + 50) is well under this
+    client = TestClient(service.app)
+
+    resp = client.post("/embed/dense", json={"texts": ["ok", "x" * 50], "model": "en"})
+    assert resp.status_code == 413
+    assert "Text 1" in resp.json()["detail"]  # the second text is the offender
+
+
+# --- TD-783: byte/superlinear-aware in-flight admission envelope ---
+
+
+def test_char_envelope_sheds_over_char_budget_concurrent_work():
+    """TD-783: once work is in flight, a request that would push the concurrent in-flight
+    CHAR total over EMBEDDING_SAFE_INFLIGHT_CHARS is shed (503 + Retry-After), while one
+    that fits is admitted. The count envelope is NOT the binding constraint here (work_units
+    stay tiny) — the byte budget is."""
+    service = _load_service(4)
+    service.EMBEDDING_SAFE_INFLIGHT_CHARS = 40
+    # Keep the count envelope non-binding so only the char gate can fire.
+    service.EMBEDDING_SAFE_INFLIGHT_TEXTS = 48
+
+    async def _drive():
+        gate = threading.Event()
+
+        def _blocking_op():
+            gate.wait(timeout=10)  # hold the slot so _inflight_chars stays at 30
+            return ["held"]
+
+        # Hold one in-flight request of 30 chars (1 text); wait until it is counted.
+        holder = asyncio.create_task(
+            service.run_inference_async(_blocking_op, work_units=1, work_chars=30)
+        )
+        while service._inflight_chars < 30:
+            await asyncio.sleep(0)
+
+        # Over-char-envelope: 30 + 20 = 50 > 40 -> shed (count is 1 + 1 = 2 << 48).
+        before_shed = _backpressure_count(service, "shed")
+        with pytest.raises(HTTPException) as over:
+            await service.run_inference_async(
+                lambda: ["x"], work_units=1, work_chars=20
+            )
+        shed_delta = _backpressure_count(service, "shed") - before_shed
+
+        # Under-envelope: 30 + 10 = 40, not over -> admitted.
+        fit = await service.run_inference_async(
+            lambda: ["y"], work_units=1, work_chars=10
+        )
+
+        gate.set()
+        await holder
+        # All in-flight char/work bookkeeping unwinds to zero — no leak.
+        for _ in range(1000):
+            if service._inflight_chars == 0 and service._inflight_work == 0:
+                break
+            await asyncio.sleep(0)
+        assert service._inflight_chars == 0
+        assert service._inflight_work == 0
+        return over.value, shed_delta, fit
+
+    err, shed_delta, fit = asyncio.run(_drive())
+    assert err.status_code == 503
+    assert err.detail == "embedding_admission_over_char_envelope"
+    assert err.headers["Retry-After"] == str(service.EMBEDDING_RETRY_AFTER)
+    assert shed_delta == 1
+    assert fit == ["y"]
+
+
+def test_char_envelope_admits_lone_request_at_budget():
+    """The lone-request ADMIT (deadlock prevention) holds for the char gate: an idle request
+    whose chars equal the envelope is admitted, never starved (TD-783)."""
+    service = _load_service(4)
+    service.EMBEDDING_SAFE_INFLIGHT_CHARS = 40
+
+    async def _drive():
+        # 40 == envelope, service idle -> admitted.
+        return await service.run_inference_async(
+            lambda: ["solo"], work_units=1, work_chars=40
+        )
+
+    assert asyncio.run(_drive()) == ["solo"]
+
+
+def test_char_envelope_enforced_on_http_path_with_large_texts():
+    """End-to-end on the real /embed/dense path: while a large-text request is in flight, a
+    concurrent large-text request that would breach EMBEDDING_SAFE_INFLIGHT_CHARS is shed
+    with the byte-envelope 503 — proving work_chars is wired from the real request size
+    (TD-783). Batches stay well under the count envelope, so the CHAR gate is the one that
+    fires."""
+    service = _load_service(4)
+    # ~2 KB/text x 8 texts = ~16 KB in flight; set the char budget just above one such
+    # request so a second concurrent one breaches it. Count stays 8 << 48.
+    one_request_chars = sum(len(t) for t in _production_shaped_batch(count=8))
+    service.EMBEDDING_SAFE_INFLIGHT_CHARS = one_request_chars + 100
+    service.EMBEDDING_SAFE_INFLIGHT_TEXTS = 48
+
+    async def _drive():
+        gate = threading.Event()
+        entered = asyncio.Event()
+        loop = asyncio.get_running_loop()
+
+        class _GatedModel:
+            name = "gated-stub"
+
+            def embed(self, embed_texts):
+                loop.call_soon_threadsafe(entered.set)
+                gate.wait(timeout=10)  # hold the slot while the second request arrives
+                return [np.full(768, 0.1, dtype=np.float32) for _ in embed_texts]
+
+        service.MODEL_REGISTRY["en"] = _GatedModel()
+        texts = _production_shaped_batch(count=8)
+
+        transport = httpx.ASGITransport(app=service.app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://embedding.test"
+        ) as client:
+            holder = asyncio.create_task(
+                client.post("/embed/dense", json={"texts": texts, "model": "en"})
+            )
+            await entered.wait()  # first request in flight (chars counted)
+
+            over = await client.post(
+                "/embed/dense", json={"texts": texts, "model": "en"}
+            )
+
+            gate.set()
+            holder_resp = await holder
+            for _ in range(1000):
+                if service._inflight_chars == 0:
+                    break
+                await asyncio.sleep(0)
+            assert service._inflight_chars == 0
+            return over.status_code, over.json().get("detail"), holder_resp.status_code
+
+    status, detail, holder_status = asyncio.run(_drive())
+    assert status == 503
+    assert detail == "embedding_admission_over_char_envelope"
+    assert holder_status == 200
+
+
+# --- TD-793/794/795: config wiring (threads, memory-high ratio, byte caps) ---
+
+
+def test_config_defaults_wired():
+    """The Fix C defaults are wired into the module and internally consistent (TD-793/794/
+    795): threads=4, the memory-high/ok hysteresis band lowered, and the byte caps sized so
+    a lone request can never exceed the concurrent envelope."""
+    for key in (
+        "EMBEDDING_INFERENCE_THREADS",
+        "EMBEDDING_MEMORY_HIGH_RATIO",
+        "EMBEDDING_MEMORY_OK_RATIO",
+        "EMBEDDING_MAX_INPUT_CHARS",
+        "EMBEDDING_MAX_TEXT_CHARS",
+        "EMBEDDING_SAFE_INFLIGHT_CHARS",
+    ):
+        os.environ.pop(key, None)
+    service = _load_service(4)
+
+    # TD-794: measured thread sweet-spot.
+    assert service.EMBEDDING_INFERENCE_THREADS == 4
+    # TD-793: lowered memory-high band, hysteresis gap preserved.
+    assert service.EMBEDDING_MEMORY_HIGH_RATIO == 0.80
+    assert service.EMBEDDING_MEMORY_OK_RATIO == 0.65
+    assert service.EMBEDDING_MEMORY_OK_RATIO < service.EMBEDDING_MEMORY_HIGH_RATIO
+    # TD-795: byte caps.
+    assert service.EMBEDDING_MAX_INPUT_CHARS == 200_000
+    assert service.EMBEDDING_MAX_TEXT_CHARS == 8_192
+    assert service.EMBEDDING_SAFE_INFLIGHT_CHARS == 200_000
+    # Sizing invariant: a lone (always-admitted) request cannot exceed the concurrent
+    # char envelope.
+    assert service.EMBEDDING_MAX_INPUT_CHARS <= service.EMBEDDING_SAFE_INFLIGHT_CHARS
+
+
+def test_thread_config_aligned_across_compose_and_env_example():
+    """TD-794: OMP_NUM_THREADS and EMBEDDING_INFERENCE_THREADS must both default to 4 and
+    stay aligned in BOTH docker-compose.yml and docker/.env.example (a non-OpenMP onnxruntime
+    build makes the two levers independent, so a drift between them silently mis-sizes the
+    pool)."""
+    repo_root = Path(__file__).resolve().parents[1]
+    compose = (repo_root / "docker" / "docker-compose.yml").read_text()
+    env_example = (repo_root / "docker" / ".env.example").read_text()
+
+    # compose uses ${VAR:-default}; .env.example uses VAR=value.
+    assert "OMP_NUM_THREADS=${OMP_NUM_THREADS:-4}" in compose
+    assert "EMBEDDING_INFERENCE_THREADS=${EMBEDDING_INFERENCE_THREADS:-4}" in compose
+    assert re.search(r"^OMP_NUM_THREADS=4$", env_example, re.MULTILINE)
+    assert re.search(r"^EMBEDDING_INFERENCE_THREADS=4$", env_example, re.MULTILINE)
+
+
+def test_new_env_keys_mirrored_in_env_example_and_compose():
+    """Every new EMBEDDING_* key must appear in BOTH docker-compose.yml and
+    docker/.env.example (env-key parity — a compose key absent from .env.example drifts the
+    operator's real .env)."""
+    repo_root = Path(__file__).resolve().parents[1]
+    compose = (repo_root / "docker" / "docker-compose.yml").read_text()
+    env_example = (repo_root / "docker" / ".env.example").read_text()
+    for key in (
+        "EMBEDDING_MAX_TEXT_CHARS",
+        "EMBEDDING_SAFE_INFLIGHT_CHARS",
+    ):
+        assert key in compose, f"{key} missing from docker-compose.yml"
+        assert re.search(
+            rf"^{key}=", env_example, re.MULTILINE
+        ), f"{key} missing from docker/.env.example"
 
 
 # --- Phase 2: cgroup-v2 reader + memory-aware AIMD self-throttle ---

--- a/tests/test_embedding_service.py
+++ b/tests/test_embedding_service.py
@@ -819,6 +819,113 @@ def test_char_envelope_enforced_on_http_path_with_large_texts():
     assert holder_status == 200
 
 
+# --- Reviewer MEDIUM: batch-padding memory bound (fastembed pads the batch to its longest
+# sequence, so peak memory tracks the padded rectangle rows x max_len, not the char sum) ---
+
+
+def test_padded_chars_rectangle():
+    """_padded_chars is the padded rectangle rows x max_len. For a uniform batch it equals
+    the char sum; for a skewed batch (one long + many tiny) it is far larger — that gap is
+    exactly the padding cost the char SUM misses."""
+    service = _load_service(4)
+    uniform = ["abcd", "efgh", "ijkl"]  # 3 x 4 = 12; sum = 12 -> equal
+    assert service._padded_chars(uniform) == 12
+    assert service._padded_chars(uniform) == sum(len(t) for t in uniform)
+
+    skewed = ["x" * 8192] + ["y"] * 47  # sum = 8239, padded = 48 x 8192 = 393216
+    assert sum(len(t) for t in skewed) == 8239
+    assert service._padded_chars(skewed) == 48 * 8192
+    assert service._padded_chars([]) == 0
+
+
+def test_skewed_batch_rejected_by_padding_gate():
+    """A skewed batch — one text at the per-text cap plus many tiny — has a small char SUM
+    (passes the total-chars cap) yet a padded rectangle of 48 x 8192 = 393216 (the load that
+    OOM'd the 10 GiB cap). At the shipped defaults it is rejected up front with a clean 413
+    (padding gate), NOT admitted-then-OOM; the service keeps serving. A uniform batch of the
+    SAME char sum is admitted, proving the gate catches padding skew, not batch size."""
+    service = _load_service(4)  # ships MAX_TEXT_CHARS=8192, MAX_INPUT_CHARS=200000
+    client = TestClient(service.app)
+
+    skewed = ["x" * service.EMBEDDING_MAX_TEXT_CHARS] + ["y"] * 47
+    assert (
+        sum(len(t) for t in skewed) <= service.EMBEDDING_MAX_INPUT_CHARS
+    )  # passes sum cap
+    resp = client.post("/embed/dense", json={"texts": skewed, "model": "en"})
+    assert resp.status_code == 413
+    assert "Batch padding too large" in resp.json()["detail"]
+
+    # Same char SUM spread uniformly -> padded ~= sum -> admitted (only skew is caught).
+    total = sum(len(t) for t in skewed)
+    uniform = ["z" * (total // 48)] * 48
+    ok = client.post("/embed/dense", json={"texts": uniform, "model": "en"})
+    assert ok.status_code == 200
+
+    # Service survived the rejection and still serves.
+    alive = client.post("/embed/dense", json={"texts": ["still alive"], "model": "en"})
+    assert alive.status_code == 200
+
+
+def test_padded_char_envelope_sheds_concurrent_skewed_work():
+    """End-to-end on /embed/dense: work_chars is wired from the PADDED rectangle, not the
+    char sum. While one skewed request (small sum, large padded footprint) holds a slot, a
+    second concurrent skewed request that would push the in-flight PADDED total over
+    EMBEDDING_SAFE_INFLIGHT_CHARS is shed — proving the byte envelope bounds real padded work
+    across concurrent slots, not the padding-blind char sum."""
+    service = _load_service(4)
+    # One skewed request: 10 texts, one at the 8192 cap + 9 tiny. padded = 10 x 8192 = 81920,
+    # char sum ~ 8201. Budget just above one padded request so a second concurrent one breaches
+    # it; a char-SUM gate (~8201 in flight) would NOT fire, so a shed proves padded accounting.
+    skewed = ["x" * service.EMBEDDING_MAX_TEXT_CHARS] + ["y"] * 9
+    one_padded = service._padded_chars(skewed)
+    assert one_padded == 10 * 8192
+    service.EMBEDDING_SAFE_INFLIGHT_CHARS = one_padded + 100
+    service.EMBEDDING_SAFE_INFLIGHT_TEXTS = 48  # keep the count gate non-binding
+
+    async def _drive():
+        gate = threading.Event()
+        entered = asyncio.Event()
+        loop = asyncio.get_running_loop()
+
+        class _GatedModel:
+            name = "gated-stub"
+
+            def embed(self, embed_texts):
+                loop.call_soon_threadsafe(entered.set)
+                gate.wait(timeout=10)  # hold the slot while the second request arrives
+                return [np.full(768, 0.1, dtype=np.float32) for _ in embed_texts]
+
+        service.MODEL_REGISTRY["en"] = _GatedModel()
+
+        transport = httpx.ASGITransport(app=service.app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://embedding.test"
+        ) as client:
+            holder = asyncio.create_task(
+                client.post("/embed/dense", json={"texts": skewed, "model": "en"})
+            )
+            await entered.wait()  # first skewed request in flight (padded chars counted)
+            assert service._inflight_chars == one_padded
+
+            over = await client.post(
+                "/embed/dense", json={"texts": skewed, "model": "en"}
+            )
+
+            gate.set()
+            holder_resp = await holder
+            for _ in range(1000):
+                if service._inflight_chars == 0:
+                    break
+                await asyncio.sleep(0)
+            assert service._inflight_chars == 0
+            return over.status_code, over.json().get("detail"), holder_resp.status_code
+
+    status, detail, holder_status = asyncio.run(_drive())
+    assert status == 503
+    assert detail == "embedding_admission_over_char_envelope"
+    assert holder_status == 200
+
+
 # --- TD-793/794/795: config wiring (threads, memory-high ratio, byte caps) ---
 
 
@@ -870,8 +977,9 @@ def test_thread_config_aligned_across_compose_and_env_example():
 
 def test_new_env_keys_mirrored_in_env_example_and_compose():
     """Every new EMBEDDING_* key must appear in BOTH docker-compose.yml and
-    docker/.env.example (env-key parity — a compose key absent from .env.example drifts the
-    operator's real .env)."""
+    docker/.env.example with the SAME default value (env-key + value parity — a compose key
+    absent from, or defaulting differently than, .env.example drifts the operator's real
+    .env). Value-equality parallels the EMBEDDING_MEMORY_LIMIT drift guard."""
     repo_root = Path(__file__).resolve().parents[1]
     compose = (repo_root / "docker" / "docker-compose.yml").read_text()
     env_example = (repo_root / "docker" / ".env.example").read_text()
@@ -883,6 +991,15 @@ def test_new_env_keys_mirrored_in_env_example_and_compose():
         assert re.search(
             rf"^{key}=", env_example, re.MULTILINE
         ), f"{key} missing from docker/.env.example"
+        # Value-equality: compose uses ``KEY=${KEY:-DEFAULT}``, .env.example uses ``KEY=VALUE``.
+        compose_default = re.search(rf"{key}=\$\{{{key}:-(\d+)\}}", compose)
+        env_value = re.search(rf"^{key}=(\d+)$", env_example, re.MULTILINE)
+        assert compose_default, f"{key} default not parseable in docker-compose.yml"
+        assert env_value, f"{key} value not parseable in docker/.env.example"
+        assert compose_default.group(1) == env_value.group(1), (
+            f"{key} default drifts: compose={compose_default.group(1)} "
+            f"env.example={env_value.group(1)}"
+        )
 
 
 # --- WI-10 acceptance proofs at PRODUCTION defaults (DEC-PM390 amended DONE-WHEN) ---
@@ -1310,11 +1427,17 @@ def test_cancelled_midinference_holds_slot_until_thread_completes():
         sem = service._inference_semaphore
         before_inflight = service.embedding_inflight._value.get()
 
-        task = asyncio.create_task(service.run_inference_async(blocking_op))
+        # Non-zero work_chars so the _inflight_chars no-leak assertion below is meaningful
+        # (a leak on cancel would strand these chars).
+        task = asyncio.create_task(
+            service.run_inference_async(blocking_op, work_units=1, work_chars=7)
+        )
         # Wait until the worker thread is actually inside the inference (slot held).
         await asyncio.get_running_loop().run_in_executor(None, started.wait, 10)
         assert sem.locked()
         assert service.embedding_inflight._value.get() == before_inflight + 1
+        assert service._inflight_work == 1
+        assert service._inflight_chars == 7
 
         # Client disconnect mid-inference.
         task.cancel()
@@ -1339,6 +1462,10 @@ def test_cancelled_midinference_holds_slot_until_thread_completes():
             await asyncio.sleep(0.01)
         assert not sem.locked(), "slot not released after the executor thread completed"
         assert service.embedding_inflight._value.get() == before_inflight
+        # M1: the release callback unwinds BOTH in-flight counters — no work/char leak on the
+        # cancel path.
+        assert service._inflight_work == 0
+        assert service._inflight_chars == 0
 
         # The freed slot admits the next request normally; a double-release would have
         # corrupted the permit count, so a clean single free slot proves exactly-once.
@@ -1369,7 +1496,8 @@ def test_submit_failure_releases_slot_and_returns_503():
 
         service._inference_executor.submit = boom
         with pytest.raises(HTTPException) as exc:
-            await service.run_inference_async(lambda: [1])
+            # Non-zero work_chars so the _inflight_chars no-leak assertion below is meaningful.
+            await service.run_inference_async(lambda: [1], work_units=1, work_chars=5)
 
         # Slot released (not leaked), inflight back to baseline, 503 (not 500).
         assert exc.value.status_code == 503
@@ -1377,9 +1505,10 @@ def test_submit_failure_releases_slot_and_returns_503():
         assert not sem.locked(), "slot leaked after submit() failure"
         assert sem._value == 1
         assert service.embedding_inflight._value.get() == before_inflight
-        # BUG-327: the inline release on submit() failure also unwinds in-flight work
-        # (incremented just before submit) back to zero — no work-unit leak.
+        # BUG-327: the inline release on submit() failure also unwinds in-flight work AND
+        # chars (both incremented just before submit) back to zero — no work-unit/char leak.
         assert service._inflight_work == 0
+        assert service._inflight_chars == 0
 
     asyncio.run(_drive())
 
@@ -1394,6 +1523,34 @@ def test_max_waiters_floored_to_one(caplog):
     assert any(
         "embedding_max_waiters_floored" in r.getMessage() for r in caplog.records
     )
+
+
+def test_max_input_chars_clamped_to_safe_inflight_chars(caplog):
+    """Reviewer MEDIUM: EMBEDDING_MAX_INPUT_CHARS is clamped down to
+    EMBEDDING_SAFE_INFLIGHT_CHARS at load (with a warning) when an operator tunes it above the
+    envelope. A lone request is always admitted, so its whole payload can sit in flight alone;
+    the clamp makes the invariant MAX_INPUT_CHARS <= SAFE_INFLIGHT_CHARS hold by construction,
+    not only in tests."""
+    os.environ["EMBEDDING_SAFE_INFLIGHT_CHARS"] = "100000"
+    os.environ["EMBEDDING_MAX_INPUT_CHARS"] = (
+        "500000"  # misconfigured above the envelope
+    )
+    with caplog.at_level(logging.WARNING, logger="ai_memory.embedding"):
+        service = _load_service(4)
+    assert service.EMBEDDING_MAX_INPUT_CHARS == 100000
+    assert service.EMBEDDING_MAX_INPUT_CHARS <= service.EMBEDDING_SAFE_INFLIGHT_CHARS
+    assert any(
+        "embedding_max_input_chars_clamped" in r.getMessage() for r in caplog.records
+    )
+
+
+def test_max_input_chars_not_clamped_when_within_envelope():
+    """The clamp is a guard, not a floor: a MAX_INPUT_CHARS at or below the envelope is left
+    untouched (no spurious downsizing at the shipped defaults)."""
+    os.environ["EMBEDDING_SAFE_INFLIGHT_CHARS"] = "200000"
+    os.environ["EMBEDDING_MAX_INPUT_CHARS"] = "150000"
+    service = _load_service(4)
+    assert service.EMBEDDING_MAX_INPUT_CHARS == 150000
 
 
 def test_blind_hold_at_one_logs_once_per_state_entry(caplog):

--- a/tests/test_embedding_service.py
+++ b/tests/test_embedding_service.py
@@ -885,6 +885,118 @@ def test_new_env_keys_mirrored_in_env_example_and_compose():
         ), f"{key} missing from docker/.env.example"
 
 
+# --- WI-10 acceptance proofs at PRODUCTION defaults (DEC-PM390 amended DONE-WHEN) ---
+
+
+def test_over_cap_request_rejected_cleanly_at_default_caps():
+    """(a) At the shipped defaults (no cap overrides), an over-cap single request is
+    rejected with a clean 413 — NOT a crash — and the service keeps serving. Covers both
+    the per-text cap (a >8192-char text) and the total-chars cap (a ~1M-char batch, the
+    old limit that could reach ~28 GiB)."""
+    service = _load_service(
+        4
+    )  # ships EMBEDDING_MAX_TEXT_CHARS=8192, MAX_INPUT_CHARS=200000
+    client = TestClient(service.app)
+
+    # A single text over the 8 KB per-text cap -> clean 413.
+    over_text = client.post("/embed/dense", json={"texts": ["x" * 8193], "model": "en"})
+    assert over_text.status_code == 413
+    assert "per text" in over_text.json()["detail"]
+
+    # The old 1,000,000-char total (as in-cap 8000-char texts) -> clean 413 on the total
+    # budget (125 x 8000 = 1,000,000 > 200,000; each text <= 8192 so the per-text cap passes
+    # and the TOTAL cap is the one exercised).
+    big_batch = ["x" * 8000] * 125
+    over_total = client.post("/embed/dense", json={"texts": big_batch, "model": "en"})
+    assert over_total.status_code == 413
+    assert "Input too large" in over_total.json()["detail"]
+
+    # Service survived both rejections and still serves a normal request.
+    ok = client.post("/embed/dense", json={"texts": ["still alive"], "model": "en"})
+    assert ok.status_code == 200
+
+
+def test_kill_load_sheds_to_envelope_at_default():
+    """(b) The 48x8 KB kill-load (~393,216 concurrent in-flight chars, which OOM'd the
+    10 GiB cap) can no longer be admitted: at the shipped EMBEDDING_SAFE_INFLIGHT_CHARS
+    default, once ~200 K chars are in flight, further work SHEDS — in-flight never reaches
+    393 K. Proven at the production default (no override)."""
+    service = _load_service(4)
+    assert (
+        service.EMBEDDING_SAFE_INFLIGHT_CHARS == 200_000
+    )  # shipped default, not overridden
+
+    async def _drive():
+        gate = threading.Event()
+
+        def _blocking_op():
+            gate.wait(
+                timeout=10
+            )  # hold the envelope full while the next request arrives
+            return ["held"]
+
+        # Fill the char envelope exactly (200 K chars, in-cap 8000-char texts, lone-admitted).
+        held_chars = service.EMBEDDING_SAFE_INFLIGHT_CHARS
+        holder = asyncio.create_task(
+            service.run_inference_async(
+                _blocking_op, work_units=1, work_chars=held_chars
+            )
+        )
+        while service._inflight_chars < held_chars:
+            await asyncio.sleep(0)
+
+        # Any further concurrent work would push in-flight past 200 K toward the 393 K
+        # kill-load -> shed (503), so in-flight is pinned at <= the envelope.
+        before_shed = _backpressure_count(service, "shed")
+        with pytest.raises(HTTPException) as over:
+            await service.run_inference_async(
+                lambda: ["x"], work_units=1, work_chars=8192
+            )
+        shed_delta = _backpressure_count(service, "shed") - before_shed
+        peak_inflight = service._inflight_chars
+
+        gate.set()
+        await holder
+        return over.value, shed_delta, peak_inflight
+
+    err, shed_delta, peak_inflight = asyncio.run(_drive())
+    assert err.status_code == 503
+    assert err.detail == "embedding_admission_over_char_envelope"
+    assert shed_delta == 1
+    # In-flight never reached the 393 K kill-load — capped at the 200 K envelope.
+    assert peak_inflight <= 200_000
+    assert peak_inflight < 393_216
+
+
+def test_computed_peak_under_cap_with_margin():
+    """(c) Documented sizing invariant: warm base + the concurrent in-flight char budget,
+    priced at the MEASURED per-char cost, stays under the 10 GiB cap with real margin.
+    This encodes the envelope math so a future retune that breaks the memory budget fails
+    loudly here."""
+    service = _load_service(4)
+
+    # Measured inputs (PM #390 X2/X4): 10 GiB cap, ~2.35 GiB warm base, 235 MiB per 8192-char
+    # text. Per-text is capped at 8192 (EMBEDDING_MAX_TEXT_CHARS), so this per-char rate is
+    # the worst case within the envelope — no O(L^2) extrapolation past the measured point.
+    cap_gib = 10.0
+    warm_base_gib = 2.35
+    mib_per_8192_chars = 235.0
+    assert service.EMBEDDING_MAX_TEXT_CHARS == 8192  # the anchor the rate is priced at
+    mib_per_char = mib_per_8192_chars / service.EMBEDDING_MAX_TEXT_CHARS
+
+    inflight_transient_gib = (
+        service.EMBEDDING_SAFE_INFLIGHT_CHARS * mib_per_char / 1024.0
+    )
+    computed_peak_gib = warm_base_gib + inflight_transient_gib
+
+    # ~7.95 GiB peak; assert it clears the cap with at least ~1.5 GiB of fragmentation
+    # headroom (X2 overshot the cap by ~0.37 GiB, so the margin must comfortably exceed it).
+    assert computed_peak_gib < cap_gib
+    assert cap_gib - computed_peak_gib >= 1.5
+    # And the lone-request ceiling cannot exceed the concurrent budget.
+    assert service.EMBEDDING_MAX_INPUT_CHARS <= service.EMBEDDING_SAFE_INFLIGHT_CHARS
+
+
 # --- Phase 2: cgroup-v2 reader + memory-aware AIMD self-throttle ---
 
 

--- a/tests/test_embedding_service.py
+++ b/tests/test_embedding_service.py
@@ -997,6 +997,91 @@ def test_computed_peak_under_cap_with_margin():
     assert service.EMBEDDING_MAX_INPUT_CHARS <= service.EMBEDDING_SAFE_INFLIGHT_CHARS
 
 
+def _committed_memory_limit_gib(text):
+    """Parse the EMBEDDING_MEMORY_LIMIT default (e.g. '10G') from a compose/.env file into
+    GiB. Docker's 'G' suffix is GiB (1024^3)."""
+    m = re.search(r"EMBEDDING_MEMORY_LIMIT(?:=|:-)(\d+)([GgMm])", text)
+    assert m, "EMBEDDING_MEMORY_LIMIT default not found"
+    value, unit = int(m.group(1)), m.group(2).upper()
+    return value if unit == "G" else value / 1024.0
+
+
+def test_envelope_consistent_with_committed_memory_limit():
+    """Drift guard: the shipped EMBEDDING_MEMORY_LIMIT (the envelope's denominator) must
+    equal the sizing basis in BOTH compose and .env.example, and the computed peak must fit
+    under it with margin. Shipping a limit smaller than the envelope's basis is a latent OOM
+    on a fresh install (base + budget >> limit) — this fails loudly if either drifts."""
+    repo_root = Path(__file__).resolve().parents[1]
+    compose = (repo_root / "docker" / "docker-compose.yml").read_text()
+    env_example = (repo_root / "docker" / ".env.example").read_text()
+
+    committed_compose = _committed_memory_limit_gib(compose)
+    committed_env = _committed_memory_limit_gib(env_example)
+    # No drift between the two files.
+    assert committed_compose == committed_env
+    committed_gib = committed_compose
+
+    service = _load_service(4)
+    mib_per_char = 235.0 / service.EMBEDDING_MAX_TEXT_CHARS
+    peak_gib = 2.35 + service.EMBEDDING_SAFE_INFLIGHT_CHARS * mib_per_char / 1024.0
+
+    # The envelope was sized against a 10 GiB basis; the committed limit must match it, and
+    # the peak must clear it with fragmentation headroom.
+    assert committed_gib == 10
+    assert peak_gib < committed_gib
+    assert committed_gib - peak_gib >= 1.5
+
+
+# --- TD-795 friction 4: legitimate large texts are admitted, not false-rejected ---
+
+
+def test_legit_max_size_text_admitted():
+    """Friction 4: a text at the largest legitimate size is ADMITTED (not 413'd). The
+    chunkers emit prose chunks <= 2048 chars and code chunks well under that; a text right
+    at the 8192 per-text cap (>=3x the largest real chunk) must still pass."""
+    service = _load_service(4)
+    client = TestClient(service.app)
+
+    # A realistic prose-sized chunk (~2 KB) — the actual production max — is admitted.
+    prose = client.post("/embed/dense", json={"texts": ["p" * 2048], "model": "en"})
+    assert prose.status_code == 200
+
+    # A text exactly at the per-text cap boundary is admitted (cap is inclusive).
+    at_cap = client.post(
+        "/embed/dense",
+        json={"texts": ["x" * service.EMBEDDING_MAX_TEXT_CHARS], "model": "en"},
+    )
+    assert at_cap.status_code == 200
+
+
+def test_embed_chunked_large_document_split_is_admitted():
+    """Friction 4: /embed/chunked receives a whole DOCUMENT (legitimately large) that it
+    splits by offsets into in-cap chunks — the per-text cap must NOT false-reject the
+    pre-split document. A 20 K-char document carved into 8 KB spans is embedded (200), while
+    the no-offsets whole-document fallback still enforces the cap (a >cap whole-doc embed is
+    the O(L^2) OOM vector and must be sent WITH offsets)."""
+    service = _load_service(4)
+    client = TestClient(service.app)
+
+    big_doc = (
+        "d" * 20_000
+    )  # > EMBEDDING_MAX_TEXT_CHARS (8192), a legit document to split
+    offsets = [[0, 8000], [8000, 16000], [16000, 20000]]  # each span <= 8192
+    split = client.post(
+        "/embed/chunked",
+        json={"texts": [big_doc], "chunk_offsets": offsets, "late_chunking": True},
+    )
+    assert split.status_code == 200
+    assert len(split.json()["embeddings"]) == len(offsets)
+
+    # No-offsets fallback embeds the document WHOLE -> the per-text cap applies (protective).
+    whole = client.post(
+        "/embed/chunked", json={"texts": [big_doc], "chunk_offsets": []}
+    )
+    assert whole.status_code == 413
+    assert "per text" in whole.json()["detail"]
+
+
 # --- Phase 2: cgroup-v2 reader + memory-aware AIMD self-throttle ---
 
 


### PR DESCRIPTION
## What
Right-sizes the embedding service's admission control so it sheds load instead of OOM-killing under bursts:

- Single-request cap: `EMBEDDING_MAX_INPUT_CHARS` 1,000,000 -> 200,000 plus a new per-text cap `EMBEDDING_MAX_TEXT_CHARS`; oversized input returns a clean 413.
- Byte-aware in-flight envelope `EMBEDDING_SAFE_INFLIGHT_CHARS` that accounts for transformer batch padding (peak memory scales with rows x longest-sequence, not the character sum), so a skewed batch is shed rather than admitted and OOM'd.
- Lower the `memory.high` throttle ratios (`EMBEDDING_MEMORY_HIGH_RATIO` 0.90 -> 0.80, `EMBEDDING_MEMORY_OK_RATIO` 0.75 -> 0.65) to trip earlier while preserving the AIMD hysteresis gap.
- `EMBEDDING_INFERENCE_THREADS` / `OMP_NUM_THREADS` 2 -> 4.
- Ship `EMBEDDING_MEMORY_LIMIT=10G` as the default (the envelope's design basis) with a drift-guard test tying the envelope to the committed limit, and a load-time clamp enforcing `MAX_INPUT_CHARS <= SAFE_INFLIGHT_CHARS`.

## Why
The service OOM-killed under concurrent bursts and under a single oversized request; the previous character-count envelope was blind to both the single-request and the batch-padding memory vectors. This makes the service shed-not-crash regardless of client behavior.

## Testing
Unit tests cover clean rejection at the caps, byte/padded-envelope shedding, the historical kill-load now shedding, config drift, and thread/ratio wiring. Full burst-soak certification against a live stack is a separate operational step; the padded-memory bound was verified against fastembed's batch-longest padding.