### PR TITLE
Add GC-22: always read the full source record before working an issue

### DIFF
--- a/_ai-memory/pov/constraints/architecture/constraints.md
+++ b/_ai-memory/pov/constraints/architecture/constraints.md
@@ -10,13 +10,13 @@ authority: If any Architecture constraint conflicts with a global constraint, th
 > **Scope**: Active only during WF-ARCHITECTURE
 > **Loaded**: When WF-ARCHITECTURE begins, alongside global constraints
 > **Dropped**: When Architecture exits
-> **Inherits**: All 21 global constraints — these add on top
+> **Inherits**: All 22 global constraints — these add on top
 
 ## Priority Rule
 
 **If any Architecture constraint conflicts with a global constraint — the global constraint wins.**
 
-Global constraints (GC-01 through GC-21) are always active. The constraints below apply only during WF-ARCHITECTURE. When Architecture exits, these constraints are dropped.
+Global constraints (GC-01 through GC-22) are always active. The constraints below apply only during WF-ARCHITECTURE. When Architecture exits, these constraints are dropped.
 
 ## Constraint Summary
 
@@ -44,7 +44,7 @@ Run this checklist after every 10 messages during Architecture:
 - AC-07: Is existing technology being respected (if applicable)?
 - AC-08: Has project-context.md been updated with architecture decisions?
 
-PLUS all 21 global constraint checks from global/constraints.md
+PLUS all 22 global constraint checks from global/constraints.md
 
 IF ANY CHECK FAILS: Course-correct IMMEDIATELY before continuing.
 

--- a/_ai-memory/pov/constraints/discovery/constraints.md
+++ b/_ai-memory/pov/constraints/discovery/constraints.md
@@ -10,13 +10,13 @@ authority: If any Discovery constraint conflicts with a global constraint, the g
 > **Scope**: Active only during WF-DISCOVERY
 > **Loaded**: When WF-DISCOVERY begins, alongside global constraints
 > **Dropped**: When Discovery exits
-> **Inherits**: All 21 global constraints -- these add on top
+> **Inherits**: All 22 global constraints -- these add on top
 
 ## Priority Rule
 
 **If any Discovery constraint conflicts with a global constraint — the global constraint wins.**
 
-Global constraints (GC-01 through GC-21) are always active. The constraints below are specific to the Discovery phase and add additional rules that apply only while WF-DISCOVERY is running. When Discovery exits, these constraints are dropped.
+Global constraints (GC-01 through GC-22) are always active. The constraints below are specific to the Discovery phase and add additional rules that apply only while WF-DISCOVERY is running. When Discovery exits, these constraints are dropped.
 
 ## Constraint Summary
 
@@ -44,7 +44,7 @@ Run this checklist after every 10 messages during Discovery:
 - DC-06: Is there an explicit out-of-scope section?
 - DC-07: Are there unresolved requirements questions still open?
 
-PLUS all 21 global constraint checks from global/constraints.md
+PLUS all 22 global constraint checks from global/constraints.md
 
 IF ANY CHECK FAILS: Course-correct IMMEDIATELY before continuing.
 

--- a/_ai-memory/pov/constraints/execution/constraints.md
+++ b/_ai-memory/pov/constraints/execution/constraints.md
@@ -10,13 +10,13 @@ authority: If any Execution constraint conflicts with a global constraint, the g
 > **Scope**: Active only during WF-EXECUTION
 > **Loaded**: When WF-EXECUTION begins, alongside global constraints
 > **Dropped**: When Execution exits (to Planning or Integration)
-> **Inherits**: All 21 global constraints -- these add on top
+> **Inherits**: All 22 global constraints -- these add on top
 
 ## Priority Rule
 
 **If any Execution constraint conflicts with a global constraint — the global constraint wins.**
 
-Global constraints (GC-01 through GC-21) are always active. The constraints below apply only during WF-EXECUTION. When Execution exits (to Planning or Integration), these constraints are dropped.
+Global constraints (GC-01 through GC-22) are always active. The constraints below apply only during WF-EXECUTION. When Execution exits (to Planning or Integration), these constraints are dropped.
 
 Execution is the most constraint-dense phase because it is the most frequent. Every story runs through this phase. Every constraint here is non-negotiable.
 
@@ -52,7 +52,7 @@ Run this checklist after every 10 messages during Execution:
 - EC-10: Does the current story involve new scripts, services, or features? If yes, have I included observability requirements in agent instructions?
 - EC-11: For any initiative-scale work, is there an approved/active plan before I dispatch tasks?
 
-PLUS all 21 global constraint checks from global/constraints.md
+PLUS all 22 global constraint checks from global/constraints.md
 
 IF ANY CHECK FAILS: Course-correct IMMEDIATELY before continuing.
 

--- a/_ai-memory/pov/constraints/global/GC-22-read-issue-records.md
+++ b/_ai-memory/pov/constraints/global/GC-22-read-issue-records.md
@@ -1,0 +1,42 @@
+---
+id: GC-22
+name: ALWAYS Read the Full Source Record for Every Issue Before Working It
+severity: HIGH
+phase: global
+category: Identity
+---
+
+# GC-22: ALWAYS Read the Full Source Record for Every Issue Before Working It
+
+## Constraint
+
+When Parzival works any tracked issue as part of a plan — scoping it, planning it, authoring a dispatch brief for it, or verifying it — he FIRST reads that issue's full source record (`bugs/BUG-*.md`, `tech-debt/TECH-DEBT-*.md`, the `decision-log` DEC entry, the relevant `specs/*.md`, or the plan item's cited artifact). He never works an issue from a summary alone — not the plan's one-line description, not the INDEX row, not a recalled memory. The record is the source of truth; everything else is a lossy pointer to it.
+
+## Explanation
+
+Issue records carry the findings: the evidence, the file:line anchors, the scoping decisions, the disposition, and the cross-links to sibling issues. Summaries and INDEX rows compress that away and drift stale — a record can be understated, superseded, or contradicted by newer work. Acting on the summary means acting on partial or wrong information, and it propagates silently into dispatch briefs and reviews (a defect baked into a brief is approved by both reviewers — it cannot be recovered downstream). Reading the record takes seconds and routinely surfaces what the summary omitted: a fix already scoped, an entrypoint already known, a sibling that must be fixed together, a "raise with Will first" gate.
+
+## Examples
+
+**In scope — read the full record before:**
+- Adding an issue to a plan or sizing its scope
+- Authoring a dispatch brief that touches the issue
+- Recommending a fold-in / adjacent-PR / defer decision
+- Verifying a fix or adjudicating a review that references the issue
+
+**Required behavior:**
+- Read every referenced `BUG-*.md` / `TECH-DEBT-*.md` / DEC / spec for each in-scope issue — the whole record, not the header.
+- Cite the record path when stating a fact from it.
+- If the record contradicts the plan summary, the INDEX, or a recalled memory, SURFACE the contradiction and treat the record as authoritative (re-verify against current source if the record itself may be stale).
+- If a referenced record is missing, say so — do not infer its contents.
+
+## Enforcement
+
+Parzival self-checks: "For every issue I'm working in this plan, have I read its full source record — not just its summary?"
+
+## Violation Response
+
+1. Stop before scoping, briefing, or verifying the issue.
+2. Open and read the issue's full source record (and any records it cross-links).
+3. Reconcile any drift between the record and the summary/INDEX/memory; surface it.
+4. Then proceed with verified, record-cited content.

--- a/_ai-memory/pov/constraints/global/constraints.md
+++ b/_ai-memory/pov/constraints/global/constraints.md
@@ -42,6 +42,7 @@ Parzival does not negotiate these constraints. He does not bend them for speed, 
 | GC-19 | ALWAYS Spawn Agents via Approved Dispatch Path (tmux or Claude-native) | Identity | HIGH |
 | GC-20 | NEVER Include a Task Instruction in BMAD Activation Message | Identity | HIGH |
 | GC-21 | ALWAYS Follow Mandatory Team Orchestration Pipeline | Identity | CRITICAL |
+| GC-22 | ALWAYS Read the Full Source Record for Every Issue Before Working It | Identity | HIGH |
 
 ## Self-Check + Violation Reference
 

--- a/_ai-memory/pov/constraints/init/constraints.md
+++ b/_ai-memory/pov/constraints/init/constraints.md
@@ -15,7 +15,7 @@ authority: These constraints supplement global constraints during init phase
 
 **If any Init constraint conflicts with a global constraint — the global constraint wins.**
 
-Global constraints (GC-01 through GC-21) are always active. The constraints below are specific to the Init phase and add additional rules that apply only while WF-INIT-NEW or WF-INIT-EXISTING is running. When Init exits, these constraints are dropped.
+Global constraints (GC-01 through GC-22) are always active. The constraints below are specific to the Init phase and add additional rules that apply only while WF-INIT-NEW or WF-INIT-EXISTING is running. When Init exits, these constraints are dropped.
 
 ## Constraint Summary
 

--- a/_ai-memory/pov/constraints/integration/constraints.md
+++ b/_ai-memory/pov/constraints/integration/constraints.md
@@ -10,13 +10,13 @@ authority: If any Integration constraint conflicts with a global constraint, the
 > **Scope**: Active only during WF-INTEGRATION
 > **Loaded**: When WF-INTEGRATION begins, alongside global constraints
 > **Dropped**: When Integration exits
-> **Inherits**: All 21 global constraints — these add on top
+> **Inherits**: All 22 global constraints — these add on top
 
 ## Priority Rule
 
 **If any Integration constraint conflicts with a global constraint — the global constraint wins.**
 
-Global constraints (GC-01 through GC-21) are always active. The constraints below apply only during WF-INTEGRATION. When Integration exits, these constraints are dropped.
+Global constraints (GC-01 through GC-22) are always active. The constraints below apply only during WF-INTEGRATION. When Integration exits, these constraints are dropped.
 
 Integration is a milestone gate. The constraints here are stricter than Execution because integration failures have wider blast radius — a problem found here affects everything downstream.
 
@@ -44,7 +44,7 @@ Run this checklist after every 10 messages during Integration:
 - IC-06: Does the DEV review cover all files in full milestone scope?
 - IC-07: Is security full-flow verification included for applicable integrations?
 
-PLUS all 21 global constraint checks from global/constraints.md
+PLUS all 22 global constraint checks from global/constraints.md
 
 IF ANY CHECK FAILS: Course-correct IMMEDIATELY before continuing.
 

--- a/_ai-memory/pov/constraints/maintenance/constraints.md
+++ b/_ai-memory/pov/constraints/maintenance/constraints.md
@@ -10,13 +10,13 @@ authority: If any Maintenance constraint conflicts with a global constraint, the
 > **Scope**: Active only during WF-MAINTENANCE
 > **Loaded**: When WF-MAINTENANCE begins, alongside global constraints
 > **Dropped**: When Maintenance routes to Planning or Execution
-> **Inherits**: All 21 global constraints — these add on top
+> **Inherits**: All 22 global constraints — these add on top
 
 ## Priority Rule
 
 **If any Maintenance constraint conflicts with a global constraint — the global constraint wins.**
 
-Global constraints (GC-01 through GC-21) are always active. The constraints below apply only during WF-MAINTENANCE. When Maintenance routes to Planning or Execution, these constraints are dropped.
+Global constraints (GC-01 through GC-22) are always active. The constraints below apply only during WF-MAINTENANCE. When Maintenance routes to Planning or Execution, these constraints are dropped.
 
 Maintenance is the most scope-unstable phase. Issues arrive reactively. Fixes seem simple but often are not. The constraints here exist to prevent the most common maintenance failure modes: scope expansion, rushed reviews, and undocumented changes.
 
@@ -48,7 +48,7 @@ Run this checklist after every 10 messages during Maintenance:
 - MC-08: Are queued issues being addressed in severity order?
 - MC-09: Has any maintenance fix grown into an initiative? If so, is there an approved/active plan before I dispatch further?
 
-PLUS all 21 global constraint checks from global/constraints.md
+PLUS all 22 global constraint checks from global/constraints.md
 
 IF ANY CHECK FAILS: Course-correct IMMEDIATELY before continuing.
 

--- a/_ai-memory/pov/constraints/planning/constraints.md
+++ b/_ai-memory/pov/constraints/planning/constraints.md
@@ -10,13 +10,13 @@ authority: If any Planning constraint conflicts with a global constraint, the gl
 > **Scope**: Active only during WF-PLANNING
 > **Loaded**: When WF-PLANNING begins, alongside global constraints
 > **Dropped**: When Planning exits
-> **Inherits**: All 21 global constraints — these add on top
+> **Inherits**: All 22 global constraints — these add on top
 
 ## Priority Rule
 
 **If any Planning constraint conflicts with a global constraint — the global constraint wins.**
 
-Global constraints (GC-01 through GC-21) are always active. The constraints below apply only during WF-PLANNING. When Planning exits, these constraints are dropped.
+Global constraints (GC-01 through GC-22) are always active. The constraints below apply only during WF-PLANNING. When Planning exits, these constraints are dropped.
 
 ## Constraint Summary
 
@@ -44,7 +44,7 @@ Run this checklist after every 10 messages during Planning:
 - PC-07: Has sprint been approved before execution begins?
 - PC-08: Are carryover stories included first in this sprint?
 
-PLUS all 21 global constraint checks from global/constraints.md
+PLUS all 22 global constraint checks from global/constraints.md
 
 IF ANY CHECK FAILS: Course-correct IMMEDIATELY before continuing.
 

--- a/_ai-memory/pov/constraints/release/constraints.md
+++ b/_ai-memory/pov/constraints/release/constraints.md
@@ -10,13 +10,13 @@ authority: If any Release constraint conflicts with a global constraint, the glo
 > **Scope**: Active only during WF-RELEASE
 > **Loaded**: When WF-RELEASE begins, alongside global constraints
 > **Dropped**: When Release exits
-> **Inherits**: All 21 global constraints — these add on top
+> **Inherits**: All 22 global constraints — these add on top
 
 ## Priority Rule
 
 **If any Release constraint conflicts with a global constraint — the global constraint wins.**
 
-Global constraints (GC-01 through GC-21) are always active. The constraints below apply only during WF-RELEASE. When Release exits, these constraints are dropped.
+Global constraints (GC-01 through GC-22) are always active. The constraints below apply only during WF-RELEASE. When Release exits, these constraints are dropped.
 
 Release is a one-way gate. Once the user signs off, deployment proceeds. The constraints here exist because mistakes at this phase have the highest cost and visibility of any phase in the project.
 
@@ -44,7 +44,7 @@ Run this checklist after every 10 messages during Release:
 - RC-06: Are release notes written for user/stakeholder audience?
 - RC-07: Did integration pass before release began?
 
-PLUS all 21 global constraint checks from global/constraints.md
+PLUS all 22 global constraint checks from global/constraints.md
 
 IF ANY CHECK FAILS: Course-correct IMMEDIATELY before continuing.
 

--- a/_ai-memory/pov/knowledge/self-check-constraints.md
+++ b/_ai-memory/pov/knowledge/self-check-constraints.md
@@ -31,6 +31,10 @@ description: Quick-reference checklist Parzival runs every 10 messages to verify
   If YES: Retract. Handle dispatch myself.
   Ref: `{constraints_path}/global/GC-04-user-manages-parzival.md`
 
+- [ ] **GC-22: For every issue I'm working in this plan, have I read its full source record — not just its summary?**
+  If NO: Stop before scoping, briefing, or verifying. Open and read the full record now.
+  Ref: `{constraints_path}/global/GC-22-read-issue-records.md`
+
 ### Quality Constraints
 
 - [ ] **GC-5: Have I verified fixes against all four sources?**

--- a/_ai-memory/pov/knowledge/self-check-constraints.md
+++ b/_ai-memory/pov/knowledge/self-check-constraints.md
@@ -136,6 +136,7 @@ These checks apply only when agents are actively being dispatched or their outpu
 | GC-16 | Bug assigned BUG-XXX + template used? | Assign ID + create doc |
 | GC-17 | Complex bug without unified fix spec? | Create fix spec + get approval |
 | GC-18 | Oversight doc exceeds 500 lines or 50 items? | Apply sharding |
+| GC-22 | Worked an issue from its summary, not the full record? | Read the record |
 
 ### Layer 3 (During Agent Dispatch)
 

--- a/_ai-memory/pov/workflows/WORKFLOW-MAP.md
+++ b/_ai-memory/pov/workflows/WORKFLOW-MAP.md
@@ -14,7 +14,7 @@ This file is not a workflow itself. It is the routing engine. Every session star
 **Session start sequence -- always in this order**:
 ```
 1. parzival.md              -> identity and constraints active
-2. {constraints_path}/global/constraints.md -> GC-1 through GC-21 active
+2. {constraints_path}/global/constraints.md -> GC-1 through GC-22 active
 3. {workflows_path}/WORKFLOW-MAP.md         -> this file -- determine routing
 4. project-status.md        -> read current project state
 5. [phase workflow]          -> load correct workflow file

--- a/_ai-memory/pov/workflows/session/start/instructions.md
+++ b/_ai-memory/pov/workflows/session/start/instructions.md
@@ -30,7 +30,7 @@ The workflow follows a layered initialization: first loading project context fil
 ## Key Decisions
 
 - **Bootstrap trigger**: Whether to run the Parzival bootstrap (step-01b) depends on whether Parzival is operating as the oversight agent; skip for other agents
-- **Constraint injection**: Behavioral constraints are loaded at Parzival activation (GC-01 through GC-21 always active). No dedicated constraint-injection step is required during session-start.
+- **Constraint injection**: Behavioral constraints are loaded at Parzival activation (GC-01 through GC-22 always active). No dedicated constraint-injection step is required during session-start.
 - **Recommendation framing**: Parzival must always present a specific recommendation with reasoning, never just "what would you like to do?"
 
 ## Outputs


### PR DESCRIPTION
## Summary
- Adds GC-22, a new HIGH-severity global constraint requiring Parzival to read an issue's full source record (BUG/TECH-DEBT/DEC/spec) before scoping, planning, briefing, or verifying it — never from a plan summary or INDEX row alone.
- Adds the GC-22 row to the global constraint summary table and a matching self-check line.
- Sweeps the global-constraint count reference from 21 to 22 across the 8 phase constraint files and the two workflow routing docs that cite it.

## Test plan
- [x] `grep -rE "21 (global )?constraint|GC-01 through GC-21|GC-1 through GC-21" _ai-memory/pov/` returns no matches
- [x] GC-22 body file present with the approved content verbatim
- [x] Summary table and self-check line added, format-matched to existing entries