### PR TITLE
Fix soak-harness metrics scrape and add restart-count OOM witness

### DIFF
--- a/scripts/perf/embedding_capacity/cgroup.py
+++ b/scripts/perf/embedding_capacity/cgroup.py
@@ -188,6 +188,36 @@ class PeakPoller:
         return self._poll_error is not None
 
 
+def container_restart_count(container: str) -> int:
+    """Return the container's cumulative restart count via `docker inspect`.
+
+    The second authoritative OOM witness alongside dmesg (TD-792/789): on this
+    host a kernel OOM-kill leaves memory.events:oom_kill=0, docker OOMKilled=
+    false, and the app's own counter=0, yet the kill crashes the container's
+    main process and Docker's restart policy restarts it — incrementing
+    RestartCount. Read this at soak start and end; a positive delta witnesses a
+    crash/restart the cgroup and app counters were blind to. Raises
+    CgroupAccessError if docker inspect fails (surface per the BLOCKER PROTOCOL,
+    never treat an unreadable count as zero restarts).
+    """
+    result = subprocess.run(
+        ["docker", "inspect", "-f", "{{.RestartCount}}", container],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise CgroupAccessError(
+            f"docker inspect {container} restart-count failed "
+            f"(exit {result.returncode}): {result.stderr.strip()}"
+        )
+    raw = result.stdout.strip()
+    try:
+        return int(raw)
+    except ValueError as e:
+        raise CgroupAccessError(f"non-integer restart count: {raw!r}") from e
+
+
 _DMESG_OOM_PATTERN = re.compile(r"Out of memory|Killed process", re.IGNORECASE)
 _DMESG_TIMESTAMP_PATTERN = re.compile(r"^\[\s*(\d+\.\d+)\]")
 

--- a/scripts/perf/embedding_capacity/gate.py
+++ b/scripts/perf/embedding_capacity/gate.py
@@ -83,7 +83,7 @@ class GateResult:
     @property
     def outcome(self) -> str:
         """PASS | FAIL | INVALID — INVALID means the load never landed, so the
-        other 6 criteria's trivial passes don't certify anything (BP-179 §4)."""
+        other 7 criteria's trivial passes don't certify anything (BP-179 §4)."""
         if not self.load_valid:
             return "INVALID"
         return "PASS" if self.passed else "FAIL"

--- a/scripts/perf/embedding_capacity/gate.py
+++ b/scripts/perf/embedding_capacity/gate.py
@@ -1,8 +1,10 @@
-"""Soak pass/fail gate — BP-179 §4, assert ALL six criteria.
+"""Soak pass/fail gate — BP-179 §4, assert ALL criteria.
 
-The OOM signal is cgroup `memory.events:oom_kill` + dmesg ONLY (BP-179 §3/§5) —
-never the Docker `OOMKilled` flag or the app's own `oom_events_total` gauge,
-both of which are blind to a killed worker/child process.
+The OOM witnesses are cgroup `memory.events:oom_kill` + dmesg + the container
+restart-count (TD-792/789) — never the Docker `OOMKilled` flag or the app's own
+`oom_events_total` gauge. On the target host a real kill left oom_kill=0,
+OOMKilled=false, and the app counter=0; only dmesg and the container restart
+witnessed it, so both are asserted so a false-PASS cannot slip through.
 """
 
 from __future__ import annotations
@@ -94,6 +96,7 @@ def evaluate_gate(
     *,
     oom_kill_delta: int,
     dmesg_oom_count: int,
+    restart_count_delta: int,
     shed_delta: float,
     admission_wait_p95_seconds: float | None,
     client_read_timeout_seconds: float,
@@ -108,11 +111,12 @@ def evaluate_gate(
     min_success_ratio: float = 0.5,
     min_peak_above_base_ratio: float = 0.02,
 ) -> GateResult:
-    """Evaluate all 6 BP-179 §4 pass/fail criteria plus the load-validity guard.
+    """Evaluate all 7 BP-179 §4 pass/fail criteria plus the load-validity guard.
 
-    The gate only PASSes if the load-validity guard holds AND all 6 criteria
-    pass; if the guard fails, the outcome is the distinct INVALID (not PASS
-    or FAIL) — the run didn't prove anything either way.
+    The 7 are the 6 BP-179 §4 criteria plus the container restart-count OOM
+    witness (TD-792/789). The gate only PASSes if the load-validity guard holds
+    AND all 7 criteria pass; if the guard fails, the outcome is the distinct
+    INVALID (not PASS or FAIL) — the run didn't prove anything either way.
     """
     validity = evaluate_load_validity(
         total_requests=total_requests,
@@ -133,6 +137,11 @@ def evaluate_gate(
         "dmesg_oom_zero",
         dmesg_oom_count == 0,
         f"dmesg OOM-kill lines={dmesg_oom_count} (must be 0)",
+    )
+    gate.add(
+        "container_restart_zero",
+        restart_count_delta == 0,
+        f"container restart-count delta={restart_count_delta} (must be 0)",
     )
     gate.add(
         "backpressure_shed_zero",

--- a/scripts/perf/embedding_capacity/metrics_client.py
+++ b/scripts/perf/embedding_capacity/metrics_client.py
@@ -30,7 +30,14 @@ class MetricsSnapshot:
 
 
 def fetch_metrics_text(base_url: str, timeout: float = 10.0) -> str:
-    response = httpx.get(f"{base_url.rstrip('/')}/metrics", timeout=timeout)
+    # The embedding service serves /metrics behind a 307 redirect; httpx does
+    # not follow redirects by default, so without follow_redirects the scrape
+    # returns the empty redirect body and every downstream metric goes missing
+    # — silently rendering the soak's admission-wait gate criterion inert
+    # (TD-793). A 307 is not a 4xx/5xx, so raise_for_status would not catch it.
+    response = httpx.get(
+        f"{base_url.rstrip('/')}/metrics", timeout=timeout, follow_redirects=True
+    )
     response.raise_for_status()
     return response.text
 

--- a/scripts/perf/embedding_capacity/metrics_client.py
+++ b/scripts/perf/embedding_capacity/metrics_client.py
@@ -31,10 +31,12 @@ class MetricsSnapshot:
 
 def fetch_metrics_text(base_url: str, timeout: float = 10.0) -> str:
     # The embedding service serves /metrics behind a 307 redirect; httpx does
-    # not follow redirects by default, so without follow_redirects the scrape
-    # returns the empty redirect body and every downstream metric goes missing
-    # — silently rendering the soak's admission-wait gate criterion inert
-    # (TD-793). A 307 is not a 4xx/5xx, so raise_for_status would not catch it.
+    # not follow redirects by default, so without follow_redirects the 307 is
+    # returned unfollowed and raise_for_status raises HTTPStatusError on it —
+    # the scrape never reaches the real metrics body, so the soak's
+    # admission-wait gate criterion cannot be evaluated (TD-793).
+    # follow_redirects=True is required simply to follow the 307 to the actual
+    # /metrics payload.
     response = httpx.get(
         f"{base_url.rstrip('/')}/metrics", timeout=timeout, follow_redirects=True
     )

--- a/scripts/perf/embedding_capacity_harness.py
+++ b/scripts/perf/embedding_capacity_harness.py
@@ -316,6 +316,11 @@ def cmd_soak(args: argparse.Namespace) -> int:
     # CgroupAccessError immediately if unreadable, and its return value
     # baselines the ring buffer so stale prior-run kills aren't re-reported.
     dmesg_baseline_ts = cgroup.dmesg_baseline()
+    # Second authoritative OOM witness (TD-792/789): a real kill is invisible to
+    # memory.events/docker-OOMKilled/app-counter on this host — only dmesg and
+    # a container restart witness it. Baseline the restart count NOW so a delta
+    # over the soak reflects only kills during the run.
+    restart_count_start = cgroup.container_restart_count(args.container)
 
     baseline_events = reader.read_events()
     working_set_start = reader.read_current()
@@ -364,6 +369,8 @@ def cmd_soak(args: argparse.Namespace) -> int:
         "oom_kill", 0
     )
     dmesg_lines = cgroup.scan_dmesg_oom(since_timestamp=dmesg_baseline_ts)
+    restart_count_end = cgroup.container_restart_count(args.container)
+    restart_count_delta = restart_count_end - restart_count_start
     final_metrics = metrics_client.parse_metrics(
         metrics_client.fetch_metrics_text(args.base_url)
     )
@@ -377,6 +384,7 @@ def cmd_soak(args: argparse.Namespace) -> int:
     gate_result = gate.evaluate_gate(
         oom_kill_delta=oom_kill_delta,
         dmesg_oom_count=len(dmesg_lines),
+        restart_count_delta=restart_count_delta,
         shed_delta=shed_delta,
         admission_wait_p95_seconds=final_metrics.admission_wait_p95_seconds,
         client_read_timeout_seconds=args.read_timeout_seconds,
@@ -411,6 +419,9 @@ def cmd_soak(args: argparse.Namespace) -> int:
         "final_events": final_events,
         "oom_kill_delta": oom_kill_delta,
         "dmesg_oom_lines": dmesg_lines,
+        "restart_count_start": restart_count_start,
+        "restart_count_end": restart_count_end,
+        "restart_count_delta": restart_count_delta,
         "shed_delta": shed_delta,
         "working_set_start_bytes": working_set_start,
         "working_set_end_bytes": working_set_end,

--- a/scripts/perf/runbook.md
+++ b/scripts/perf/runbook.md
@@ -97,7 +97,7 @@ reviewed decision — not something the harness does automatically.
 ## Step 4 — Soak (`soak`)
 
 Validates the chosen envelope survives sustained, burst-shaped, genuine
-multi-caller load and asserts all 6 BP-179 §4 gate criteria. Run overnight.
+multi-caller load and asserts all 7 BP-179 §4 gate criteria. Run overnight.
 
 ```bash
 python scripts/perf/embedding_capacity_harness.py soak \
@@ -118,14 +118,14 @@ python scripts/perf/embedding_capacity_harness.py soak \
 - The harness snapshots `memory.events` **before** the run and reports
   deltas — a baseline is mandatory per BP-179 §4; without it, pre-existing
   kills would be misattributed to this soak.
-- The gate has three possible outcomes — exit code **0** (`PASS`, all 6
+- The gate has three possible outcomes — exit code **0** (`PASS`, all 7
   criteria pass), **1** (`FAIL`, at least one criterion failed), or **2**
-  (`INVALID`, the load-validity guard tripped before the 6 criteria were
+  (`INVALID`, the load-validity guard tripped before the 7 criteria were
   even meaningful). `INVALID` fires when either too few requests succeeded
   (success ratio below the floor) or the measured peak never rose
   meaningfully above the base RSS — both indicate the burst/soak load never
   actually landed (e.g. wrong port, all-503s, not-ready container), so a
-  trivial all-PASS on the 6 criteria wouldn't certify anything. On
+  trivial all-PASS on the 7 criteria wouldn't certify anything. On
   `INVALID`, fix why the load didn't land (check `--base-url`/`--container`,
   confirm the target is warm and serving) and re-run — it is not a capacity
   verdict either way.
@@ -137,6 +137,7 @@ python scripts/perf/embedding_capacity_harness.py soak \
 | Failing criterion | What it means | Where to look |
 |---|---|---|
 | `oom_kill_delta_zero` / `dmesg_oom_zero` | The envelope is unsafe — the primary gate. | `docker exec ai-memory-embedding cat /sys/fs/cgroup/memory.events`, `dmesg` |
+| `container_restart_zero` | The container's main process was OOM-killed by the kernel even though cgroup `memory.events` / docker `OOMKilled` / the app counter all stayed 0 (the TD-792/789 blind-spot). | `docker inspect -f '{{.RestartCount}}' <container>`; compare `restart_count_start`/`restart_count_end` in the results JSON |
 | `backpressure_shed_zero` | A request was dropped (lost memory), not just delayed. | `embedding_backpressure_total{action="shed"}` on `:28080/metrics` |
 | `admission_wait_p95_within_timeout` | Clients would time out and retry-storm under this envelope. | `embedding_admission_wait_seconds` histogram |
 | `no_working_set_climb` | Possible slow leak/fragmentation drift (BUG-324 axis). | Compare `working_set_start_bytes`/`working_set_end_bytes` in the results JSON |

--- a/tests/perf/test_cgroup.py
+++ b/tests/perf/test_cgroup.py
@@ -124,6 +124,56 @@ def test_docker_exec_raises_cgroup_access_error_on_nonzero_exit(monkeypatch):
         cgroup._docker_exec("missing", "cat", "/x")
 
 
+def test_container_restart_count_parses_int(monkeypatch):
+    class _Result:
+        returncode = 0
+        stdout = "3\n"
+        stderr = ""
+
+    monkeypatch.setattr(cgroup.subprocess, "run", lambda *a, **k: _Result())
+    assert cgroup.container_restart_count("ai-memory-embedding") == 3
+
+
+def test_container_restart_count_delta_witnesses_oom(monkeypatch):
+    # TD-792/789: a start->end restart-count delta is the authoritative OOM
+    # witness when memory.events/docker-OOMKilled/app-counter are all blind.
+    outputs = iter(["1\n", "2\n"])
+
+    class _Result:
+        returncode = 0
+        stderr = ""
+
+        def __init__(self):
+            self.stdout = next(outputs)
+
+    monkeypatch.setattr(cgroup.subprocess, "run", lambda *a, **k: _Result())
+    start = cgroup.container_restart_count("c1")
+    end = cgroup.container_restart_count("c1")
+    assert end - start == 1
+
+
+def test_container_restart_count_raises_on_inspect_failure(monkeypatch):
+    class _Result:
+        returncode = 1
+        stdout = ""
+        stderr = "Error: No such container: missing"
+
+    monkeypatch.setattr(cgroup.subprocess, "run", lambda *a, **k: _Result())
+    with pytest.raises(cgroup.CgroupAccessError):
+        cgroup.container_restart_count("missing")
+
+
+def test_container_restart_count_raises_on_non_integer(monkeypatch):
+    class _Result:
+        returncode = 0
+        stdout = "<no value>\n"
+        stderr = ""
+
+    monkeypatch.setattr(cgroup.subprocess, "run", lambda *a, **k: _Result())
+    with pytest.raises(cgroup.CgroupAccessError):
+        cgroup.container_restart_count("c1")
+
+
 def test_scan_dmesg_oom_filters_by_pattern(monkeypatch):
     class _Result:
         returncode = 0

--- a/tests/perf/test_gate.py
+++ b/tests/perf/test_gate.py
@@ -1,6 +1,6 @@
 """Unit tests for scripts/perf/embedding_capacity/gate.py — BP-179 §4 pass/fail gate.
 
-Each of the 6 criteria is tested independently for its failure case, plus the
+Each of the 7 criteria is tested independently for its failure case, plus the
 overall pass case, matching the "assert ALL" requirement (a single failing
 criterion must fail the whole gate).
 """

--- a/tests/perf/test_gate.py
+++ b/tests/perf/test_gate.py
@@ -10,6 +10,7 @@ from embedding_capacity import gate
 BASE_KWARGS = {
     "oom_kill_delta": 0,
     "dmesg_oom_count": 0,
+    "restart_count_delta": 0,
     "shed_delta": 0.0,
     "admission_wait_p95_seconds": 0.5,
     "client_read_timeout_seconds": 30.0,
@@ -28,7 +29,7 @@ def test_all_criteria_pass_gate_passes():
     result = gate.evaluate_gate(**BASE_KWARGS)
     assert result.passed
     assert result.outcome == "PASS"
-    assert len(result.criteria) == 6
+    assert len(result.criteria) == 7
     assert all(c.passed for c in result.criteria)
 
 
@@ -46,6 +47,36 @@ def test_dmesg_oom_count_nonzero_fails_gate():
     result = gate.evaluate_gate(**kwargs)
     assert not result.passed
     assert not next(c for c in result.criteria if c.name == "dmesg_oom_zero").passed
+
+
+def test_restart_count_delta_nonzero_fails_gate():
+    # TD-792/789: the authoritative OOM witness on this host. A restart during
+    # the soak means the container's main process was killed (kernel OOM) even
+    # though memory.events:oom_kill stayed 0 — the gate must fail.
+    kwargs = {**BASE_KWARGS, "restart_count_delta": 1}
+    result = gate.evaluate_gate(**kwargs)
+    assert not result.passed
+    assert not next(
+        c for c in result.criteria if c.name == "container_restart_zero"
+    ).passed
+
+
+def test_restart_witnesses_oom_when_cgroup_and_app_counters_blind():
+    # The exact TD-792 scenario: oom_kill delta 0, dmesg would be the only
+    # other witness — here dmesg also 0 but the restart count caught the kill.
+    # A gate relying only on oom_kill/dmesg would false-PASS; restart-count
+    # must independently fail it.
+    kwargs = {
+        **BASE_KWARGS,
+        "oom_kill_delta": 0,
+        "dmesg_oom_count": 0,
+        "restart_count_delta": 1,
+    }
+    result = gate.evaluate_gate(**kwargs)
+    assert result.outcome == "FAIL"
+    assert not next(
+        c for c in result.criteria if c.name == "container_restart_zero"
+    ).passed
 
 
 def test_shed_delta_nonzero_fails_gate():
@@ -114,11 +145,11 @@ def test_peak_at_or_over_mem_limit_fails_gate():
 
 
 def test_single_failing_criterion_fails_the_whole_gate():
-    # 5 of 6 pass; the gate must still fail (assert ALL, not majority).
+    # 6 of 7 pass; the gate must still fail (assert ALL, not majority).
     kwargs = {**BASE_KWARGS, "oom_kill_delta": 1}
     result = gate.evaluate_gate(**kwargs)
     passing = [c for c in result.criteria if c.passed]
-    assert len(passing) == 5
+    assert len(passing) == 6
     assert not result.passed
     assert result.outcome == "FAIL"
 

--- a/tests/perf/test_metrics_client.py
+++ b/tests/perf/test_metrics_client.py
@@ -4,6 +4,7 @@ Works entirely off raw exposition text, matching what a live embedding
 container's `/metrics` endpoint returns (BP-179 §6) — no live service needed.
 """
 
+import httpx
 import pytest
 from embedding_capacity import metrics_client
 
@@ -80,3 +81,33 @@ def test_histogram_quantile_zero_total_count_returns_none():
     assert (
         metrics_client._histogram_quantile({0.1: 0.0}, total_count=0.0, q=0.95) is None
     )
+
+
+def test_fetch_metrics_follows_307_redirect(monkeypatch):
+    # TD-793: the service serves /metrics behind a 307 redirect. httpx does not
+    # follow redirects by default, so the unfixed scrape returned the empty
+    # redirect body and the admission-wait gate criterion was silently inert.
+    # This routes the request through a MockTransport that faithfully honors
+    # whatever `follow_redirects` value fetch_metrics_text passes: without the
+    # fix the 307 body (empty) comes back and p95 is None; with it the scrape
+    # follows through to the real metrics body. No live service.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/metrics":
+            return httpx.Response(307, headers={"Location": "/metrics/"})
+        if request.url.path == "/metrics/":
+            return httpx.Response(200, text=SAMPLE_METRICS)
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+
+    def patched_get(url, **kwargs):
+        follow = kwargs.pop("follow_redirects", False)
+        with httpx.Client(transport=transport, follow_redirects=follow) as client:
+            return client.get(url, **kwargs)
+
+    monkeypatch.setattr(metrics_client.httpx, "get", patched_get)
+
+    text = metrics_client.fetch_metrics_text("http://localhost:28080")
+    snapshot = metrics_client.parse_metrics(text)
+    assert snapshot.admission_wait_p95_seconds is not None
+    assert snapshot.backpressure["shed"] == 0.0

--- a/tests/perf/test_results.py
+++ b/tests/perf/test_results.py
@@ -18,6 +18,7 @@ def test_write_results_json_serializes_nested_dataclasses(tmp_path):
     gate_result = gate.evaluate_gate(
         oom_kill_delta=0,
         dmesg_oom_count=0,
+        restart_count_delta=0,
         shed_delta=0.0,
         admission_wait_p95_seconds=0.5,
         client_read_timeout_seconds=30.0,
@@ -37,5 +38,5 @@ def test_write_results_json_serializes_nested_dataclasses(tmp_path):
 
     data = json.loads(out_path.read_text())
     assert data["gate_passed"] is True
-    assert len(data["gate"]["criteria"]) == 6
+    assert len(data["gate"]["criteria"]) == 7
     assert data["gate"]["criteria"][0]["name"] == "oom_kill_delta_zero"


### PR DESCRIPTION
## What
Hardens the embedding capacity soak harness:

- Follow the metrics endpoint redirect so the admission-wait soak criterion is actually measured (it was silently inert).
- Add a container restart-count criterion to the pass/fail gate so a kernel OOM is witnessed even when the cgroup / docker / app counters stay zero, and record restart counts in the results.
- Reconcile the runbook and gate docs for the new criterion.

## Why
The soak gate could pass without measuring admission latency, and could miss a real OOM entirely on hosts where the standard counters are blind — only dmesg and the container restart count witnessed it.

## Testing
Unit tests cover the redirect-following scrape, the restart-count gate criterion (including the exact blind-counter OOM scenario), and the gate accounting.