### PR TITLE
Coordinate embedding client timeout budget and shape submit rate

### DIFF
--- a/.claude/hooks/scripts/error_store_async.py
+++ b/.claude/hooks/scripts/error_store_async.py
@@ -5,7 +5,9 @@ This script runs in a detached background process, storing captured
 error patterns to Qdrant with type="error_pattern" (v2.0).
 
 Performance: Runs independently of hook (no <500ms constraint)
-Timeout: Configurable via HOOK_TIMEOUT env var (default: 60s)
+Timeout: Configurable via HOOK_TIMEOUT env var (default: 90s — TD-782/788 coherent
+    ceiling above the embedding client's coordinated timeout budget; see
+    memory.hooks_common.get_hook_timeout)
 """
 
 # LANGFUSE: Uses trace buffer (Path A). See LANGFUSE-INTEGRATION-SPEC.md §3.1, §4, §7.7

--- a/.claude/hooks/scripts/store_async.py
+++ b/.claude/hooks/scripts/store_async.py
@@ -8,7 +8,9 @@ This script runs in a detached background process, storing captured
 implementation patterns to Qdrant with proper error handling.
 
 Performance: Runs independently of hook (no <500ms constraint)
-Timeout: Configurable via HOOK_TIMEOUT env var (default: 60s)
+Timeout: Configurable via HOOK_TIMEOUT env var (default: 90s — TD-782/788 coherent
+    ceiling above the embedding client's coordinated timeout budget; see
+    memory.hooks_common.get_hook_timeout)
 
 Sources:
 - Qdrant AsyncQdrantClient: https://python-client.qdrant.tech/

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -390,6 +390,19 @@ EMBEDDING_READ_TIMEOUT_CODE=30
 # raise EMBEDDING_TIMEOUT for the pending-status fallback to run. A construction-
 # time check warns if the invariant is violated.
 EMBEDDING_TOTAL_TIMEOUT=45.0
+# TD-782/788: realistic worst-case single-request inference time (seconds). It is added
+# to the server admission wait (EMBEDDING_ACQUIRE_TIMEOUT, in the resilience section
+# below) to form the coherent client read-timeout floor: the client read timeout is
+# raised to at least EMBEDDING_ACQUIRE_TIMEOUT + EMBEDDING_INFERENCE_TIMEOUT so it cannot
+# expire before the server can plausibly respond (admission + a large-text embed,
+# ~19-28s). EMBEDDING_TOTAL_TIMEOUT is likewise floored to this budget. Keep coherent
+# with EMBEDDING_ACQUIRE_TIMEOUT.
+EMBEDDING_INFERENCE_TIMEOUT=30.0
+# PLAN-030 WI-10 client load-shaping: cap the rate (texts/sec) at which the client
+# submits embeddings, so bulk consumers (github/jira sync) apply patient backpressure
+# instead of overrunning the shared server's sustainable compute ceiling (~9.6 txt/s at
+# INFERENCE_THREADS=4). <= 0 disables shaping.
+EMBEDDING_CLIENT_MAX_TXT_PER_SEC=9.6
 # TD-670 embedding-service resilience controls (defaults provisional, tune under live load):
 # Max simultaneous model inferences (peak-memory / shared-model guard).
 EMBEDDING_MAX_CONCURRENCY=4

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -373,23 +373,28 @@ EMBEDDING_CLIENT_SUBBATCH=128
 # The embedding server enforces the same envelope directly — a lone request whose
 # work-units exceed it is rejected with HTTP 413.
 EMBEDDING_SAFE_INFLIGHT_TEXTS=48
-# TD-774: per-request read timeout for the en model (seconds; default 15s).
-# CPU mode typical: 10-15s. GPU mode: <2s. Increase for underpowered hardware.
-EMBEDDING_READ_TIMEOUT=15.0
-# Per-request read timeout for code model (seconds; default 30s — code model is slower than en)
-# CPU mode typical: 20-30s. Increase for very large files or underpowered hardware.
-EMBEDDING_READ_TIMEOUT_CODE=30
-# BUG-329/TD-710: overall wall-clock deadline (seconds) for embed()'s retry loop.
-# Caps each attempt's READ/inference timeout to the remaining budget, so the read
-# phase itself can never exceed this value. It is NOT an exact ceiling on total
-# wall-clock time: the fixed httpx connect+write+pool overhead (~11s) on each
-# attempt is not budget-capped, so worst-case wall-clock per call is roughly
-# EMBEDDING_TOTAL_TIMEOUT + 11s. That combined figure must stay below the store
-# hooks' HOOK_TIMEOUT (default 60s), or the hook's own timeout can still fire
-# first and abort the store coroutine before this deadline gets a chance to
-# raise EMBEDDING_TIMEOUT for the pending-status fallback to run. A construction-
-# time check warns if the invariant is violated.
-EMBEDDING_TOTAL_TIMEOUT=45.0
+# TD-774/TD-782: per-request read timeout for the en model (seconds). Floored in code to
+# EMBEDDING_ACQUIRE_TIMEOUT + EMBEDDING_INFERENCE_TIMEOUT (the coherent 60s default) so it
+# cannot expire before the server can respond; a LARGER value is honoured for slower
+# hardware, a smaller one is raised to the floor. GPU mode can lower the inference term.
+EMBEDDING_READ_TIMEOUT=60.0
+# Per-request read timeout for the code model (seconds). Same coherent floor applies; set
+# it above the en value only if code embeds are measurably slower on your hardware.
+EMBEDDING_READ_TIMEOUT_CODE=60
+# BUG-329/TD-710 + TD-782/788: overall wall-clock deadline (seconds) for embed()'s retry
+# loop. Made inference-time-aware — its default and lower floor are the coherent
+# single-attempt budget (EMBEDDING_ACQUIRE_TIMEOUT + EMBEDDING_INFERENCE_TIMEOUT, 60s) so
+# it cannot clip a legitimate attempt; a smaller configured value is floored up WITH a
+# warning. Caps each attempt's READ/inference timeout to the remaining budget, so the read
+# phase itself can never exceed this value. It is NOT an exact ceiling on total wall-clock
+# time: the fixed httpx connect+write+pool overhead (~11s) on each attempt is not
+# budget-capped, so worst-case wall-clock per call is roughly EMBEDDING_TOTAL_TIMEOUT +
+# 11s. That combined figure must stay below the store hooks' HOOK_TIMEOUT (coherent
+# default 90s), or the hook's own timeout can still fire first and abort the store
+# coroutine before this deadline gets a chance to raise EMBEDDING_TIMEOUT for the
+# pending-status fallback to run. A construction-time check warns if the invariant is
+# violated.
+EMBEDDING_TOTAL_TIMEOUT=60.0
 # TD-782/788: realistic worst-case single-request inference time (seconds). It is added
 # to the server admission wait (EMBEDDING_ACQUIRE_TIMEOUT, in the resilience section
 # below) to form the coherent client read-timeout floor: the client read timeout is

--- a/scripts/memory/post_work_store_async.py
+++ b/scripts/memory/post_work_store_async.py
@@ -44,6 +44,7 @@ from memory.config import (
     COLLECTION_CONVENTIONS,
     COLLECTION_DISCUSSIONS,
 )
+from memory.hooks_common import get_hook_timeout
 from memory.logging_config import StructuredFormatter
 from memory.qdrant_client import QdrantUnavailable
 from memory.storage import MemoryStorage
@@ -92,22 +93,11 @@ def _log_to_activity(message: str) -> None:
         pass
 
 
-def get_timeout() -> int:
-    """
-    Get timeout value from env var.
-
-    Returns:
-        Timeout in seconds (default: 60)
-    """
-    try:
-        timeout_str = os.getenv("HOOK_TIMEOUT", "60")
-        return int(timeout_str)
-    except ValueError:
-        logger.warning(
-            "invalid_timeout_env", extra={"value": timeout_str, "using_default": 60}
-        )
-        return 60
-
+# CR-1.4 consolidation: the local get_timeout() duplicate was removed in favour of
+# memory.hooks_common.get_hook_timeout() (same helper store_async/error_store_async use)
+# so this post-work store path inherits the coherent HOOK_TIMEOUT default (TD-782/788)
+# and cannot fire its outer wait_for mid-embed before the embedding client's coordinated
+# budget completes.
 
 # QUEUE-UNIFY: queue_to_file() removed - using consolidated queue_operation() from memory.queue
 # This provides automatic retry with exponential backoff via MemoryQueue class
@@ -358,7 +348,7 @@ async def main_async() -> int:
             return 1
 
         # Apply timeout
-        timeout = get_timeout()
+        timeout = get_hook_timeout()
 
         # Run storage with timeout
         await asyncio.wait_for(store_memory_async(payload), timeout=timeout)
@@ -367,7 +357,7 @@ async def main_async() -> int:
 
     except asyncio.TimeoutError:
         # Handle timeout
-        logger.error("storage_timeout", extra={"timeout_seconds": get_timeout()})
+        logger.error("storage_timeout", extra={"timeout_seconds": get_hook_timeout()})
         # Queue for retry
         if payload:
             queue_operation(payload, "timeout")

--- a/src/memory/embeddings.py
+++ b/src/memory/embeddings.py
@@ -248,6 +248,15 @@ class EmbeddingClient:
         )
         coherent_read_floor = self._acquire_timeout + self._inference_timeout
 
+        # BP-184 (reserve-attempt-window): the minimum time a submission's HTTP call
+        # must be left to have a real chance of succeeding — the SAME coherent
+        # read-timeout floor (server acquire + inference). embed() reserves this much of
+        # the per-request deadline before spending any of the remainder on submit-rate
+        # pacing, so load-shaping can never borrow the budget the attempt itself needs.
+        # Wired to the real constants (not a magic number) so it stays coherent if the
+        # acquire/inference knobs change.
+        self._min_attempt_window = coherent_read_floor
+
         # EMBEDDING_READ_TIMEOUT / _CODE remain configurable, but are floored UP to the
         # coherent value so a stale/short setting can never reintroduce the inversion.
         # A larger configured value (slow hardware) is preserved.
@@ -341,6 +350,11 @@ class EmbeddingClient:
         # fire before embed() gets a chance to raise EMBEDDING_TIMEOUT and let the
         # caller's pending-status fallback run. Read HOOK_TIMEOUT the same way the
         # hooks do (hooks_common.get_hook_timeout()).
+        # NOTE: this "90" default is deliberately kept in lockstep with
+        # hooks_common.get_hook_timeout()'s own "90" default. The two are duplicated
+        # rather than shared to avoid coupling src/memory (shipped, importable by Docker
+        # services) to the hook-scripts layer; if one default changes the other must
+        # change with it.
         try:
             hook_timeout = int(os.getenv("HOOK_TIMEOUT", "90"))
         except ValueError:
@@ -409,10 +423,25 @@ class EmbeddingClient:
             # server's sustainable compute ceiling so bulk consumers apply patient
             # backpressure instead of firehosing. Done BEFORE computing `remaining` so
             # the pacing wait is charged against the deadline (the per-attempt read
-            # timeout below shrinks accordingly); max_wait caps it to the remaining
-            # budget so shaping can never make a must-not-drop request miss its deadline.
+            # timeout below shrinks accordingly).
+            #
+            # BP-184 (deadline-budget partitioning — reserve the attempt window):
+            # max_wait is the SLACK above the attempt window the request itself needs
+            # (`remaining - _min_attempt_window`), NOT the full remaining deadline.
+            # Reserving _min_attempt_window (the coherent read-timeout floor: server
+            # acquire + inference) guarantees by construction that >= one full
+            # legitimate attempt always survives pacing, so the reproduced HIGH defect
+            # ("limiter sleeps out the whole deadline -> 0s left, 0 attempts made") is
+            # impossible. On the interactive per-hook path `remaining` equals
+            # _min_attempt_window (budget 60 == floor 60), so pacing_budget is 0 and the
+            # limiter always bypasses: pacing is inert there BY DESIGN — backpressure on
+            # that path is owned by Lane A server-side admission (BP-175) plus the
+            # durable pending-embed queue (BP-180), not a client sleep. Client pacing
+            # only shapes where slack exists (bulk consumers carry their own longer
+            # budget; relocating pacing onto them is TD-799).
             budget = deadline - time.monotonic()
-            _get_submit_rate_limiter().acquire(len(texts), max_wait=max(0.0, budget))
+            pacing_budget = max(0.0, budget - self._min_attempt_window)
+            _get_submit_rate_limiter().acquire(len(texts), max_wait=pacing_budget)
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 self._log_total_timeout_exceeded(attempt, texts, model)

--- a/src/memory/embeddings.py
+++ b/src/memory/embeddings.py
@@ -11,6 +11,7 @@ import contextlib
 import logging
 import os
 import random
+import threading
 import time
 
 import httpx
@@ -59,6 +60,106 @@ logger = logging.getLogger("ai_memory.embed")
 # services. @observe creates orphaned Langfuse traces when OTel context doesn't cross
 # process boundaries. Use emit_trace_event() with explicit session_id instead.
 # See LANGFUSE-INTEGRATION-SPEC.md §4.3
+
+
+class _SubmitRateLimiter:
+    """Process-global patient rate limiter that shapes embedding submissions to the
+    embedding server's sustainable compute ceiling (PLAN-030 WI-10 load-shaping).
+
+    Why: bulk single-process consumers (github-sync, jira-sync, document_pipeline) can
+    firehose the shared embedding service far past its ~9.6 txt/s compute ceiling
+    (PLAN-030 X1/TD-794), driving admission waits and last-resort sheds. BP-175 §1/§4
+    prescribe BACKPRESSURE (make the producer WAIT) over shedding for a must-not-drop
+    system. This is the client half: pace submissions so the server is fed at a rate it
+    can sustain instead of being overrun.
+
+    Mechanism: a reservation clock (no per-call polling). Each ``acquire(cost)`` reserves
+    the next ``cost / rate`` seconds of server time and blocks until that slot opens. A
+    bounded burst credit (``burst`` texts) lets an idle client send a short burst without
+    pacing — so an interactive single-chunk store is never delayed — after which sustained
+    submission is paced to ``rate`` texts/sec. Shared process-wide so all EmbeddingClient
+    instances in one process (e.g. a sync loop that rebuilds clients) share one schedule.
+
+    ``time_source``/``sleeper`` are injectable so the pacing math is unit-testable without
+    real wall-clock sleeps.
+    """
+
+    def __init__(self, rate_per_sec, burst=None, *, time_source=None, sleeper=None):
+        self._rate = float(rate_per_sec)
+        # Default burst = ~1 second of credit, so a brief interactive burst is unshaped.
+        self._burst = float(burst) if burst is not None else max(1.0, self._rate)
+        self._time = time_source or time.monotonic
+        self._sleep = sleeper or time.sleep
+        self._lock = threading.Lock()
+        self._next_free = 0.0
+
+    def acquire(self, cost, max_wait=None):
+        """Block (patiently) until ``cost`` texts may be submitted; return seconds waited.
+
+        Args:
+            cost: Number of texts in this submission (the pacing unit).
+            max_wait: If the required wait would exceed this many seconds, skip shaping
+                and return immediately (0.0) WITHOUT reserving a slot. Callers pass their
+                remaining deadline budget here so load-shaping can never cause a
+                must-not-drop request to blow its own timeout.
+
+        Returns:
+            Seconds actually slept (0.0 when within burst credit or shaping disabled).
+        """
+        if self._rate <= 0 or cost <= 0:
+            return 0.0
+        with self._lock:
+            now = self._time()
+            # Credit only up to `burst` texts of idleness — bounds the burst so a long
+            # idle period cannot forgive an unbounded backlog all at once.
+            floor = now - (self._burst / self._rate)
+            if self._next_free < floor:
+                self._next_free = floor
+            start = self._next_free
+            wait = start - now
+            if wait < 0:
+                wait = 0.0
+            if max_wait is not None and wait > max_wait:
+                # Deadline-tight caller: let it through unshaped rather than risk a
+                # missed deadline / lost memory. Do NOT advance the reservation clock.
+                return 0.0
+            self._next_free = start + (cost / self._rate)
+        if wait > 0:
+            self._sleep(wait)
+        return wait
+
+
+# Client-side submit-rate ceiling (texts/sec). Default = the ~9.6 txt/s server compute
+# ceiling measured at INFERENCE_THREADS=4 (PLAN-030 X1/TD-794). <= 0 disables shaping.
+EMBEDDING_CLIENT_MAX_TXT_PER_SEC = float(
+    os.getenv("EMBEDDING_CLIENT_MAX_TXT_PER_SEC", "9.6")
+)
+
+# Process-global limiter singleton (lazy). Shared across all EmbeddingClient instances
+# in a process so a bulk sync loop that rebuilds clients is still paced as one stream.
+_submit_rate_limiter: _SubmitRateLimiter | None = None
+_submit_rate_limiter_lock = threading.Lock()
+
+
+def _get_submit_rate_limiter() -> _SubmitRateLimiter:
+    """Return the process-global submit-rate limiter, creating it on first use.
+
+    The rate is read from the environment at first construction (falling back to the
+    default ceiling) so a deployment — or the test suite — can tune or disable shaping
+    without editing code. Set ``_submit_rate_limiter = None`` to force a rebuild.
+    """
+    global _submit_rate_limiter
+    if _submit_rate_limiter is None:
+        with _submit_rate_limiter_lock:
+            if _submit_rate_limiter is None:
+                rate = float(
+                    os.getenv(
+                        "EMBEDDING_CLIENT_MAX_TXT_PER_SEC",
+                        str(EMBEDDING_CLIENT_MAX_TXT_PER_SEC),
+                    )
+                )
+                _submit_rate_limiter = _SubmitRateLimiter(rate)
+    return _submit_rate_limiter
 
 
 class EmbeddingError(Exception):
@@ -127,23 +228,42 @@ class EmbeddingClient:
             f"http://{self.config.embedding_host}:{self.config.embedding_port}"
         )
 
-        # 2025 Best Practice: Granular timeouts per operation type
-        # Source: https://www.python-httpx.org/advanced/timeouts/
-        # Read timeout is configurable via EMBEDDING_READ_TIMEOUT for integration tests
-        # CPU mode (7B model): 20-30s typical, use 60s for safety
-        # GPU mode: <2s (NFR-P2 compliant)
-        read_timeout = float(os.getenv("EMBEDDING_READ_TIMEOUT", "15.0"))
+        # TD-782/788 TIMEOUT COHERENCE: the client read timeout must out-wait the
+        # server's worst-case response time, or the client abandons a request the
+        # server is still legitimately servicing (premature EMBEDDING_TIMEOUT → retry
+        # storm → server-side admission shed). The server response spans TWO phases the
+        # client holds the connection open for: the admission wait (block-not-drop up to
+        # EMBEDDING_ACQUIRE_TIMEOUT for an inference slot — docker/embedding/main.py) and
+        # then the inference itself (a single large-text embed measured at ~19-28s,
+        # PLAN-030 X1). So the coherent floor for any read timeout is
+        # acquire_timeout + inference_timeout. Below that floor is the inversion bug.
+        self._acquire_timeout = max(
+            0.0, float(os.getenv("EMBEDDING_ACQUIRE_TIMEOUT", "30.0"))
+        )
+        # Realistic worst-case single-request inference time (covers the observed
+        # 19-28s large-text range with margin). Separate knob so ops can tune the
+        # inference term without touching the server's admission timeout.
+        self._inference_timeout = max(
+            0.0, float(os.getenv("EMBEDDING_INFERENCE_TIMEOUT", "30.0"))
+        )
+        coherent_read_floor = self._acquire_timeout + self._inference_timeout
+
+        # EMBEDDING_READ_TIMEOUT / _CODE remain configurable, but are floored UP to the
+        # coherent value so a stale/short setting can never reintroduce the inversion.
+        # A larger configured value (slow hardware) is preserved.
         # BUG-329 fix round (F1): stored on self so _embed_once() can cap it to the
         # remaining EMBEDDING_TOTAL_TIMEOUT budget on each attempt.
-        self._read_timeout = read_timeout
+        self._read_timeout = max(
+            float(os.getenv("EMBEDDING_READ_TIMEOUT", "15.0")), coherent_read_floor
+        )
         # BUG-288: Code model is slower than en model under CPU load.
         # Per-request override applied in _embed_once() when model="code".
-        self._read_timeout_code = float(
-            os.getenv("EMBEDDING_READ_TIMEOUT_CODE", "30.0")
+        self._read_timeout_code = max(
+            float(os.getenv("EMBEDDING_READ_TIMEOUT_CODE", "30.0")), coherent_read_floor
         )
         timeout_config = httpx.Timeout(
             connect=CONNECT_TIMEOUT,  # Connection establishment timeout
-            read=read_timeout,  # Read timeout - configurable for CPU vs GPU mode
+            read=self._read_timeout,  # Coherent read floor (>= acquire + inference)
             write=WRITE_TIMEOUT,  # Write timeout for request body
             pool=POOL_TIMEOUT,  # Pool acquisition timeout
         )
@@ -165,7 +285,7 @@ class EmbeddingClient:
 
         # BUG-329/TD-710: Overall wall-clock deadline for embed()'s retry loop.
         # Per-chunk retries with no cumulative bound can exceed the store hooks'
-        # HOOK_TIMEOUT (default 60s), which cancels the whole store coroutine
+        # HOOK_TIMEOUT (coherent default 90s), which cancels the whole store coroutine
         # mid-embed instead of letting the pending-status fallback handle it.
         # Must stay below HOOK_TIMEOUT so embed() raises EMBEDDING_TIMEOUT while
         # the caller still has budget left to upsert with embedding_status=pending.
@@ -174,7 +294,29 @@ class EmbeddingClient:
         # hard ceiling rather than just a between-attempts check. Fixed httpx
         # connect/write/pool overhead runs on top of this budget (see the
         # construction-time invariant check below).
-        self._total_timeout = float(os.getenv("EMBEDDING_TOTAL_TIMEOUT", "45.0"))
+        # TD-782/788: made inference-time-aware. The default AND the lower floor are the
+        # coherent single-attempt budget (acquire + inference) so the deadline can never
+        # be smaller than one full legitimate attempt — otherwise the deadline itself
+        # would clip a request the server is still servicing (the inversion, one layer
+        # up). Per-attempt HTTP read timeout is still capped to the remaining portion of
+        # this budget (see _embed_once()).
+        default_total = coherent_read_floor if coherent_read_floor > 0 else 45.0
+        self._total_timeout = float(
+            os.getenv("EMBEDDING_TOTAL_TIMEOUT", str(default_total))
+        )
+        if coherent_read_floor > 0 and self._total_timeout < coherent_read_floor:
+            # A configured deadline below one coherent attempt reintroduces premature
+            # timeout. Floor it up and log so the misconfiguration is visible.
+            logger.warning(
+                "embedding_total_timeout_below_coherent_floor",
+                extra={
+                    "configured_value": self._total_timeout,
+                    "coherent_read_floor": coherent_read_floor,
+                    "acquire_timeout": self._acquire_timeout,
+                    "inference_timeout": self._inference_timeout,
+                },
+            )
+            self._total_timeout = coherent_read_floor
         if self._total_timeout <= 0:
             # A non-positive budget would make embed() raise EMBEDDING_TIMEOUT on
             # every call before a first attempt is ever made, silently disabling
@@ -200,9 +342,9 @@ class EmbeddingClient:
         # caller's pending-status fallback run. Read HOOK_TIMEOUT the same way the
         # hooks do (hooks_common.get_hook_timeout()).
         try:
-            hook_timeout = int(os.getenv("HOOK_TIMEOUT", "60"))
+            hook_timeout = int(os.getenv("HOOK_TIMEOUT", "90"))
         except ValueError:
-            hook_timeout = 60
+            hook_timeout = 90
         fixed_overhead = CONNECT_TIMEOUT + WRITE_TIMEOUT + POOL_TIMEOUT
         if self._total_timeout + fixed_overhead > hook_timeout:
             logger.warning(
@@ -226,13 +368,14 @@ class EmbeddingClient:
         the caller wait and re-submit rather than dropping the memory. Non-retryable
         errors (e.g. 413 oversized, 4xx) raise immediately.
 
-        BUG-329/TD-710 (fix round F1/F4): The whole retry loop is bounded by an
-        overall wall-clock deadline (``EMBEDDING_TOTAL_TIMEOUT``, default 45s). F1
-        caps each attempt's HTTP read/inference timeout to ``min(configured_read_timeout,
-        remaining_budget)`` (see _embed_once()), so the READ phase of no single
-        attempt can run long enough on its own to blow past the deadline. Without this
-        cap, per-chunk retries could cumulatively exceed the store hooks' HOOK_TIMEOUT
-        (60s) even though the deadline was "checked" between attempts, because a
+        BUG-329/TD-710 (fix round F1/F4) + TD-782/788: The whole retry loop is bounded
+        by an overall wall-clock deadline (``EMBEDDING_TOTAL_TIMEOUT``, coherent default
+        = acquire + inference, 60s). F1 caps each attempt's HTTP read/inference timeout
+        to ``min(configured_read_timeout, remaining_budget)`` (see _embed_once()), so the
+        READ phase of no single attempt can run long enough on its own to blow past the
+        deadline. Without this cap, per-chunk retries could cumulatively exceed the store
+        hooks' HOOK_TIMEOUT (coherent default 90s) even though the deadline was "checked"
+        between attempts, because a
         single slow attempt could still run for the full configured read timeout
         regardless of how little budget remained — aborting the entire store coroutine
         mid-embed instead of letting the caller's pending-status fallback run. This is
@@ -262,6 +405,14 @@ class EmbeddingClient:
         last_error: EmbeddingError | None = None
         deadline = time.monotonic() + self._total_timeout
         for attempt in range(1 + self._max_retries):
+            # Load-shaping (BP-175/BP-180, PLAN-030 WI-10): pace submissions to the
+            # server's sustainable compute ceiling so bulk consumers apply patient
+            # backpressure instead of firehosing. Done BEFORE computing `remaining` so
+            # the pacing wait is charged against the deadline (the per-attempt read
+            # timeout below shrinks accordingly); max_wait caps it to the remaining
+            # budget so shaping can never make a must-not-drop request miss its deadline.
+            budget = deadline - time.monotonic()
+            _get_submit_rate_limiter().acquire(len(texts), max_wait=max(0.0, budget))
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 self._log_total_timeout_exceeded(attempt, texts, model)

--- a/src/memory/hooks_common.py
+++ b/src/memory/hooks_common.py
@@ -161,20 +161,30 @@ def get_hook_timeout() -> int:
     Consolidated from CR-1.4 (duplicated in error_store_async.py, store_async.py).
 
     Returns:
-        Timeout in seconds (default: 60)
+        Timeout in seconds (default: 90)
 
     Environment Variables:
         HOOK_TIMEOUT: Timeout in seconds for background operations
+
+    Note:
+        TD-782/788 TIMEOUT COHERENCE: this is the OUTER ceiling that wraps the store
+        coroutine (asyncio.wait_for). It must sit ABOVE the embedding client's
+        coordinated budget so it cannot fire mid-embed and cancel the whole store
+        (which defeats the per-chunk pending-status fallback). The client's worst-case
+        per-embed wall clock is EMBEDDING_TOTAL_TIMEOUT (coherent default 60s =
+        acquire 30 + inference 30) plus ~11s fixed httpx connect/write/pool overhead
+        (~71s); 90s keeps the ceiling above that sum. The client warns
+        (embedding_total_timeout_invariant_violated) if a custom config breaks this.
     """
     try:
-        timeout_str = os.getenv("HOOK_TIMEOUT", "60")
+        timeout_str = os.getenv("HOOK_TIMEOUT", "90")
         return int(timeout_str)
     except ValueError:
         logger = logging.getLogger("ai_memory.hooks")
         logger.warning(
-            "invalid_timeout_env", extra={"value": timeout_str, "using_default": 60}
+            "invalid_timeout_env", extra={"value": timeout_str, "using_default": 90}
         )
-        return 60
+        return 90
 
 
 def get_metrics():

--- a/src/memory/hooks_common.py
+++ b/src/memory/hooks_common.py
@@ -177,6 +177,10 @@ def get_hook_timeout() -> int:
         (embedding_total_timeout_invariant_violated) if a custom config breaks this.
     """
     try:
+        # NOTE: this "90" default is deliberately kept in lockstep with the "90"
+        # default in embeddings.py's construction-time HOOK_TIMEOUT invariant check.
+        # The two are duplicated rather than shared to avoid coupling src/memory to the
+        # hook-scripts layer; if one default changes the other must change with it.
         timeout_str = os.getenv("HOOK_TIMEOUT", "90")
         return int(timeout_str)
     except ValueError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -824,6 +824,9 @@ def integration_test_env():
         "QDRANT_PORT": os.environ.get("QDRANT_PORT"),
         "SIMILARITY_THRESHOLD": os.environ.get("SIMILARITY_THRESHOLD"),
         "EMBEDDING_DIMENSION": os.environ.get("EMBEDDING_DIMENSION"),
+        "EMBEDDING_CLIENT_MAX_TXT_PER_SEC": os.environ.get(
+            "EMBEDDING_CLIENT_MAX_TXT_PER_SEC"
+        ),
     }
 
     # Set integration test environment
@@ -837,6 +840,10 @@ def integration_test_env():
     # DEC-010: Jina Embeddings v2 Base Code uses 768 dimensions
     # Fix per code review: store_async.py defaults to 3584 which causes dimension mismatch
     os.environ["EMBEDDING_DIMENSION"] = "768"
+    # PLAN-030 WI-10: disable client-side submit-rate shaping in tests so the
+    # process-global limiter never injects real sleeps into embed()-calling tests
+    # (its pacing math is covered deterministically in TestSubmitRateLimiter).
+    os.environ["EMBEDDING_CLIENT_MAX_TXT_PER_SEC"] = "0"
 
     yield
 

--- a/tests/hooks/test_post_work_store_async.py
+++ b/tests/hooks/test_post_work_store_async.py
@@ -7,9 +7,10 @@ Covers: valid payload routing, Qdrant unavailable handling, payload validation
 
 import io
 import json
+import os
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -331,3 +332,50 @@ class TestPostStoreMetricLabels:
             collection="unknown",
         )
         assert child._value.get() == 1.0
+
+
+class TestPostWorkHookTimeoutCoherence:
+    """TD-782/788: the post-work store path must inherit the SAME coherent HOOK_TIMEOUT
+    ceiling as store_async/error_store_async, so its outer asyncio.wait_for cannot fire
+    mid-embed (< the embedding client's coordinated budget) and cancel the store. The
+    old local get_timeout() duplicate (default 60s) was consolidated onto
+    memory.hooks_common.get_hook_timeout() (default 90s).
+    """
+
+    def test_uses_shared_hook_timeout_helper_not_local_duplicate(self):
+        """The path routes through the consolidated helper, and the stale local
+        get_timeout() duplicate is gone."""
+        import memory.hooks_common as hc
+
+        assert pwsav.get_hook_timeout is hc.get_hook_timeout
+        assert not hasattr(pwsav, "get_timeout")
+
+    def test_default_ceiling_is_coherent_90s(self, monkeypatch):
+        """With HOOK_TIMEOUT unset, the post-work path's ceiling is the coherent 90s
+        (was an incoherent 60s before consolidation)."""
+        monkeypatch.delenv("HOOK_TIMEOUT", raising=False)
+        assert pwsav.get_hook_timeout() == 90
+
+    def test_main_applies_hook_timeout_to_wait_for(self, valid_decision_payload):
+        """main_async() passes get_hook_timeout()'s value to the outer wait_for that
+        bounds the whole store (incl. the embedding call)."""
+        captured = {}
+
+        async def fake_wait_for(coro, timeout=None):
+            captured["timeout"] = timeout
+            return await coro
+
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch.object(
+                pwsav.sys, "stdin", io.StringIO(json.dumps(valid_decision_payload))
+            ),
+            patch.object(pwsav, "get_hook_timeout", return_value=4242),
+            patch.object(pwsav, "store_memory_async", new=AsyncMock()),
+            patch.object(pwsav.asyncio, "wait_for", side_effect=fake_wait_for),
+        ):
+            rc = pwsav.main()
+
+        assert rc == 0
+        # The coordinated ceiling (not a hardcoded 60) bounds the store coroutine.
+        assert captured["timeout"] == 4242

--- a/tests/integration/test_posttooluse_hook.py
+++ b/tests/integration/test_posttooluse_hook.py
@@ -290,7 +290,7 @@ class TestTimeoutHandling:
 
     @pytest.mark.slow
     def test_timeout_default_value(self):
-        """HOOK_TIMEOUT should default to 60s if not set."""
+        """HOOK_TIMEOUT should default to 90s if not set."""
         script_path = Path(".claude/hooks/scripts/store_async.py")
 
         # Read script to verify timeout configuration exists

--- a/tests/test_compose_bare_up_topology.py
+++ b/tests/test_compose_bare_up_topology.py
@@ -75,6 +75,13 @@ EMBEDDING_CLIENT_KNOBS = {
     "EMBEDDING_MAX_RETRIES",
     "EMBEDDING_BACKOFF_BASE",
     "EMBEDDING_BACKOFF_CAP",
+    # TD-782/788 timeout-coherence knobs: the acquire/inference terms feed the
+    # coherent read-timeout floor AND (BP-184) the reserved attempt window used by
+    # embed()'s submit-rate pacing; both baking services must receive them.
+    "EMBEDDING_ACQUIRE_TIMEOUT",
+    "EMBEDDING_INFERENCE_TIMEOUT",
+    # PLAN-030 WI-10 load-shaping: the client submit-rate ceiling.
+    "EMBEDDING_CLIENT_MAX_TXT_PER_SEC",
 }
 
 

--- a/tests/unit/test_embedding_retry.py
+++ b/tests/unit/test_embedding_retry.py
@@ -908,7 +908,10 @@ class TestSubmitRateLimiter:
 
     def test_embed_consults_limiter_with_text_count(self):
         """embed() feeds the submission's text count to the shared limiter before
-        posting, so bulk callers are actually shaped."""
+        posting (so bulk callers are actually shaped) AND forwards the BP-184 reserved
+        pacing budget as max_wait — the deadline SLACK above the attempt window
+        (remaining - min_attempt_window), NOT the full remaining deadline — so pacing
+        can never eat the window the HTTP request itself needs."""
         import memory.embeddings as emod
         from memory.config import reset_config
 
@@ -924,12 +927,21 @@ class TestSubmitRateLimiter:
         mock_ok.raise_for_status = Mock()
         mock_ok.json.return_value = {"embeddings": [[0.1] * 768] * 3}
 
+        # Non-zero coherence terms => min_attempt_window = 20s; a longer total deadline
+        # (100s) leaves observable slack so the reserved budget is distinguishable from
+        # the full deadline.
         with patch.dict(
             os.environ,
-            {"EMBEDDING_ACQUIRE_TIMEOUT": "0", "EMBEDDING_INFERENCE_TIMEOUT": "0"},
+            {
+                "EMBEDDING_ACQUIRE_TIMEOUT": "10",
+                "EMBEDDING_INFERENCE_TIMEOUT": "10",
+                "EMBEDDING_TOTAL_TIMEOUT": "100",
+                "EMBEDDING_MAX_RETRIES": "0",
+            },
         ):
             reset_config()
             c = EmbeddingClient()
+            assert c._min_attempt_window == 20.0
             try:
                 with (
                     patch.object(
@@ -939,6 +951,117 @@ class TestSubmitRateLimiter:
                 ):
                     c.embed(["a", "b", "c"])
                 assert recorded
-                assert recorded[0][0] == 3  # cost == number of texts
+                cost, max_wait = recorded[0]
+                assert cost == 3  # cost == number of texts
+                # BP-184: max_wait is the reserved slack (~80s), not the full ~100s
+                # deadline — proving pacing reserves the attempt window.
+                assert max_wait == pytest.approx(
+                    c._total_timeout - c._min_attempt_window, abs=1.0
+                )
+                assert max_wait < c._total_timeout - 1.0
             finally:
                 c.close()
+
+    def test_embed_reserves_attempt_window_near_boundary(self):
+        """BP-184 red->green near-boundary: with the submit-rate limiter primed into
+        the danger band (a pacing backlog just under the full deadline), embed() still
+        leaves >= min_attempt_window for the HTTP attempt. The pre-fix behavior (the
+        limiter sleeps out ~the whole deadline -> ~0s left -> 0 attempts made) is
+        impossible by construction, because max_wait is the reserved slack, not the
+        full deadline.
+        """
+        import memory.embeddings as emod
+        from memory.config import reset_config
+        from memory.embeddings import _SubmitRateLimiter
+
+        # Interactive per-hook path: acquire 30 + inference 30 => min_attempt_window 60,
+        # deadline 60 (60 == 60, structurally zero slack) => pacing_budget 0 => bypass.
+        with patch.dict(
+            os.environ,
+            {
+                "EMBEDDING_ACQUIRE_TIMEOUT": "30",
+                "EMBEDDING_INFERENCE_TIMEOUT": "30",
+                "EMBEDDING_TOTAL_TIMEOUT": "60",
+                "EMBEDDING_MAX_RETRIES": "0",
+            },
+        ):
+            reset_config()
+            c = EmbeddingClient()
+            assert c._min_attempt_window == 60.0
+
+            clock = {"now": 1000.0}
+
+            def fake_monotonic():
+                return clock["now"]
+
+            def fake_sleep(seconds):
+                clock["now"] += seconds
+
+            # Real limiter on the same fake clock, primed so a single-text submission
+            # would require ~59s of pacing wait (just under the 60s deadline).
+            lim = _SubmitRateLimiter(
+                1.0, burst=0.0, time_source=fake_monotonic, sleeper=fake_sleep
+            )
+            lim._next_free = clock["now"] + 59.0
+
+            captured = {}
+
+            def fake_embed_once(
+                texts, model="en", project="unknown", remaining_budget=None
+            ):
+                captured["remaining_budget"] = remaining_budget
+                return [[0.1] * 768 for _ in texts]
+
+            try:
+                with (
+                    patch.object(emod.time, "monotonic", fake_monotonic),
+                    patch.object(emod, "_get_submit_rate_limiter", lambda: lim),
+                    patch.object(c, "_embed_once", side_effect=fake_embed_once),
+                ):
+                    c.embed(["x"])
+                # Limiter bypassed: it did NOT sleep out the 59s backlog.
+                assert clock["now"] == 1000.0
+                # The attempt got the full coherent window (60s), not ~1s.
+                assert captured["remaining_budget"] >= c._min_attempt_window
+            finally:
+                c.close()
+
+    def test_pacing_never_eats_attempt_window_property(self):
+        """BP-184 invariant (property): for arbitrary backlog and deadline, after the
+        submit-rate acquire either the limiter bypassed (waited 0) OR at least
+        min_attempt_window of the deadline still remains for the HTTP attempt. A long
+        pacing sleep followed by a doomed sub-window attempt is impossible.
+        """
+        from memory.embeddings import _SubmitRateLimiter
+
+        min_attempt_window = 60.0
+        for deadline_remaining in (60.0, 61.0, 90.0, 120.0, 600.0):
+            for backlog in (0.0, 30.0, 59.0, 59.9, 61.0, 200.0, 599.0):
+                clk = self._FakeReservationClock()
+                lim = _SubmitRateLimiter(
+                    1.0, burst=0.0, time_source=clk.time, sleeper=clk.sleep
+                )
+                lim._next_free = clk.now + backlog
+                pacing_budget = max(0.0, deadline_remaining - min_attempt_window)
+                slept = lim.acquire(1, max_wait=pacing_budget)
+                remaining_for_attempt = deadline_remaining - slept
+                assert (
+                    slept == 0.0 or remaining_for_attempt >= min_attempt_window - 1e-9
+                ), (deadline_remaining, backlog, slept)
+
+    def test_bulk_budget_still_paces(self):
+        """BP-184 feature-preservation: where the caller has real slack (a long bulk
+        budget), the reserved-window math still yields a large pacing_budget, so the
+        limiter DOES pace. Load-shaping is preserved wherever slack exists — it is only
+        inert on the tight interactive path where slack is structurally zero.
+        """
+        min_attempt_window = 60.0
+        bulk_budget = 600.0
+        pacing_budget = max(0.0, bulk_budget - min_attempt_window)  # 540s of slack
+        lim, _clk = self._make(rate=10.0, burst=1.0)
+        total = 0.0
+        for _ in range(11):
+            total += lim.acquire(1, max_wait=pacing_budget)
+        # 10 texts past the 1-text burst, paced at 10/s => ~1.0s of real shaping, far
+        # within the 540s slack (pacing is NOT bypassed).
+        assert abs(total - 1.0) < 1e-9

--- a/tests/unit/test_embedding_retry.py
+++ b/tests/unit/test_embedding_retry.py
@@ -206,6 +206,11 @@ class TestEmbeddingTotalTimeout:
             {
                 "EMBEDDING_MAX_RETRIES": "2",
                 "EMBEDDING_TOTAL_TIMEOUT": "10.0",
+                # Disable the TD-782 coherence floor (acquire+inference=0) so this
+                # test can exercise the raw F1 deadline mechanics at a small 10s
+                # budget; the coherence flooring has its own tests (TestTimeoutCoherence).
+                "EMBEDDING_ACQUIRE_TIMEOUT": "0",
+                "EMBEDDING_INFERENCE_TIMEOUT": "0",
             },
         ):
             from memory.config import reset_config
@@ -300,7 +305,15 @@ class TestEmbeddingTotalTimeout:
 
         with patch.dict(
             os.environ,
-            {"EMBEDDING_MAX_RETRIES": "2", "EMBEDDING_TOTAL_TIMEOUT": "45.0"},
+            {
+                "EMBEDDING_MAX_RETRIES": "2",
+                "EMBEDDING_TOTAL_TIMEOUT": "45.0",
+                # Coherence floor disabled so the configured 30s code read timeout
+                # governs (this test asserts the F1 remaining-budget cap, not the
+                # TD-782 floor — see TestTimeoutCoherence for that).
+                "EMBEDDING_ACQUIRE_TIMEOUT": "0",
+                "EMBEDDING_INFERENCE_TIMEOUT": "0",
+            },
         ):
             from memory.config import reset_config
 
@@ -358,8 +371,8 @@ class TestEmbeddingTotalTimeoutInvariantGuard:
     """
 
     def test_invariant_guard_silent_on_default_config(self, monkeypatch, caplog):
-        """Shipped defaults (EMBEDDING_TOTAL_TIMEOUT=45, HOOK_TIMEOUT=60) must not
-        trigger the invariant warning: 45 + 11 (fixed overhead) = 56 <= 60."""
+        """Coherent shipped defaults (EMBEDDING_TOTAL_TIMEOUT=60, HOOK_TIMEOUT=90) must
+        not trigger the invariant warning: 60 + 11 (fixed overhead) = 71 <= 90."""
         monkeypatch.delenv("EMBEDDING_TOTAL_TIMEOUT", raising=False)
         monkeypatch.delenv("HOOK_TIMEOUT", raising=False)
         from memory.config import reset_config
@@ -381,6 +394,10 @@ class TestEmbeddingTotalTimeoutInvariantGuard:
         45 + 11 (fixed overhead) = 56 > 50."""
         monkeypatch.setenv("EMBEDDING_TOTAL_TIMEOUT", "45.0")
         monkeypatch.setenv("HOOK_TIMEOUT", "50")
+        # Coherence floor disabled so the configured 45s total is used as-is (this test
+        # asserts the fixed-overhead invariant, not the TD-782 floor).
+        monkeypatch.setenv("EMBEDDING_ACQUIRE_TIMEOUT", "0")
+        monkeypatch.setenv("EMBEDDING_INFERENCE_TIMEOUT", "0")
         from memory.config import reset_config
 
         reset_config()
@@ -448,7 +465,15 @@ class TestEmbeddingTimeoutStoreFallback:
 
         with patch.dict(
             os.environ,
-            {"EMBEDDING_MAX_RETRIES": "2", "EMBEDDING_TOTAL_TIMEOUT": "10.0"},
+            {
+                "EMBEDDING_MAX_RETRIES": "2",
+                "EMBEDDING_TOTAL_TIMEOUT": "10.0",
+                # Coherence floor disabled so the small 10s budget drives the
+                # store-path pending fallback quickly (TestTimeoutCoherence covers
+                # the floor itself).
+                "EMBEDDING_ACQUIRE_TIMEOUT": "0",
+                "EMBEDDING_INFERENCE_TIMEOUT": "0",
+            },
         ):
             from memory.config import reset_config
 
@@ -612,6 +637,11 @@ class TestStoreAsyncHookFallback:
             "EMBEDDING_TOTAL_TIMEOUT": "3.0",
             "EMBEDDING_MAX_RETRIES": "2",
             "HOOK_TIMEOUT": "5",
+            # Coherence floor disabled (acquire+inference=0) so the scaled-down 3s
+            # total / 5s read / 5s HOOK budgets drive the F1 tail case; the TD-782
+            # floor is covered by TestTimeoutCoherence.
+            "EMBEDDING_ACQUIRE_TIMEOUT": "0",
+            "EMBEDDING_INFERENCE_TIMEOUT": "0",
             # Isolate from the classifier enqueue side path (unrelated to this
             # fix; avoids it resolving a queue dir off an unconfigured mock).
             "MEMORY_CLASSIFIER_ENABLED": "false",
@@ -664,3 +694,251 @@ class TestStoreAsyncHookFallback:
         for point in points:
             assert point["payload"]["embedding_status"] == "pending"
             assert point["vector"] == [0.0] * 768
+
+
+class TestTimeoutCoherence:
+    """TD-782/788: the client read timeout / overall deadline must out-wait the
+    embedding server's worst-case response (admission wait + inference), or the
+    client abandons a request the server is still legitimately servicing — the
+    inversion bug that drives premature EMBEDDING_TIMEOUT and server-side sheds.
+    """
+
+    def test_read_timeout_floored_removes_inversion(self):
+        """With the shipped (inverted) read timeouts, the effective read timeout is
+        floored UP to acquire + inference, so it can no longer expire before the
+        server can even admit the request (let alone finish inference)."""
+        from memory.config import reset_config
+
+        with patch.dict(
+            os.environ,
+            {
+                "EMBEDDING_ACQUIRE_TIMEOUT": "30",
+                "EMBEDDING_INFERENCE_TIMEOUT": "30",
+                # The shipped, inverted values (15s < 30s server admission alone).
+                "EMBEDDING_READ_TIMEOUT": "15.0",
+                "EMBEDDING_READ_TIMEOUT_CODE": "30.0",
+            },
+        ):
+            reset_config()
+            c = EmbeddingClient()
+            try:
+                floor = 30.0 + 30.0
+                assert c._read_timeout == floor
+                assert c._read_timeout_code == floor
+                # Inversion removed: the read timeout now exceeds the server's
+                # admission wait, so the client never gives up mid-admission.
+                assert c._read_timeout > c._acquire_timeout
+            finally:
+                c.close()
+
+    def test_configured_read_above_floor_is_preserved(self):
+        """A LONGER configured read timeout (slow hardware) is kept — the floor only
+        raises, never lowers."""
+        from memory.config import reset_config
+
+        with patch.dict(
+            os.environ,
+            {
+                "EMBEDDING_ACQUIRE_TIMEOUT": "30",
+                "EMBEDDING_INFERENCE_TIMEOUT": "30",
+                "EMBEDDING_READ_TIMEOUT": "120.0",
+            },
+        ):
+            reset_config()
+            c = EmbeddingClient()
+            try:
+                assert c._read_timeout == 120.0  # above the 60s floor, preserved
+            finally:
+                c.close()
+
+    def test_total_timeout_default_is_inference_aware(self):
+        """With no EMBEDDING_TOTAL_TIMEOUT set, the default deadline equals the
+        coherent single-attempt budget (acquire + inference), not a flat constant."""
+        from memory.config import reset_config
+
+        with patch.dict(
+            os.environ,
+            {"EMBEDDING_ACQUIRE_TIMEOUT": "30", "EMBEDDING_INFERENCE_TIMEOUT": "30"},
+        ):
+            os.environ.pop("EMBEDDING_TOTAL_TIMEOUT", None)
+            reset_config()
+            c = EmbeddingClient()
+            try:
+                assert c._total_timeout == 60.0
+            finally:
+                c.close()
+
+    def test_total_timeout_below_floor_is_raised_with_warning(self, caplog):
+        """A stale/short EMBEDDING_TOTAL_TIMEOUT (e.g. the shipped 45s) is floored up
+        to the coherent budget so it can't clip a legitimate attempt — and the
+        misconfiguration is logged, not silently swallowed."""
+        from memory.config import reset_config
+
+        with patch.dict(
+            os.environ,
+            {
+                "EMBEDDING_ACQUIRE_TIMEOUT": "30",
+                "EMBEDDING_INFERENCE_TIMEOUT": "30",
+                "EMBEDDING_TOTAL_TIMEOUT": "45.0",
+            },
+        ):
+            reset_config()
+            with caplog.at_level(logging.WARNING, logger="ai_memory.embed"):
+                c = EmbeddingClient()
+            try:
+                assert c._total_timeout == 60.0
+                warnings = [
+                    r
+                    for r in caplog.records
+                    if r.getMessage() == "embedding_total_timeout_below_coherent_floor"
+                ]
+                assert len(warnings) == 1
+                assert warnings[0].configured_value == 45.0
+                assert warnings[0].coherent_read_floor == 60.0
+            finally:
+                c.close()
+
+    def test_hook_ceiling_sits_above_coordinated_budget(self):
+        """The whole point of the coordinated budget: HOOK_TIMEOUT (the outer store
+        ceiling) must exceed EMBEDDING_TOTAL_TIMEOUT + fixed httpx overhead, so the
+        hook cannot fire mid-embed. Proven on the coherent defaults."""
+        from memory.config import reset_config
+        from memory.embeddings import (
+            CONNECT_TIMEOUT,
+            POOL_TIMEOUT,
+            WRITE_TIMEOUT,
+        )
+        from memory.hooks_common import get_hook_timeout
+
+        with patch.dict(
+            os.environ,
+            {"EMBEDDING_ACQUIRE_TIMEOUT": "30", "EMBEDDING_INFERENCE_TIMEOUT": "30"},
+        ):
+            for key in ("EMBEDDING_TOTAL_TIMEOUT", "HOOK_TIMEOUT"):
+                os.environ.pop(key, None)
+            reset_config()
+            c = EmbeddingClient()
+            try:
+                fixed_overhead = CONNECT_TIMEOUT + WRITE_TIMEOUT + POOL_TIMEOUT
+                assert c._total_timeout + fixed_overhead <= get_hook_timeout()
+            finally:
+                c.close()
+
+
+class TestSubmitRateLimiter:
+    """PLAN-030 WI-10 load-shaping: the client paces embedding submissions to the
+    server's sustainable compute ceiling (~9.6 txt/s) with patient backpressure
+    (BP-175/BP-180) instead of firehosing it.
+    """
+
+    class _FakeReservationClock:
+        """Deterministic clock where sleep() advances time (models real wall-clock
+        consumption) so the limiter's pacing math is tested without real sleeps."""
+
+        def __init__(self):
+            self.now = 0.0
+            self.slept = []
+
+        def time(self):
+            return self.now
+
+        def sleep(self, seconds):
+            self.slept.append(seconds)
+            self.now += seconds
+
+    def _make(self, rate, burst):
+        from memory.embeddings import _SubmitRateLimiter
+
+        clk = self._FakeReservationClock()
+        lim = _SubmitRateLimiter(
+            rate, burst=burst, time_source=clk.time, sleeper=clk.sleep
+        )
+        return lim, clk
+
+    def test_default_rate_targets_server_ceiling(self):
+        """The default submit rate is the ~9.6 txt/s server compute ceiling."""
+        from memory.embeddings import EMBEDDING_CLIENT_MAX_TXT_PER_SEC
+
+        assert EMBEDDING_CLIENT_MAX_TXT_PER_SEC == 9.6
+
+    def test_sustained_submissions_paced_to_rate(self):
+        """N single-text submissions are paced so cumulative wall-clock ~= the time
+        the server needs at the ceiling: (N - burst_credit) / rate."""
+        lim, clk = self._make(rate=10.0, burst=1.0)
+        for _ in range(11):
+            lim.acquire(1)
+        # burst=1 forgives ~1 text; the remaining 10 are paced at 10/s => ~1.0s.
+        assert abs(sum(clk.slept) - 1.0) < 1e-9
+
+    def test_batch_cost_counts_all_texts(self):
+        """A batch submission is charged for every text in it (the pacing unit is
+        texts, not requests)."""
+        lim, clk = self._make(rate=10.0, burst=0.0)
+        lim.acquire(5)  # first call: reserves 0.5s of future server time, waits 0
+        lim.acquire(5)  # second call must wait for that 0.5s to elapse
+        assert abs(sum(clk.slept) - 0.5) < 1e-9
+
+    def test_burst_credit_absorbs_idle(self):
+        """After an idle period, up to `burst` texts submit unshaped (bounded burst),
+        then pacing resumes."""
+        lim, clk = self._make(rate=10.0, burst=5.0)
+        clk.now = 100.0  # simulate a long idle gap
+        total = 0.0
+        for _ in range(5):
+            total += lim.acquire(1)
+        assert total == 0.0  # 5 texts within the burst credit: no shaping
+
+    def test_disabled_when_rate_nonpositive(self):
+        """rate <= 0 disables shaping entirely (never sleeps)."""
+        lim, clk = self._make(rate=0.0, burst=1.0)
+        for _ in range(50):
+            assert lim.acquire(1) == 0.0
+        assert clk.slept == []
+
+    def test_deadline_bypass_does_not_shape_or_reserve(self):
+        """When the required wait would exceed the caller's remaining budget, the
+        submission passes through unshaped AND the reservation clock is not advanced —
+        a must-not-drop request never misses its deadline because of shaping."""
+        lim, _clk = self._make(rate=2.0, burst=0.0)
+        lim.acquire(10)  # reserves 5s of future server time
+        next_free_before = lim._next_free
+        waited = lim.acquire(1, max_wait=0.5)  # would need ~5s wait > 0.5 budget
+        assert waited == 0.0
+        assert lim._next_free == next_free_before  # reservation not advanced
+
+    def test_embed_consults_limiter_with_text_count(self):
+        """embed() feeds the submission's text count to the shared limiter before
+        posting, so bulk callers are actually shaped."""
+        import memory.embeddings as emod
+        from memory.config import reset_config
+
+        recorded = []
+
+        class _RecordingLimiter:
+            def acquire(self, cost, max_wait=None):
+                recorded.append((cost, max_wait))
+                return 0.0
+
+        mock_ok = Mock()
+        mock_ok.status_code = 200
+        mock_ok.raise_for_status = Mock()
+        mock_ok.json.return_value = {"embeddings": [[0.1] * 768] * 3}
+
+        with patch.dict(
+            os.environ,
+            {"EMBEDDING_ACQUIRE_TIMEOUT": "0", "EMBEDDING_INFERENCE_TIMEOUT": "0"},
+        ):
+            reset_config()
+            c = EmbeddingClient()
+            try:
+                with (
+                    patch.object(
+                        emod, "_get_submit_rate_limiter", lambda: _RecordingLimiter()
+                    ),
+                    patch.object(c.client, "post", return_value=mock_ok),
+                ):
+                    c.embed(["a", "b", "c"])
+                assert recorded
+                assert recorded[0][0] == 3  # cost == number of texts
+            finally:
+                c.close()

--- a/tests/unit/test_hooks_common.py
+++ b/tests/unit/test_hooks_common.py
@@ -274,16 +274,17 @@ class TestGetHookTimeout:
         monkeypatch.setenv("HOOK_TIMEOUT", "120")
         assert get_hook_timeout() == 120
 
-    def test_default_60_when_env_var_unset(self, monkeypatch):
-        """get_hook_timeout returns 60 when HOOK_TIMEOUT is not set."""
+    def test_default_90_when_env_var_unset(self, monkeypatch):
+        """get_hook_timeout returns 90 when HOOK_TIMEOUT is not set (TD-782/788
+        coherent ceiling above the embedding client's coordinated timeout budget)."""
         monkeypatch.delenv("HOOK_TIMEOUT", raising=False)
-        assert get_hook_timeout() == 60
+        assert get_hook_timeout() == 90
 
-    def test_invalid_env_var_returns_60_not_raises(self, monkeypatch):
-        """get_hook_timeout returns 60 (not raises) when HOOK_TIMEOUT is non-numeric."""
+    def test_invalid_env_var_returns_90_not_raises(self, monkeypatch):
+        """get_hook_timeout returns 90 (not raises) when HOOK_TIMEOUT is non-numeric."""
         monkeypatch.setenv("HOOK_TIMEOUT", "not_a_number")
         result = get_hook_timeout()
-        assert result == 60
+        assert result == 90
 
     def test_return_type_is_always_int(self, monkeypatch):
         """get_hook_timeout always returns an int, never a string."""


### PR DESCRIPTION
## What
Makes the embedding client's timeouts coherent with the server and shapes bulk submit load:

- Establish a coherent read-timeout floor (server acquire timeout + inference time) so the client no longer abandons a request before the server can plausibly respond; floor the overall attempt deadline to match, and raise the hook-timeout ceiling so it cannot fire mid-request. Route every store-hook path through the shared hook-timeout helper.
- Add a patient client-side submit-rate limiter (`EMBEDDING_CLIENT_MAX_TXT_PER_SEC`) that reserves an attempt window from the request deadline before pacing, so pacing can never consume the budget the request itself needs.
- Ship coherent client timeout defaults and add the new client knobs to the compose env-parity guard.

## Why
The client's read timeout was shorter than the server's admission-plus-inference time, causing premature timeouts and retry storms under load; the naive rate limiter could consume a request's entire deadline and self-inflict a timeout. Both are corrected so bulk consumers apply backpressure without dropping requests.

## Testing
Unit tests cover the coherent timeout budget across all hook paths, the reserved-attempt-window invariant (including the near-boundary case and a property sweep), and that pacing is preserved where the deadline has slack.