### PR TITLE
Complete managed-file deploy parity and add HITL drift reconciliation

### DIFF
--- a/_ai-memory/pov/skills/aim-content-drift/scripts/reconcile_engine.py
+++ b/_ai-memory/pov/skills/aim-content-drift/scripts/reconcile_engine.py
@@ -70,6 +70,14 @@ class ReconcileError(Exception):
     """Base class for reconciliation failures."""
 
 
+class ManifestError(ReconcileError):
+    """The manifest is unparseable or an entry is missing a required field.
+
+    Wraps the low-level ``json.JSONDecodeError`` / ``KeyError`` so callers catch one
+    uniform :class:`ReconcileError` type (fail-loud, no write).
+    """
+
+
 class UnsupportedSchemaError(ReconcileError):
     """The manifest's schema_version MAJOR is newer than this engine supports."""
 
@@ -200,7 +208,10 @@ def classify(entry: ReconcileEntry) -> Decision:
 # --------------------------------------------------------------------------- #
 def load_manifest(path: str | os.PathLike[str]) -> Manifest:
     """Parse and validate ``pending-updates.json``."""
-    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ManifestError(f"manifest is not valid JSON: {exc}") from exc
 
     raw_version = str(data.get("schema_version", ""))
     try:
@@ -215,21 +226,24 @@ def load_manifest(path: str | os.PathLike[str]) -> Manifest:
             f"(engine supports <= {SUPPORTED_SCHEMA_MAJOR})"
         )
 
-    entries = tuple(
-        ReconcileEntry(
-            id=e["id"],
-            path=e["path"],
-            classification=e.get("classification", ""),
-            old_shipped_hash=e.get("old_shipped_hash", ""),
-            deployed_hash=e.get("deployed_hash", ""),
-            new_template_hash=e.get("new_template_hash", ""),
-            suggested_action=e.get("suggested_action", ""),
-            rationale=e.get("rationale", ""),
-            severity=e.get("severity", ""),
-            order=int(e.get("order", 0)),
+    try:
+        entries = tuple(
+            ReconcileEntry(
+                id=e["id"],
+                path=e["path"],
+                classification=e.get("classification", ""),
+                old_shipped_hash=e.get("old_shipped_hash", ""),
+                deployed_hash=e.get("deployed_hash", ""),
+                new_template_hash=e.get("new_template_hash", ""),
+                suggested_action=e.get("suggested_action", ""),
+                rationale=e.get("rationale", ""),
+                severity=e.get("severity", ""),
+                order=int(e.get("order", 0)),
+            )
+            for e in data.get("entries", [])
         )
-        for e in data.get("entries", [])
-    )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ManifestError(f"malformed manifest entry: {exc!r}") from exc
     return Manifest(
         schema_version=raw_version,
         generated_at=data.get("generated_at", ""),
@@ -270,18 +284,28 @@ def is_stale(
 # ``format_version`` stamp — lives in the YAML frontmatter block (BP-187 §3 stamp).
 # --------------------------------------------------------------------------- #
 _FRONTMATTER_RE = re.compile(r"\Aformat_version:\s*(\d+)\s*\Z")
+# A YAML frontmatter block carries ``key: value`` lines. This distinguishes a real
+# frontmatter block from a leading markdown thematic break (``---`` … ``---``) that
+# fences prose — the latter must never be treated as frontmatter (never stamped).
+_FRONTMATTER_KEY_RE = re.compile(r"\A[A-Za-z0-9_-]+:(\s|\Z)")
 
 
 def _frontmatter_bounds(lines: list[str]) -> tuple[int, int] | None:
     """Return (open_idx, close_idx) of the frontmatter fences, or None if absent.
 
-    A frontmatter block is a leading ``---`` line and the next ``---`` line.
+    A frontmatter block is a leading ``---`` line, a following ``---`` line, and at
+    least one ``key: value`` line between them. The key-line requirement rejects a
+    leading markdown thematic break wrapping prose, which would otherwise be
+    mis-stamped as frontmatter (F4).
     """
     if not lines or lines[0].strip() != "---":
         return None
     for idx in range(1, len(lines)):
         if lines[idx].strip() == "---":
-            return 0, idx
+            has_key = any(
+                _FRONTMATTER_KEY_RE.match(lines[i].strip()) for i in range(1, idx)
+            )
+            return (0, idx) if has_key else None
     return None
 
 
@@ -312,7 +336,12 @@ def write_format_version(text: str, version: int) -> str:
     if bounds is None:
         raise CannotStampError("file has no frontmatter block to stamp")
     open_idx, close_idx = bounds
-    stamp = f"format_version: {version}"
+    # Match the file's dominant newline so a CRLF file does not gain a bare-LF stamp
+    # line (mixed endings). Lines were split on "\n", so a CRLF line retains its
+    # trailing "\r"; the stamp must carry the same "\r" to rejoin cleanly (F5).
+    crlf = text.count("\r\n")
+    eol = "\r" if crlf > text.count("\n") - crlf else ""
+    stamp = f"format_version: {version}{eol}"
     for idx in range(open_idx + 1, close_idx):
         if re.match(r"\Aformat_version:\s*\d+\s*\Z", lines[idx].strip()):
             lines[idx] = stamp
@@ -389,6 +418,25 @@ MIGRATIONS: tuple[Migration, ...] = (
 # --------------------------------------------------------------------------- #
 # Atomic, backup-first write (BP-187 §4.1-§4.3).
 # --------------------------------------------------------------------------- #
+def _next_backup_path(target: Path) -> str:
+    """Return the first free, collision-safe backup path for ``target``.
+
+    Sequence ``<path>.bak``, ``<path>.bak.1``, ``<path>.bak.2`` … stopping at the
+    first name that does not already exist. ``os.path.lexists`` (not ``exists``) is
+    used so a *symlink* at the candidate counts as occupied — this both (BP-187 §4.5)
+    never silently clobbers an operator's own sibling ``.bak`` nor self-clobbers an
+    earlier backup, AND (BP-187 §4) guarantees the returned path is not an existing
+    symlink, so the subsequent copy cannot follow one into an unrelated file.
+    """
+    base = str(target) + ".bak"
+    if not os.path.lexists(base):
+        return base
+    i = 1
+    while os.path.lexists(f"{base}.{i}"):
+        i += 1
+    return f"{base}.{i}"
+
+
 def atomic_write(
     path: str | os.PathLike[str],
     data: str | bytes,
@@ -397,17 +445,17 @@ def atomic_write(
 ) -> str | None:
     """Write ``data`` to ``path`` crash-atomically, backing up any prior content.
 
-    backup-before-write (``path`` -> ``path.bak``) then write a temp file in the SAME
-    directory -> flush -> fsync -> ``os.replace`` (atomic rename on one filesystem) ->
-    fsync the directory. A crash never leaves a truncated hybrid. Returns the backup
-    path (or None if nothing was backed up).
+    backup-before-write (``path`` -> a collision-safe ``path.bak`` sibling) then write
+    a temp file in the SAME directory -> flush -> fsync -> ``os.replace`` (atomic rename
+    on one filesystem) -> fsync the directory. A crash never leaves a truncated hybrid.
+    Returns the backup path (or None if nothing was backed up).
     """
     target = Path(path)
     payload = data.encode("utf-8") if isinstance(data, str) else data
 
     backup_path: str | None = None
     if backup and target.exists():
-        backup_path = str(target) + ".bak"
+        backup_path = _next_backup_path(target)
         shutil.copy2(target, backup_path)
 
     directory = target.parent
@@ -440,6 +488,32 @@ def atomic_write(
 
 
 # --------------------------------------------------------------------------- #
+# Data-bearing classification — decides whether a REFRESH may raw-overwrite.
+# --------------------------------------------------------------------------- #
+# Classifications for files the operator holds NO data in (fully installer-owned):
+# for these a REFRESH may safely raw-overwrite with the new template. Everything else
+# is treated as data-bearing and migrated forward instead — mirroring the pristine-base
+# fail-safe in :func:`classify` (unknown provenance never takes the destructive path).
+#
+# NOTE (extension point): P1's classification taxonomy is not yet formally defined.
+# Today ``install.sh::_write_pending_updates`` emits only ``MANAGED_MERGE_REQUIRED``
+# (always the CONFLICT quadrant -> data-bearing -> migrate), so the raw-refresh path is
+# unreachable in production. ``INSTALLER_OWNED`` below is a documented PLACEHOLDER — the
+# defense-in-depth hook for a future installer-owned safe-refresh token, NOT an
+# authoritative P1 token.
+_OVERWRITE_SAFE_CLASSIFICATIONS = frozenset({"INSTALLER_OWNED"})
+
+
+def _is_data_bearing(classification: str) -> bool:
+    """True if the entry may carry operator data (=> migrate-forward, never overwrite).
+
+    Fail-safe: only an explicitly installer-owned classification is overwrite-safe;
+    any other, empty, or unknown value is treated as data-bearing.
+    """
+    return classification.strip() not in _OVERWRITE_SAFE_CLASSIFICATIONS
+
+
+# --------------------------------------------------------------------------- #
 # Top-level per-entry reconciliation — ties decision + migration + write together.
 # --------------------------------------------------------------------------- #
 def reconcile_entry(
@@ -452,11 +526,14 @@ def reconcile_entry(
 ) -> ReconcileResult:
     """Reconcile one manifest entry against the operator's on-disk file.
 
-    NO_OP / PRESERVE make no write. REFRESH overwrites with the new template (safe:
-    the user never edited it). CONFLICT — the both-changed case — migrates STRUCTURE
-    forward on the operator's file while preserving DATA; a file already current (or
-    one with no frontmatter to stamp) is a clean "preserved" terminal, never a
-    dead-end. Every write path runs the staleness re-check first and is crash-atomic.
+    NO_OP / PRESERVE make no write. A REFRESH raw-overwrites with the new template only
+    for a NON-data-bearing (fully installer-owned) file; a data-bearing REFRESH is
+    routed through the SAME migrate-forward/preserve path as CONFLICT so operator data
+    is never destroyed (F1 defense-in-depth, BP-187 §3). CONFLICT — the both-changed
+    case — migrates STRUCTURE forward on the operator's file while preserving DATA; a
+    file already current (or one with no frontmatter to stamp) is a clean "preserved"
+    terminal, never a dead-end. Every write path runs the staleness re-check first and
+    is crash-atomic.
     """
     deployed_path = Path(project_root) / entry.path
     decision = classify(entry)
@@ -466,15 +543,22 @@ def reconcile_entry(
     if decision is Decision.PRESERVE:
         return ReconcileResult(entry.id, decision, "preserved", None)
 
-    # REFRESH and CONFLICT both write — re-check staleness before touching disk.
-    check_template = new_template_path if decision is Decision.REFRESH else None
+    # A raw template overwrite is only safe for a REFRESH of a NON-data-bearing file.
+    # A data-bearing REFRESH (and every CONFLICT) migrates structure forward instead.
+    raw_refresh = decision is Decision.REFRESH and not _is_data_bearing(
+        entry.classification
+    )
+
+    # Writing paths re-check staleness before touching disk. Only a raw refresh reads
+    # the new template, so only it re-checks the template's staleness.
+    check_template = new_template_path if raw_refresh else None
     if is_stale(entry, deployed_path=deployed_path, new_template_path=check_template):
         raise StaleManifestError(
             f"{entry.id}: deployed file or template moved since manifest generation; "
             f"regenerate rather than apply stale"
         )
 
-    if decision is Decision.REFRESH:
+    if raw_refresh:
         if new_template_path is None:
             raise ReconcileError(
                 f"{entry.id}: REFRESH requires new_template_path (source content)"
@@ -483,7 +567,7 @@ def reconcile_entry(
         backup_path = atomic_write(deployed_path, content, backup=True)
         return ReconcileResult(entry.id, decision, "refreshed", backup_path)
 
-    # CONFLICT — migrate structure forward, preserve the operator's data.
+    # CONFLICT, or a data-bearing REFRESH — migrate structure forward, preserve data.
     original = deployed_path.read_text(encoding="utf-8")
     migrated = apply_migrations(original, target_version, migrations)
     if migrated == original:

--- a/_ai-memory/pov/skills/aim-content-drift/scripts/reconcile_engine.py
+++ b/_ai-memory/pov/skills/aim-content-drift/scripts/reconcile_engine.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+"""Template-drift reconciliation engine (PLAN-033 P3, grounded in BP-187).
+
+Consumes the frozen ``pending-updates.json`` manifest the installer emits (PLAN-033
+P1 producer, ``install.sh::_write_pending_updates``) and reconciles each drifted
+oversight file **without ever clobbering the operator's data**. This is the
+data-safety-critical core: a bad merge corrupts an operator's accumulated oversight
+data (decision-log entries, task tables, TD records), so every decision is grounded
+in BP-187 and every write is crash-atomic.
+
+Design (W-07 skills-with-scripts, mirrors sibling ``content_drift.py``): this is the
+deterministic, standalone, import-testable engine invoked BY PATH — it has NO
+dependency on ``install.sh`` or the Parzival session-start surface (those are P1 /
+P2). SKILL orchestration decides *when* to run and *how to present*; this module
+does the exact decision, migration, and write mechanics.
+
+Three responsibilities, straight from BP-187:
+
+1. **The 4-outcome decision** (BP-187 §2.2). Two comparisons against the pristine
+   base ``B`` — ``user_edited = D != B`` and ``template_changed = S != B`` — yield
+   ``no-op`` / ``refresh`` / ``preserve`` / ``conflict``. The pristine base is
+   non-negotiable (BP-187 §2.1): when ``B`` is unknown ("" — a legacy pre-manifest
+   file per the P1 producer) we CANNOT prove the file is unedited, so we fail safe to
+   CONFLICT and never blind-refresh.
+
+2. **Structural migration** (BP-187 §3, the Alembic model). Data-bearing oversight
+   files carry user data in an evolving *structure* (frontmatter, INDEX format,
+   headers). A text merge would corrupt them; overwrite would destroy the data. So
+   STRUCTURE evolves via a stamped (``format_version`` in frontmatter), ordered,
+   idempotent migration chain that transforms the operator's on-disk file FORWARD —
+   never ship-new-empty. The operator's DATA (body) rides through untouched.
+
+3. **Write-safety invariants** (BP-187 §4). Every write: backup-before-write, then
+   write-temp (same directory) -> fsync -> atomic rename. A crash leaves either the
+   whole old file or the whole new file, never a truncated hybrid — matters given the
+   documented WSL2 single-file bind-mount corruption risk. A level-triggered
+   staleness re-check runs BEFORE any apply: if the source or deployed file moved
+   since the manifest was generated, we refuse to apply stale (regenerate instead).
+
+Migration ``0001`` establishes the ``format_version`` baseline stamp; the registry is
+the extension point for concrete structural transforms (``0002+``) added as real
+old-vs-new scaffold deltas are identified downstream. The engine itself ships the
+proven machinery + the zero-data-loss guarantee.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import re
+import shutil
+import tempfile
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+# The manifest schema this engine understands. Mirrors the P1 producer's
+# reject-unknown-MAJOR guard (install.sh): a higher MINOR is
+# backward-compatible (additive), a higher MAJOR is not and is refused fail-loud.
+SUPPORTED_SCHEMA_MAJOR = 1
+
+# The current structural format all managed oversight files migrate toward.
+CURRENT_FORMAT_VERSION = 1
+
+
+class ReconcileError(Exception):
+    """Base class for reconciliation failures."""
+
+
+class UnsupportedSchemaError(ReconcileError):
+    """The manifest's schema_version MAJOR is newer than this engine supports."""
+
+
+class StaleManifestError(ReconcileError):
+    """The deployed file or new template moved since the manifest was generated.
+
+    Level-triggered (BP-187 / BP-188): the manifest describes a point-in-time drift
+    state; if the underlying files have since changed, applying it would act on stale
+    inputs. The caller must regenerate the manifest rather than apply this entry.
+    """
+
+
+class MigrationChainError(ReconcileError):
+    """No migration is registered to advance a file from its stamped version."""
+
+
+class CannotStampError(ReconcileError):
+    """The file has no frontmatter block to carry a ``format_version`` stamp."""
+
+
+class Decision(Enum):
+    """The four canonical reconciliation outcomes (BP-187 §2.2)."""
+
+    NO_OP = "no-op"
+    REFRESH = "refresh"
+    PRESERVE = "preserve"
+    CONFLICT = "conflict"
+
+
+@dataclass(frozen=True)
+class ReconcileEntry:
+    """One drifted file from the manifest — the three-state digest triple + metadata.
+
+    Field names mirror the P1 producer's emitted JSON exactly
+    (install.sh::_write_pending_updates).
+    """
+
+    id: str
+    path: str
+    classification: str
+    old_shipped_hash: str  # base B — may be "" for a legacy pre-manifest file
+    deployed_hash: str  # D — the operator's on-disk copy
+    new_template_hash: str  # S — the new shipped template
+    suggested_action: str
+    rationale: str
+    severity: str
+    order: int
+
+
+@dataclass(frozen=True)
+class Manifest:
+    """The whole ``pending-updates.json`` manifest."""
+
+    schema_version: str
+    generated_at: str
+    generated_by: str
+    source_version: str
+    manifest_id: str
+    entries: tuple[ReconcileEntry, ...]
+
+
+@dataclass(frozen=True)
+class Migration:
+    """One structural migration step in the ordered chain (BP-187 §3).
+
+    ``transform`` changes only STRUCTURE and must be zero-data-loss for the operator's
+    body content. The version stamp itself is written by :func:`apply_migrations`
+    after a successful transform, so a transform never has to manage the stamp.
+    """
+
+    from_version: int
+    to_version: int
+    transform: Callable[[str], str]
+    name: str
+
+
+@dataclass(frozen=True)
+class ReconcileResult:
+    """The outcome of reconciling one entry."""
+
+    entry_id: str
+    decision: Decision
+    action_taken: str  # no-op | refreshed | preserved | migrated
+    backup_path: str | None
+
+
+# --------------------------------------------------------------------------- #
+# Hashing — matches the installer's ``_sha256_file`` (sha256sum of raw bytes,
+# lowercase hex), so a staleness re-check compares like-for-like.
+# --------------------------------------------------------------------------- #
+def compute_hash(path: str | os.PathLike[str]) -> str:
+    """Return the sha256 hex digest of a file's raw bytes."""
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+# --------------------------------------------------------------------------- #
+# The 4-outcome decision (BP-187 §2.2).
+# --------------------------------------------------------------------------- #
+def decide(*, user_edited: bool, template_changed: bool) -> Decision:
+    """Map the two comparisons to a reconciliation outcome (the RPM table)."""
+    if not user_edited and not template_changed:
+        return Decision.NO_OP
+    if not user_edited and template_changed:
+        return Decision.REFRESH
+    if user_edited and not template_changed:
+        return Decision.PRESERVE
+    return Decision.CONFLICT
+
+
+def classify(entry: ReconcileEntry) -> Decision:
+    """Classify an entry from its digest triple, failing safe when base is unknown.
+
+    BP-187 §2.1: without a pristine base ``B`` you cannot distinguish "user edited it"
+    from "a new default arrived" — so an empty base forces CONFLICT (never a blind
+    refresh that could clobber operator edits).
+    """
+    base = entry.old_shipped_hash
+    if not base:
+        return Decision.CONFLICT
+    user_edited = entry.deployed_hash != base
+    template_changed = entry.new_template_hash != base
+    return decide(user_edited=user_edited, template_changed=template_changed)
+
+
+# --------------------------------------------------------------------------- #
+# Manifest loading — reject an unknown MAJOR (mirrors the P1 producer guard).
+# --------------------------------------------------------------------------- #
+def load_manifest(path: str | os.PathLike[str]) -> Manifest:
+    """Parse and validate ``pending-updates.json``."""
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+
+    raw_version = str(data.get("schema_version", ""))
+    try:
+        major = int(raw_version.split(".")[0])
+    except (ValueError, IndexError) as exc:
+        raise UnsupportedSchemaError(
+            f"invalid schema_version: {raw_version!r}"
+        ) from exc
+    if major > SUPPORTED_SCHEMA_MAJOR:
+        raise UnsupportedSchemaError(
+            f"unsupported schema_version major {major} "
+            f"(engine supports <= {SUPPORTED_SCHEMA_MAJOR})"
+        )
+
+    entries = tuple(
+        ReconcileEntry(
+            id=e["id"],
+            path=e["path"],
+            classification=e.get("classification", ""),
+            old_shipped_hash=e.get("old_shipped_hash", ""),
+            deployed_hash=e.get("deployed_hash", ""),
+            new_template_hash=e.get("new_template_hash", ""),
+            suggested_action=e.get("suggested_action", ""),
+            rationale=e.get("rationale", ""),
+            severity=e.get("severity", ""),
+            order=int(e.get("order", 0)),
+        )
+        for e in data.get("entries", [])
+    )
+    return Manifest(
+        schema_version=raw_version,
+        generated_at=data.get("generated_at", ""),
+        generated_by=data.get("generated_by", ""),
+        source_version=data.get("source_version", ""),
+        manifest_id=data.get("manifest_id", ""),
+        entries=entries,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Level-triggered staleness re-check (BP-187 §4 / BP-188).
+# --------------------------------------------------------------------------- #
+def is_stale(
+    entry: ReconcileEntry,
+    *,
+    deployed_path: str | os.PathLike[str],
+    new_template_path: str | os.PathLike[str] | None = None,
+) -> bool:
+    """True if the deployed file (or new template) moved since the manifest.
+
+    A missing deployed file is treated as stale — the manifest no longer describes
+    what is on disk.
+    """
+    dpath = Path(deployed_path)
+    if not dpath.exists():
+        return True
+    if compute_hash(dpath) != entry.deployed_hash:
+        return True
+    if new_template_path is not None:
+        tpath = Path(new_template_path)
+        if not tpath.exists() or compute_hash(tpath) != entry.new_template_hash:
+            return True
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# ``format_version`` stamp — lives in the YAML frontmatter block (BP-187 §3 stamp).
+# --------------------------------------------------------------------------- #
+_FRONTMATTER_RE = re.compile(r"\Aformat_version:\s*(\d+)\s*\Z")
+
+
+def _frontmatter_bounds(lines: list[str]) -> tuple[int, int] | None:
+    """Return (open_idx, close_idx) of the frontmatter fences, or None if absent.
+
+    A frontmatter block is a leading ``---`` line and the next ``---`` line.
+    """
+    if not lines or lines[0].strip() != "---":
+        return None
+    for idx in range(1, len(lines)):
+        if lines[idx].strip() == "---":
+            return 0, idx
+    return None
+
+
+def read_format_version(text: str) -> int:
+    """Return the stamped ``format_version`` (0 if no frontmatter / no stamp)."""
+    lines = text.split("\n")
+    bounds = _frontmatter_bounds(lines)
+    if bounds is None:
+        return 0
+    open_idx, close_idx = bounds
+    for line in lines[open_idx + 1 : close_idx]:
+        match = _FRONTMATTER_RE.match(line.strip())
+        if match:
+            return int(match.group(1))
+    return 0
+
+
+def write_format_version(text: str, version: int) -> str:
+    """Upsert ``format_version: <version>`` into the frontmatter block.
+
+    Every non-stamp line is preserved verbatim; only the stamp line is
+    inserted/replaced. Raises :class:`CannotStampError` if there is no frontmatter
+    block to carry the stamp (the caller decides that file is N/A for stamping —
+    never forcing a structural change on a plain-body file).
+    """
+    lines = text.split("\n")
+    bounds = _frontmatter_bounds(lines)
+    if bounds is None:
+        raise CannotStampError("file has no frontmatter block to stamp")
+    open_idx, close_idx = bounds
+    stamp = f"format_version: {version}"
+    for idx in range(open_idx + 1, close_idx):
+        if re.match(r"\Aformat_version:\s*\d+\s*\Z", lines[idx].strip()):
+            lines[idx] = stamp
+            return "\n".join(lines)
+    # No existing stamp: insert just before the closing fence.
+    lines.insert(close_idx, stamp)
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
+# The ordered, idempotent migration chain (BP-187 §3, Alembic model).
+# --------------------------------------------------------------------------- #
+def apply_migrations(
+    text: str,
+    target_version: int,
+    migrations: Sequence[Migration],
+) -> str:
+    """Advance ``text`` from its stamped version up to ``target_version``.
+
+    - Idempotent: already at/above target -> returned unchanged.
+    - Ordered: applies exactly the migrations between current and target, following
+      each migration's ``from_version`` -> ``to_version`` link.
+    - Fail-loud on a gap: a missing migration for the current version raises
+      :class:`MigrationChainError` (never "assume fresh").
+    - N/A-tolerant: if a file cannot carry a stamp (no frontmatter), the structural
+      transform is still applied (zero-data-loss) and the chain stops cleanly — the
+      file is validly reconciled without a stamp, not a dead-end.
+    """
+    current = read_format_version(text)
+    if current >= target_version:
+        return text
+
+    by_from: dict[int, Migration] = {}
+    for mig in migrations:
+        by_from[mig.from_version] = mig
+
+    while current < target_version:
+        mig = by_from.get(current)
+        if mig is None:
+            raise MigrationChainError(
+                f"no migration registered from format_version {current}"
+            )
+        transformed = mig.transform(text)
+        try:
+            text = write_format_version(transformed, mig.to_version)
+        except CannotStampError:
+            # No frontmatter to stamp: the structural transform (if any) is applied
+            # and the file is left un-stamped — a valid terminal, data preserved.
+            return transformed
+        current = mig.to_version
+    return text
+
+
+def _migration_0001_baseline(text: str) -> str:
+    """0001 — establish the ``format_version`` baseline stamp.
+
+    Purely additive: no body change. The stamp itself is written by
+    :func:`apply_migrations`; this transform only marks that a file entering the
+    chain at v0 needs no structural rewrite to reach v1.
+    """
+    return text
+
+
+MIGRATIONS: tuple[Migration, ...] = (
+    Migration(
+        from_version=0,
+        to_version=1,
+        transform=_migration_0001_baseline,
+        name="0001_baseline_format_version_stamp",
+    ),
+)
+
+
+# --------------------------------------------------------------------------- #
+# Atomic, backup-first write (BP-187 §4.1-§4.3).
+# --------------------------------------------------------------------------- #
+def atomic_write(
+    path: str | os.PathLike[str],
+    data: str | bytes,
+    *,
+    backup: bool = True,
+) -> str | None:
+    """Write ``data`` to ``path`` crash-atomically, backing up any prior content.
+
+    backup-before-write (``path`` -> ``path.bak``) then write a temp file in the SAME
+    directory -> flush -> fsync -> ``os.replace`` (atomic rename on one filesystem) ->
+    fsync the directory. A crash never leaves a truncated hybrid. Returns the backup
+    path (or None if nothing was backed up).
+    """
+    target = Path(path)
+    payload = data.encode("utf-8") if isinstance(data, str) else data
+
+    backup_path: str | None = None
+    if backup and target.exists():
+        backup_path = str(target) + ".bak"
+        shutil.copy2(target, backup_path)
+
+    directory = target.parent
+    fd, tmp_name = tempfile.mkstemp(
+        dir=directory, prefix=target.name + ".", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(payload)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_name, target)
+    except BaseException:
+        # Leave the original (and its backup) intact; never a partial target.
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+    # Best-effort: fsync the directory so the rename itself survives a crash.
+    try:
+        dir_fd = os.open(directory, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except OSError:
+        pass
+
+    return backup_path
+
+
+# --------------------------------------------------------------------------- #
+# Top-level per-entry reconciliation — ties decision + migration + write together.
+# --------------------------------------------------------------------------- #
+def reconcile_entry(
+    entry: ReconcileEntry,
+    *,
+    project_root: str | os.PathLike[str],
+    migrations: Sequence[Migration] = MIGRATIONS,
+    target_version: int = CURRENT_FORMAT_VERSION,
+    new_template_path: str | os.PathLike[str] | None = None,
+) -> ReconcileResult:
+    """Reconcile one manifest entry against the operator's on-disk file.
+
+    NO_OP / PRESERVE make no write. REFRESH overwrites with the new template (safe:
+    the user never edited it). CONFLICT — the both-changed case — migrates STRUCTURE
+    forward on the operator's file while preserving DATA; a file already current (or
+    one with no frontmatter to stamp) is a clean "preserved" terminal, never a
+    dead-end. Every write path runs the staleness re-check first and is crash-atomic.
+    """
+    deployed_path = Path(project_root) / entry.path
+    decision = classify(entry)
+
+    if decision is Decision.NO_OP:
+        return ReconcileResult(entry.id, decision, "no-op", None)
+    if decision is Decision.PRESERVE:
+        return ReconcileResult(entry.id, decision, "preserved", None)
+
+    # REFRESH and CONFLICT both write — re-check staleness before touching disk.
+    check_template = new_template_path if decision is Decision.REFRESH else None
+    if is_stale(entry, deployed_path=deployed_path, new_template_path=check_template):
+        raise StaleManifestError(
+            f"{entry.id}: deployed file or template moved since manifest generation; "
+            f"regenerate rather than apply stale"
+        )
+
+    if decision is Decision.REFRESH:
+        if new_template_path is None:
+            raise ReconcileError(
+                f"{entry.id}: REFRESH requires new_template_path (source content)"
+            )
+        content = Path(new_template_path).read_bytes()
+        backup_path = atomic_write(deployed_path, content, backup=True)
+        return ReconcileResult(entry.id, decision, "refreshed", backup_path)
+
+    # CONFLICT — migrate structure forward, preserve the operator's data.
+    original = deployed_path.read_text(encoding="utf-8")
+    migrated = apply_migrations(original, target_version, migrations)
+    if migrated == original:
+        # Already current, or no frontmatter to stamp: data preserved, clean terminal.
+        return ReconcileResult(entry.id, decision, "preserved", None)
+    backup_path = atomic_write(deployed_path, migrated, backup=True)
+    return ReconcileResult(entry.id, decision, "migrated", backup_path)

--- a/_ai-memory/pov/skills/aim-content-drift/scripts/reconcile_helper.py
+++ b/_ai-memory/pov/skills/aim-content-drift/scripts/reconcile_helper.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Session-start reconciliation helper (PLAN-033 P2 — the consumer seam).
+
+Thin orchestration wrapper the Parzival session-start step-files invoke BY PATH,
+keeping those step-files as thin prose (W-07 skills-with-scripts, mirrors how the
+sibling ``reconcile_engine.py`` is invoked). It owns the two mechanics the step-files
+must NOT re-implement in markdown:
+
+1. **Effective-pending filtering with hash-move re-nag suppression.** Reads the frozen
+   ``pending-updates.json`` manifest (P1 producer) and the disposition ledger, and
+   returns only entries the operator still needs to see — an entry with a *terminal*
+   disposition (``applied`` / ``dismissed``) recorded at the SAME ``new_template_hash``
+   is suppressed; it re-surfaces only when that hash MOVES (a genuinely new upstream
+   template), never on a "shown-before" flag. A ``deferred`` entry is recorded for
+   audit but re-surfaces next session (defer == "ask me later", not "stop asking").
+
+2. **Apply-and-record.** For an approved entry it invokes the data-safety-critical
+   ``reconcile_engine.reconcile_entry`` and records the disposition + the engine's
+   ``action_taken`` / ``backup_path`` to the ledger atomically — so a disposition is
+   never recorded for a reconcile that did not actually complete.
+
+This module does NOT change ``reconcile_engine.py`` (P3) or the manifest producer (P1);
+it composes them. It is fail-safe for the ambient surface: a missing or unparseable
+manifest yields an empty result (a silent rollup), never a session-start error.
+
+Ledger: ``<project-root>/.audit/state/reconcile-dispositions.json`` (sibling to the
+manifest). Manifest: ``<project-root>/.audit/state/pending-updates.json``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+# Load the sibling engine by file location (skill scripts are invoked by path, not
+# importable as a package — mirrors tests/test_plan033_p3_reconcile_engine.py).
+_ENGINE_PATH = Path(__file__).resolve().parent / "reconcile_engine.py"
+_spec = importlib.util.spec_from_file_location("reconcile_engine", _ENGINE_PATH)
+engine = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = engine
+_spec.loader.exec_module(engine)
+
+LEDGER_SCHEMA_VERSION = "1.0"
+
+# Terminal dispositions suppress re-surfacing until new_template_hash moves. A
+# "deferred" entry re-surfaces next session (it is recorded only for audit history).
+_TERMINAL_DISPOSITIONS = frozenset({"applied", "dismissed"})
+_VALID_DISPOSITIONS = frozenset({"applied", "deferred", "dismissed"})
+
+# Severity rank for presentation ordering (lower = surfaced first). Unknown severities
+# sort last but are still shown — never silently dropped.
+_SEVERITY_RANK = {"high": 0, "medium": 1, "low": 2}
+_UNKNOWN_SEVERITY_RANK = 99
+
+
+def _manifest_path(project_root: Path) -> Path:
+    return project_root / ".audit" / "state" / "pending-updates.json"
+
+
+def _ledger_path(project_root: Path) -> Path:
+    return project_root / ".audit" / "state" / "reconcile-dispositions.json"
+
+
+def _now() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# --------------------------------------------------------------------------- #
+# Ledger read/write.
+# --------------------------------------------------------------------------- #
+def load_ledger(path: Path) -> dict:
+    """Read the disposition ledger, returning an empty structure if absent/corrupt.
+
+    Fail-safe: a corrupt ledger must not brick the ambient surface. An unreadable
+    ledger is treated as "no dispositions recorded" (every entry re-surfaces) — the
+    conservative direction (show, never silently suppress).
+    """
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        data = {}
+    if not isinstance(data, dict):
+        data = {}
+    dispositions = data.get("dispositions")
+    if not isinstance(dispositions, dict):
+        dispositions = {}
+    data["dispositions"] = dispositions
+    return data
+
+
+def write_ledger(path: Path, ledger: dict) -> None:
+    """Persist the ledger crash-atomically (temp -> fsync -> same-dir rename, no .bak).
+
+    Reuses the engine's proven ``atomic_write`` with ``backup=False`` — a state file
+    does not want a ``.bak`` sibling on every write.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(ledger, indent=2, sort_keys=True) + "\n"
+    engine.atomic_write(path, payload, backup=False)
+
+
+def _is_suppressed(entry, ledger: dict) -> bool:
+    """True if a terminal disposition was recorded at the entry's current hash."""
+    record = ledger.get("dispositions", {}).get(entry.id)
+    if not isinstance(record, dict):
+        return False
+    if record.get("disposition") not in _TERMINAL_DISPOSITIONS:
+        return False
+    return record.get("new_template_hash") == entry.new_template_hash
+
+
+def _severity_sort_key(entry):
+    return (_SEVERITY_RANK.get(entry.severity, _UNKNOWN_SEVERITY_RANK), entry.order)
+
+
+def effective_pending(manifest, ledger: dict) -> list:
+    """Manifest entries the operator still needs to see, severity-ranked.
+
+    Drops entries with a terminal disposition recorded at the same hash (re-nag
+    suppression); keeps everything else (never-disposed, deferred, or hash-moved).
+    """
+    pending = [e for e in manifest.entries if not _is_suppressed(e, ledger)]
+    return sorted(pending, key=_severity_sort_key)
+
+
+def _load_manifest_safe(path: Path):
+    """Load the manifest, returning None if absent or unparseable (silent rollup)."""
+    try:
+        if not path.exists():
+            return None
+        return engine.load_manifest(path)
+    except (
+        engine.ReconcileError,
+        AttributeError,
+        TypeError,
+        OSError,
+        UnicodeDecodeError,
+    ) as exc:
+        sys.stderr.write(
+            f"pending-updates: manifest unreadable, treating as empty: {exc}\n"
+        )
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# `pending` — effective-pending summary + list (step-02 rollup / step-03 list).
+# --------------------------------------------------------------------------- #
+def _severity_tally(entries) -> dict:
+    tally: dict[str, int] = {}
+    for e in entries:
+        tally[e.severity] = tally.get(e.severity, 0) + 1
+    return tally
+
+
+def _rollup_line(entries) -> str:
+    """One-line ambient rollup, or "" when nothing is pending (=> silent)."""
+    if not entries:
+        return ""
+    tally = _severity_tally(entries)
+    ordered = sorted(
+        tally.items(),
+        key=lambda kv: (_SEVERITY_RANK.get(kv[0], _UNKNOWN_SEVERITY_RANK), kv[0]),
+    )
+    parts = ", ".join(f"{n} {sev}" for sev, n in ordered)
+    return f"Pending Updates: {len(entries)} pending ({parts})"
+
+
+def cmd_pending(args) -> int:
+    project_root = Path(args.project_root)
+    manifest = _load_manifest_safe(_manifest_path(project_root))
+    ledger = load_ledger(_ledger_path(project_root))
+    entries = effective_pending(manifest, ledger) if manifest else []
+
+    if args.format == "rollup":
+        line = _rollup_line(entries)
+        if line:
+            print(line)
+        return 0
+
+    result = {
+        "summary": {
+            "total": len(entries),
+            "by_severity": _severity_tally(entries),
+            "manifest_id": manifest.manifest_id if manifest else None,
+        },
+        "entries": [
+            {
+                "id": e.id,
+                "path": e.path,
+                "severity": e.severity,
+                "classification": e.classification,
+                "suggested_action": e.suggested_action,
+                "rationale": e.rationale,
+                "new_template_hash": e.new_template_hash,
+                "order": e.order,
+            }
+            for e in entries
+        ],
+    }
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# `reconcile` — apply/defer/dismiss one entry, record atomically.
+# --------------------------------------------------------------------------- #
+def _record_disposition(
+    ledger: dict,
+    entry,
+    disposition: str,
+    *,
+    action_taken=None,
+    decision=None,
+    backup_path=None,
+) -> None:
+    ledger.setdefault("dispositions", {})[entry.id] = {
+        "disposition": disposition,
+        "new_template_hash": entry.new_template_hash,
+        "decision": decision,
+        "action_taken": action_taken,
+        "backup_path": backup_path,
+        "recorded_at": _now(),
+    }
+    ledger["schema_version"] = LEDGER_SCHEMA_VERSION
+    ledger["updated_at"] = _now()
+
+
+def cmd_reconcile(args) -> int:
+    project_root = Path(args.project_root)
+    disposition = args.disposition
+    if disposition not in _VALID_DISPOSITIONS:
+        print(
+            json.dumps(
+                {"status": "error", "message": f"invalid disposition: {disposition}"}
+            ),
+            file=sys.stderr,
+        )
+        return 2
+
+    manifest = _load_manifest_safe(_manifest_path(project_root))
+    if manifest is None:
+        print(
+            json.dumps({"status": "error", "message": "no manifest to reconcile"}),
+            file=sys.stderr,
+        )
+        return 2
+
+    entry = next((e for e in manifest.entries if e.id == args.id), None)
+    if entry is None:
+        print(
+            json.dumps({"status": "error", "message": f"entry not found: {args.id}"}),
+            file=sys.stderr,
+        )
+        return 2
+
+    ledger_path = _ledger_path(project_root)
+    ledger = load_ledger(ledger_path)
+
+    if disposition != "applied":
+        # defer / dismiss: no engine write; record disposition only.
+        _record_disposition(ledger, entry, disposition)
+        write_ledger(ledger_path, ledger)
+        print(
+            json.dumps(
+                {"status": "ok", "id": entry.id, "disposition": disposition}, indent=2
+            )
+        )
+        return 0
+
+    # applied: run the engine, then record atomically (record only on success).
+    try:
+        result = engine.reconcile_entry(entry, project_root=project_root)
+    except engine.ReconcileError as exc:
+        print(
+            json.dumps(
+                {
+                    "status": "error",
+                    "id": entry.id,
+                    "error_type": type(exc).__name__,
+                    "message": str(exc),
+                },
+                indent=2,
+            ),
+            file=sys.stderr,
+        )
+        return 1
+
+    _record_disposition(
+        ledger,
+        entry,
+        "applied",
+        action_taken=result.action_taken,
+        decision=result.decision.value,
+        backup_path=result.backup_path,
+    )
+    write_ledger(ledger_path, ledger)
+    print(
+        json.dumps(
+            {
+                "status": "ok",
+                "id": entry.id,
+                "disposition": "applied",
+                "decision": result.decision.value,
+                "action_taken": result.action_taken,
+                "backup_path": result.backup_path,
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="PLAN-033 P2 session-start reconciliation helper (manifest + ledger)."
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_pending = sub.add_parser("pending", help="list effective-pending entries")
+    p_pending.add_argument("--project-root", required=True)
+    p_pending.add_argument("--format", choices=["json", "rollup"], default="json")
+    p_pending.set_defaults(func=cmd_pending)
+
+    p_reconcile = sub.add_parser("reconcile", help="apply/defer/dismiss one entry")
+    p_reconcile.add_argument("--project-root", required=True)
+    p_reconcile.add_argument("--id", required=True)
+    p_reconcile.add_argument(
+        "--disposition", required=True, choices=sorted(_VALID_DISPOSITIONS)
+    )
+    p_reconcile.set_defaults(func=cmd_reconcile)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/_ai-memory/pov/workflows/session/close/steps-c/step-02b-update-plan.md
+++ b/_ai-memory/pov/workflows/session/close/steps-c/step-02b-update-plan.md
@@ -10,7 +10,7 @@ nextStepFile: './step-03-create-handoff.md'
 
 ## STEP GOAL:
 
-Bring the active per-initiative plan into sync with what actually happened this session: update item statuses, run the completeness / supersession audit so no plan ends with silent open items, and confirm the done-condition by evidence when the plan is done.
+Bring the active per-initiative plan into sync with what actually happened this session: update item statuses, run the completeness / supersession audit so no plan ends with silent open items, roll a session child back into its master spine row, and confirm the done-condition by evidence when the plan is done.
 
 **Scope:**
 - Available context: Session summary from Step 1, updated tracking from Step 2, plans under `{oversight_path}/plans/`
@@ -29,6 +29,8 @@ Bring the active per-initiative plan into sync with what actually happened this 
 ### 0. Locate the Active Plan
 
 Identify the active plan for this session's work under `{oversight_path}/plans/` — the one whose front-matter `status:` is `active` or `approved` and whose subject matches the worked initiative.
+
+**Exclude any `plan_role: master` plan from this candidate set** — a master is the spine, never "the active plan" being closed; it is updated via Section 4 (Master-Row Roll-Up), not selected here. When no master spine exists, apply the selection below unchanged.
 
 - If none applies (trivial/reactive work with no plan) → note "no active plan" and advance to `{nextStepFile}`.
 - If one applies → proceed.
@@ -64,13 +66,32 @@ If all items are `done` and the plan is being closed:
 
 ---
 
-### 4. Verify Plan State
+### 4. Master-Row Roll-Up (when the active plan is a session child)
+
+If the active plan's front-matter is `plan_role: session`, it MUST roll back into its master spine the **same session** — an unrolled child is an orphan (the #1 way the master stops being SSoT). Using the plan's `master_plan` + `step_id` link, update that master row from **git + live evidence as truth**:
+
+- `Built? (+SHA)` from the merge / commit evidence.
+- `Verified? (mocked)` from the test / CI evidence (a ref, not a bare ✅).
+- `Live-verified?` **only** with an evidence link + date — **never** mark a step Live-verified without one (anti-watermelon: green ≠ runnable). If there is no live-run evidence, leave it unset with the reason.
+- **Derive** the row's `Status` (RAG: `GREEN` / `YELLOW` / `RED` / `—`) from those columns — never hand-set it.
+- Stamp the row's open-issue ids + `Updated` date.
+
+**`step_id: ALL` carve-out:** a spine-wide verification/audit child (`step_id: ALL`) rolls up into **every** master row (a documented exception, not one row), applying the same evidence rules per row.
+
+If the step did not complete this session, the row keeps its prior status, this plan's Continuity Log marks it **carried-over**, and the master's open-child pointer keeps referencing this plan. Flag any session child that closes without rolling into its master row as an orphan anomaly.
+
+If the active plan has no master (`plan_role: standalone` or absent), skip this section.
+
+---
+
+### 5. Verify Plan State
 
 After updates, confirm:
 - Item statuses match the session's actual outcomes; at most one item is `doing`
 - Every open item is accounted for (rolled forward, or plan superseded/abandoned with a reason)
 - Continuity Log records each status change and any supersession/abandonment reason
 - A `done` plan's done-condition was confirmed by evidence before the status flip
+- A `plan_role: session` child rolled up into its master row this session (evidence-linked; no `Live-verified?` without an evidence link + date), or is explicitly marked carried-over (N/A for a standalone plan / no master)
 
 ## CRITICAL STEP COMPLETION NOTE
 

--- a/_ai-memory/pov/workflows/session/start/steps-c/step-02-compile-status.md
+++ b/_ai-memory/pov/workflows/session/start/steps-c/step-02-compile-status.md
@@ -66,6 +66,11 @@ Compile each field from the loaded context:
 - Surface the one-line rollup from the output: `drift: <clean> clean, <stale> stale, <unverified> unverified, <changed> changed, <docs_stale> docs-stale` (the `changed` / `docs-stale` counts come from `drift_rollup`)
 - If no `.sot/registry.yaml` exists, surface the one-line G3 bootstrap nudge instead ("no SOT registry — run `aim-sot detect-propose` to start tracking") — do not fabricate counts
 
+**Pending Updates** (aim-content-drift reconciliation surface — PLAN-033; only when `<project-root>/.audit/state/pending-updates.json` exists):
+- Read-only rollup: `python3 "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/_ai-memory/pov/skills/aim-content-drift/scripts/reconcile_helper.py" pending --project-root <project-root> --format rollup`
+- Surface the single line it emits verbatim (e.g. `Pending Updates: 3 pending (3 high)`) — the count is severity-tallied and already excludes entries the operator applied/dismissed at the current template hash
+- Emits nothing when the manifest is absent OR every entry has been disposed — in that case surface NOTHING (fire-only-on-drift; do not fabricate a "0 pending" line). Detail (the entry list) is on-request only, in Step 3 — never inline it here
+
 **Continuation Point**:
 - Where work should resume based on handoff "Next Steps" or current task status
 

--- a/_ai-memory/pov/workflows/session/start/steps-c/step-02b-plan-bearings.md
+++ b/_ai-memory/pov/workflows/session/start/steps-c/step-02b-plan-bearings.md
@@ -10,7 +10,7 @@ nextStepFile: './step-03-present-and-wait.md'
 
 ## STEP GOAL:
 
-Enrich the status report compiled in Step 2 with plan bearings: load the active per-initiative plan, identify the resume point, and apply the proportionate plan-gate so no initiative is dispatched into a vacuum.
+Enrich the status report compiled in Step 2 with plan bearings: read any master spine first, load the active per-initiative plan, identify the resume point, and apply the proportionate plan-gate (including the stage-gate ordering guard) so no initiative is dispatched into a vacuum.
 
 **Scope:**
 - Available context: The compiled status report from Step 2, plans under `{oversight_path}/plans/`
@@ -26,9 +26,26 @@ Enrich the status report compiled in Step 2 with plan bearings: load the active 
 
 ## Sequence
 
+### 0. Master-First Spine Read (only when a master plan exists)
+
+Before locating a single active plan, check for a master spine: scan the front-matter of plan files under `{oversight_path}/plans/*.md` — those carrying plan front-matter (a `plan_id` or `plan_role` field present) — for a plan with `plan_role: master`. Skip any file with no plan front-matter (e.g. `README.md` / `INDEX.md`); a master need not be named `PLAN-*` (e.g. `MASTER-PIPELINE-PLAN.md`) and is still detected this way.
+
+- **If no `plan_role: master` plan exists** → skip this section and use the single-plan logic in Sections 1–4 unchanged. This preserves today's behavior for projects with no master spine.
+- **If a `plan_role: master` plan exists** → read it FIRST, ahead of any single active plan:
+  1. **Current step** = the first master-spine row, in canonical order, whose `Status` is not `GREEN` (i.e. `RED`, `YELLOW`, or `—`/NOT_STARTED).
+  2. **Recommended resume point** = that current step's open **session child** — the `plan_role: session` plan whose `master_plan` + `step_id` link back to this master row — not merely "the most recent active plan."
+  3. **Orphan-child check (F-10):** any `plan_role: session` plan missing `master_plan` or `step_id` is a plan-integrity anomaly (an orphan child — the #1 SSoT-killer). Flag it (same treatment as the baseline-drift anomaly below); do not resolve it here.
+  4. **`step_id: ALL` carve-out:** a spine-wide verification/audit child may set `step_id: ALL` (a documented exception — it maps to **every** master row, not one). Treat it as a valid session child for the current step, not a mismatch or an orphan.
+
+Fold the spine rollup — current step, recommended session child, any orphan anomaly — into the report, then continue to Section 1 to confirm the active plan against this bearing.
+
+---
+
 ### 1. Locate the Active Plan
 
 Scan `{oversight_path}/plans/PLAN-*.md` filenames (no full reads yet). Identify the plan for the current initiative — the one whose front-matter `status:` is `active` or `approved` and whose subject matches the current task/initiative from the Step 2 report.
+
+**When Section 0 found a master spine:** exclude any `plan_role: master` plan from this candidate set (a master is the spine, never "the active plan") and prefer the current step's session child — the Section 0 resume point — as the active plan. When no master spine exists, apply the selection below unchanged.
 
 - If exactly one active/approved plan matches → that is the active plan.
 - If none exists → record "no active plan" (feeds the gate in Section 3).
@@ -62,11 +79,13 @@ Gate on **scope, never effort or time**. Classify the pending work:
 
 If the pending work is an **initiative** AND no `status: approved | active` plan exists for it, then the first recommended action in Step 3 MUST be **"draft a plan and get user approval before any task dispatch"** — ahead of any execution recommendation.
 
+**Stage-gate ordering (F-09 — applies only when a master spine was read in Section 0):** if the recommended or user-requested next action targets a master step *downstream* of the current step while an upstream row is `RED`, `YELLOW`, or `—`, that downstream step's BUILD / verify-claims work is **gated**. Surface a WARN and require an explicit user override before recommending it in Step 3 — e.g. "upstream ST-NN is not GREEN; downstream BUILD is gated — proceed read-only, or override with a reason." Read-only design / research / story-authoring look-ahead for the downstream step is **not** gated. This is a warn-and-override, not a hard block.
+
 ---
 
 ### 4. Hand Bearings to Step 3
 
-Fold the plan-status rollup, the resume point, any plan/tracking anomaly, and the gate outcome into the compiled report so Step 3's recommendation reflects them. Do not present here.
+Fold the plan-status rollup, the resume point (the current step's session child when a master spine applies), any plan/tracking or orphan-child anomaly, and the gate outcome — including any F-09 stage-gate WARN — into the compiled report so Step 3's recommendation reflects them. Do not present here.
 
 ## CRITICAL STEP COMPLETION NOTE
 

--- a/_ai-memory/pov/workflows/session/start/steps-c/step-03-present-and-wait.md
+++ b/_ai-memory/pov/workflows/session/start/steps-c/step-03-present-and-wait.md
@@ -110,6 +110,37 @@ After presenting:
 - Do NOT start executing any tasks until user confirms
 - WAIT for the user to give explicit direction
 
+---
+
+### 5. On-Request: Reconcile Pending Updates (only when the operator asks)
+
+This is a REACTIVE branch, NOT a gate and NOT a mandatory step. Step 2's "Pending Updates" rollup already told the operator the count; this workflow still terminates normally at the wait above. Enter this branch ONLY when the operator explicitly asks to see or act on pending updates (e.g. "show pending", "reconcile the updates", "what are the pending updates?"). Never auto-expand it, and never inline it into the status report.
+
+**5.1 — List (count + pointer, never inline diffs).** Run:
+
+```
+python3 "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/_ai-memory/pov/skills/aim-content-drift/scripts/reconcile_helper.py" pending --project-root <project-root>
+```
+
+Present the returned `entries` severity-ranked as a numbered list — for each: `#n` · severity · `path` · one-line `rationale` · `classification`. State the count. Do NOT inline file contents or diffs (BP-159 index-not-log); the `path` is the pointer the operator opens if they want the detail. If the list is empty, say so and stop.
+
+**5.2 — Operator selects scope.** Ask which to reconcile: **all**, a specific **#n**, or **defer** (stop here — the workflow stays terminal, nothing is recorded). WAIT for the choice.
+
+**5.3 — Reconcile chosen entries ONE AT A TIME.** For each selected entry, in severity-rank order:
+- Restate the single entry (path · severity · rationale).
+- Ask the operator for a per-entry disposition: **approve** / **defer** / **dismiss**. WAIT.
+- Invoke it (map approve→`applied`, defer→`deferred`, dismiss→`dismissed`):
+
+  ```
+  python3 "${AI_MEMORY_INSTALL_DIR:-$HOME/.ai-memory}/_ai-memory/pov/skills/aim-content-drift/scripts/reconcile_helper.py" reconcile --project-root <project-root> --id <entry-id> --disposition <applied|deferred|dismissed>
+  ```
+
+- For **approve/applied** the helper runs the reconciliation engine (backup-before-write, crash-atomic, staleness-checked) and reports `decision` + `action_taken` (migrated | preserved | no-op | refreshed) + `backup_path`. Relay that outcome factually. On a non-zero status, the helper's JSON error payload carries an `error_type`. If `error_type` is `StaleManifestError`, the manifest is stale — tell the operator to re-run the installer to regenerate it. For any OTHER `error_type` (e.g. `MigrationChainError`), surface the `error_type` and the engine's message factually — do NOT tell the operator to re-run the installer, and do NOT retry or hand-edit either.
+- The helper records the disposition to `<project-root>/.audit/state/reconcile-dispositions.json`, keyed to the entry id + its current `new_template_hash`. A disposed entry will NOT re-surface at Step 2 unless that template hash moves in a later install.
+- Move to the next selected entry only after the current one is recorded.
+
+**5.4 — Close.** After the selected entries are processed, return to the terminal wait ("What would you like to do?"). Do not start unrelated work off the back of this branch.
+
 ## TERMINATION STEP PROTOCOLS:
 
 - This is a FINAL step — workflow completion required

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5871,8 +5871,16 @@ _sync_oversight_templates() {
     local n_new=0 n_sync=0 n_migrate=0 n_warn=0
 
     # Collect both-changed entries for the pending-change manifest (deploy only).
+    # Producer-only path: a temp-alloc failure (restricted/unwritable TMPDIR) must
+    # NOT abort the oversight-template deploy. The `if !` runs mktemp in a
+    # set-e-exempt context; on failure we degrade to a warning and skip the emit.
     local pending_tsv=""
-    [[ "$mode" == "deploy" ]] && pending_tsv="$(mktemp)"
+    if [[ "$mode" == "deploy" ]]; then
+        if ! pending_tsv="$(mktemp 2>/dev/null)"; then
+            log_warning "pending-updates: temp alloc failed (non-fatal); skipping emit"
+            pending_tsv=""
+        fi
+    fi
 
     if [[ ! -d "$tmpl_source" ]]; then
         log_warning "Oversight templates not found at $tmpl_source"
@@ -5956,7 +5964,9 @@ _sync_oversight_templates() {
                     old_base="$known_hashes"
                 fi
             fi
-            printf '%s\t%s\t%s\t%s\n' "$rel_path" "$old_base" "$h_project" "$h_shipped" >> "$pending_tsv"
+            # Skip when temp alloc failed (empty path); `|| true` tolerates a
+            # mid-loop write failure (e.g. ENOSPC) without aborting under set -e.
+            [[ -n "$pending_tsv" ]] && { printf '%s\t%s\t%s\t%s\n' "$rel_path" "$old_base" "$h_project" "$h_shipped" >> "$pending_tsv" || true; }
         fi
         [[ "$mode" == "check" ]] && echo "  [warn]    oversight/$rel_path (locally-modified → needs-merge)"
     done < <(find "$tmpl_source" -type f)
@@ -5967,11 +5977,14 @@ _sync_oversight_templates() {
         # Producer-only + additive: the emit MUST NOT break the install. Guard it
         # so any failure degrades to a warning (the `if !` also runs it in a
         # set-e-checked context) instead of aborting the Parzival-setup sequence.
-        if ! _write_pending_updates "$pending_manifest" "$pending_tsv" \
-            "install.sh@${INSTALLER_VERSION}" "$INSTALLER_VERSION"; then
-            log_warning "pending-updates.json emit failed (non-fatal); continuing install"
+        # Empty path => temp alloc failed upstream: nothing to emit, skip entirely.
+        if [[ -n "$pending_tsv" ]]; then
+            if ! _write_pending_updates "$pending_manifest" "$pending_tsv" \
+                "install.sh@${INSTALLER_VERSION}" "$INSTALLER_VERSION"; then
+                log_warning "pending-updates.json emit failed (non-fatal); continuing install"
+            fi
+            rm -f "$pending_tsv"
         fi
-        rm -f "$pending_tsv"
     fi
 
     if [[ "$mode" == "check" ]]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3863,13 +3863,43 @@ detect_codex_cli() {
     command -v codex >/dev/null 2>&1
 }
 
+# BUG-529: project-adapter-presence detection. An IDE whose AI-Memory adapters
+# are already deployed in the *project* must be refreshed on a normal update,
+# even when its CLI is absent from the current machine's PATH — otherwise those
+# adapters permanently drift. Markers mirror what write_<ide>_config deploys.
+detect_gemini_project() {
+    local project_path="$1"
+    [[ -f "$project_path/.gemini/settings.json" ]] || [[ -f "$project_path/AI-MEMORY.md" ]]
+}
+
+detect_cursor_project() {
+    local project_path="$1"
+    [[ -f "$project_path/.cursor/hooks.json" ]] || [[ -d "$project_path/.cursor/skills" ]] || [[ -f "$project_path/.cursor/rules/ai-memory.mdc" ]]
+}
+
+detect_codex_project() {
+    local project_path="$1"
+    [[ -f "$project_path/.codex/hooks.json" ]] || [[ -d "$project_path/.codex/skills" ]] || [[ -d "$project_path/.agents/skills" ]]
+}
+
 parse_ide_flag() {
     local flag="$1"
+    local project_path="${2:-}"
     if [[ -z "$flag" ]]; then
+        # Auto-detect: UNION machine-CLI presence with already-deployed
+        # project-adapter presence (BUG-529). Each IDE is added at most once
+        # (short-circuit ||), so no duplicate tokens. Explicit --ide / none
+        # (handled below) bypass auto-detect entirely.
         local detected=""
-        detect_gemini_cli && detected="$detected gemini"
-        detect_cursor_ide && detected="$detected cursor"
-        detect_codex_cli && detected="$detected codex"
+        if detect_gemini_cli || { [[ -n "$project_path" ]] && detect_gemini_project "$project_path"; }; then
+            detected="$detected gemini"
+        fi
+        if detect_cursor_ide || { [[ -n "$project_path" ]] && detect_cursor_project "$project_path"; }; then
+            detected="$detected cursor"
+        fi
+        if detect_codex_cli || { [[ -n "$project_path" ]] && detect_codex_project "$project_path"; }; then
+            detected="$detected codex"
+        fi
         echo "$detected"
     elif [[ "$flag" == "none" ]]; then
         echo ""
@@ -4168,7 +4198,7 @@ configure_multi_ide() {
     local force="${5:-false}"
 
     local ide_list
-    ide_list=$(parse_ide_flag "$ide_flag")
+    ide_list=$(parse_ide_flag "$ide_flag" "$project_path")
 
     if [[ -z "$ide_list" ]]; then
         log_info "No additional IDEs detected — Claude Code hooks already configured"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3867,19 +3867,32 @@ detect_codex_cli() {
 # are already deployed in the *project* must be refreshed on a normal update,
 # even when its CLI is absent from the current machine's PATH — otherwise those
 # adapters permanently drift. Markers mirror what write_<ide>_config deploys.
+#
+# Detection requires AI-Memory *ownership*, not bare per-IDE path existence:
+# generic native configs (.gemini/settings.json, .cursor/hooks.json,
+# .codex/hooks.json) count only when they CONTAIN the AI_MEMORY_INSTALL_DIR
+# marker (mirroring the write_<ide>_config force-gate grep), and skill presence
+# is scoped to the ai-memory-named subskill dir (search-memory) rather than the
+# bare skills/ dir. This prevents a user's unrelated hand-written native config
+# from being selected and then wholesale-overwritten by write_<ide>_config.
 detect_gemini_project() {
     local project_path="$1"
-    [[ -f "$project_path/.gemini/settings.json" ]] || [[ -f "$project_path/AI-MEMORY.md" ]]
+    { [[ -f "$project_path/.gemini/settings.json" ]] && grep -q "AI_MEMORY_INSTALL_DIR" "$project_path/.gemini/settings.json" 2>/dev/null; } \
+        || [[ -f "$project_path/AI-MEMORY.md" ]]
 }
 
 detect_cursor_project() {
     local project_path="$1"
-    [[ -f "$project_path/.cursor/hooks.json" ]] || [[ -d "$project_path/.cursor/skills" ]] || [[ -f "$project_path/.cursor/rules/ai-memory.mdc" ]]
+    { [[ -f "$project_path/.cursor/hooks.json" ]] && grep -q "AI_MEMORY_INSTALL_DIR" "$project_path/.cursor/hooks.json" 2>/dev/null; } \
+        || [[ -d "$project_path/.cursor/skills/search-memory" ]] \
+        || [[ -f "$project_path/.cursor/rules/ai-memory.mdc" ]]
 }
 
 detect_codex_project() {
     local project_path="$1"
-    [[ -f "$project_path/.codex/hooks.json" ]] || [[ -d "$project_path/.codex/skills" ]] || [[ -d "$project_path/.agents/skills" ]]
+    { [[ -f "$project_path/.codex/hooks.json" ]] && grep -q "AI_MEMORY_INSTALL_DIR" "$project_path/.codex/hooks.json" 2>/dev/null; } \
+        || [[ -d "$project_path/.codex/skills/search-memory" ]] \
+        || [[ -d "$project_path/.agents/skills/search-memory" ]]
 }
 
 parse_ide_flag() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5876,6 +5876,16 @@ _sync_oversight_templates() {
     # set-e-exempt context; on failure we degrade to a warning and skip the emit.
     local pending_tsv=""
     if [[ "$mode" == "deploy" ]]; then
+        # Temp cleanup runs on EVERY return path via a RETURN trap, so removing the
+        # temp can never abort the install under set -e: `rm -f` still exits non-zero
+        # on an unremovable temp (read-only TMPDIR remounted mid-run / immutable bit /
+        # ACL), but the trap's `|| true` makes cleanup abort-proof by construction.
+        # (Verified: a RETURN trap preserves the function's return status, so check
+        # mode's drift=1 signal is unaffected.) Without `functrace` the trap also
+        # fires once when the caller wrapper returns, where the local is out of
+        # scope — `${pending_tsv:-}` keeps that no-op firing safe under set -u; it
+        # does not leak to unrelated later calls.
+        trap 'rm -f "${pending_tsv:-}" 2>/dev/null || true' RETURN
         if ! pending_tsv="$(mktemp 2>/dev/null)"; then
             log_warning "pending-updates: temp alloc failed (non-fatal); skipping emit"
             pending_tsv=""
@@ -5884,8 +5894,7 @@ _sync_oversight_templates() {
 
     if [[ ! -d "$tmpl_source" ]]; then
         log_warning "Oversight templates not found at $tmpl_source"
-        [[ -n "$pending_tsv" ]] && rm -f "$pending_tsv"
-        return 0
+        return 0  # RETURN trap cleans up pending_tsv on this path
     fi
 
     [[ "$mode" == "deploy" ]] && mkdir -p "$oversight_dest"
@@ -5959,7 +5968,11 @@ _sync_oversight_templates() {
             local old_base="$h_recorded"
             if [[ -z "$old_base" ]]; then
                 local known_hashes
-                known_hashes="$(_known_template_hashes "$rel_path" "$registry")"
+                # Producer-only base-B lookup: `|| true` inside the substitution keeps
+                # an awk read error (unreadable registry) from propagating non-zero
+                # under set -e; on failure known_hashes="" degrades base B to empty
+                # (same as the ambiguous-base path) instead of aborting the deploy.
+                known_hashes="$(_known_template_hashes "$rel_path" "$registry" || true)"
                 if [[ -n "$known_hashes" && "$(printf '%s\n' "$known_hashes" | wc -l)" -eq 1 ]]; then
                     old_base="$known_hashes"
                 fi
@@ -5983,8 +5996,9 @@ _sync_oversight_templates() {
                 "install.sh@${INSTALLER_VERSION}" "$INSTALLER_VERSION"; then
                 log_warning "pending-updates.json emit failed (non-fatal); continuing install"
             fi
-            rm -f "$pending_tsv"
         fi
+        # pending_tsv cleanup happens in the RETURN trap (armed above), so it runs on
+        # every exit path and can never abort the install.
     fi
 
     if [[ "$mode" == "check" ]]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5792,7 +5792,9 @@ except FileNotFoundError:
 if not rows:
     try:
         os.remove(out)
-    except FileNotFoundError:
+    except OSError:
+        # Absent (nothing to remove) or unremovable (e.g. read-only dir): the
+        # emit is best-effort and must never abort the install.
         pass
     sys.exit(0)
 
@@ -5836,14 +5838,24 @@ manifest = {
     "entries": entries,
 }
 
-os.makedirs(os.path.dirname(out), exist_ok=True)
 tmp = out + ".tmp"
-with open(tmp, "w") as fh:
-    json.dump(manifest, fh, indent=2, sort_keys=True)
-    fh.write("\n")
-    fh.flush()
-    os.fsync(fh.fileno())
-os.replace(tmp, out)  # same-dir atomic rename (crash-safe; BP-187 write-safety)
+try:
+    os.makedirs(os.path.dirname(out), exist_ok=True)
+    with open(tmp, "w") as fh:
+        json.dump(manifest, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+        fh.flush()
+        os.fsync(fh.fileno())
+    os.replace(tmp, out)  # same-dir atomic rename (crash-safe; BP-187 write-safety)
+except Exception as e:  # noqa: BLE001 - emit is best-effort; never abort the install
+    # PermissionError / ENOSPC / os.replace failure etc.: clean up the temp and
+    # exit 0 so the producer-only emit can never propagate non-zero under set -e.
+    try:
+        os.remove(tmp)
+    except OSError:
+        pass
+    sys.stderr.write(f"pending-updates: emit failed (non-fatal): {e}\n")
+    sys.exit(0)
 PY
 }
 
@@ -5864,6 +5876,7 @@ _sync_oversight_templates() {
 
     if [[ ! -d "$tmpl_source" ]]; then
         log_warning "Oversight templates not found at $tmpl_source"
+        [[ -n "$pending_tsv" ]] && rm -f "$pending_tsv"
         return 0
     fi
 
@@ -5930,11 +5943,19 @@ _sync_oversight_templates() {
         log_warning "template drifted + upstream changed; review + merge: oversight/$rel_path"
         # Additionally record the three-state digest triple for the pending-change
         # manifest so the in-project Parzival can reconcile it under review (P2/P3).
-        # old_shipped_hash (base B): recorded deploy hash, else last known prior-shipped
-        # hash for this path, else "" for a legacy pre-manifest file.
+        # old_shipped_hash (base B): recorded deploy hash, else the sole known
+        # prior-shipped hash for this path. The registry is sort -u (lexicographic,
+        # not chronological), so if MULTIPLE prior hashes exist the latest-shipped
+        # is not identifiable — leave base B "" rather than guess a wrong base.
         if [[ "$mode" == "deploy" ]]; then
             local old_base="$h_recorded"
-            [[ -z "$old_base" ]] && old_base="$(_known_template_hashes "$rel_path" "$registry" | tail -n 1)"
+            if [[ -z "$old_base" ]]; then
+                local known_hashes
+                known_hashes="$(_known_template_hashes "$rel_path" "$registry")"
+                if [[ -n "$known_hashes" && "$(printf '%s\n' "$known_hashes" | wc -l)" -eq 1 ]]; then
+                    old_base="$known_hashes"
+                fi
+            fi
             printf '%s\t%s\t%s\t%s\n' "$rel_path" "$old_base" "$h_project" "$h_shipped" >> "$pending_tsv"
         fi
         [[ "$mode" == "check" ]] && echo "  [warn]    oversight/$rel_path (locally-modified → needs-merge)"
@@ -5943,8 +5964,13 @@ _sync_oversight_templates() {
     # Emit/replace the pending-change manifest from the collected both-changed
     # entries (empty => stale manifest removed). Additive; deploy path only.
     if [[ "$mode" == "deploy" ]]; then
-        _write_pending_updates "$pending_manifest" "$pending_tsv" \
-            "install.sh@${INSTALLER_VERSION}" "$INSTALLER_VERSION"
+        # Producer-only + additive: the emit MUST NOT break the install. Guard it
+        # so any failure degrades to a warning (the `if !` also runs it in a
+        # set-e-checked context) instead of aborting the Parzival-setup sequence.
+        if ! _write_pending_updates "$pending_manifest" "$pending_tsv" \
+            "install.sh@${INSTALLER_VERSION}" "$INSTALLER_VERSION"; then
+            log_warning "pending-updates.json emit failed (non-fatal); continuing install"
+        fi
         rm -f "$pending_tsv"
     fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5707,6 +5707,146 @@ with open(p, "w") as fh:
 PY
 }
 
+# ---------------------------------------------------------------------------
+# Pending-change manifest (PLAN-033 P1 / BP-188)
+#
+# When _sync_oversight_templates finds an oversight file that is BOTH
+# user-modified AND changed upstream (the n_warn "needs-merge" branch), the
+# installer additionally emits a machine-readable pending-change manifest at a
+# fixed project-audit path. The long-lived in-project Parzival discovers it at
+# session-start (PLAN-033 P2) and reconciles each entry under human review
+# (P3) — so a shipped structural update reaches the operator's data-bearing
+# files WITHOUT the installer ever clobbering their data.
+#
+# This is additive/producer-only: it never mutates user data and never changes
+# the existing new/sync/migrate/warn behavior (the log_warning STAYS).
+#
+#   $PROJECT_PATH/.audit/state/pending-updates.json
+#       JSON, schema per BP-188 §3.2; sibling to oversight-templates.manifest.
+# ---------------------------------------------------------------------------
+
+# Manifest schema version (Terraform format_version semantics: bump MINOR for
+# backward-compatible additions; a consumer REJECTS an unknown MAJOR).
+_PENDING_UPDATES_SCHEMA_VERSION="1.0"
+
+# Consumer-side read guard (P1 fail-loud stub the P2 discovery builds on): read
+# pending-updates.json and REJECT an unknown MAJOR schema_version (accepts a
+# newer minor within the known major). Absent file => nothing pending => ok.
+# Returns non-zero + stderr on an unsupported major or unparseable manifest.
+_pending_updates_schema_ok() {
+    local manifest="$1"
+    [[ -f "$manifest" ]] || return 0
+    python3 - "$manifest" "$_PENDING_UPDATES_SCHEMA_VERSION" <<'PY'
+import json, sys
+path, known = sys.argv[1], sys.argv[2]
+known_major = int(known.split(".")[0])
+try:
+    with open(path) as fh:
+        d = json.load(fh)
+    major = int(str(d.get("schema_version", "")).split(".")[0])
+except Exception as e:  # noqa: BLE001 - fail loud on any malformed manifest
+    sys.stderr.write(f"pending-updates: invalid manifest/schema_version: {e}\n")
+    sys.exit(2)
+if major != known_major:
+    sys.stderr.write(
+        f"pending-updates: unsupported schema_version major {major} "
+        f"(this installer understands major {known_major})\n"
+    )
+    sys.exit(2)
+PY
+}
+
+# Emit/replace the pending-updates.json manifest from the collected both-changed
+# entries. $1 = manifest path, $2 = TSV entries file (one
+# "rel_path\told_shipped\tdeployed\tnew_template" line per both-changed file),
+# $3 = generated_by, $4 = source_version. An empty/absent entries file REMOVES
+# any stale manifest (level-triggered: absence = nothing pending, BP-188 §3.3).
+# manifest_id is content-derived so the same drift state always yields the same
+# id — a re-run REPLACES the whole file, never appends duplicate entries.
+_write_pending_updates() {
+    local out="$1" entries_tsv="$2" gen_by="$3" src_ver="$4"
+    python3 - "$out" "$entries_tsv" "$gen_by" "$src_ver" \
+        "$_PENDING_UPDATES_SCHEMA_VERSION" <<'PY'
+import datetime
+import hashlib
+import json
+import os
+import sys
+
+out, tsv, gen_by, src_ver, schema_version = sys.argv[1:6]
+
+rows = []
+try:
+    with open(tsv) as fh:
+        for line in fh:
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            rel, old, dep, new = line.split("\t")
+            rows.append((rel, old, dep, new))
+except FileNotFoundError:
+    rows = []
+
+# Level-triggered: no pending entries => remove any stale manifest so the
+# consumer's presence-of-file discovery reads "nothing pending".
+if not rows:
+    try:
+        os.remove(out)
+    except FileNotFoundError:
+        pass
+    sys.exit(0)
+
+rows.sort(key=lambda r: r[0])
+entries = []
+for order, (rel, old, dep, new) in enumerate(rows):
+    entries.append(
+        {
+            "id": rel,
+            "path": f"oversight/{rel}",
+            # Both-changed = BP-187 4-outcome "conflict": user edits AND upstream
+            # both moved since the last-shipped base -> 3-way merge required.
+            "classification": "MANAGED_MERGE_REQUIRED",
+            "old_shipped_hash": old,  # base B (may be "" for a legacy pre-manifest file)
+            "deployed_hash": dep,
+            "new_template_hash": new,
+            "suggested_action": "merge",
+            "rationale": (
+                "Local edits and upstream template both changed since last "
+                "deploy; 3-way merge required to preserve user data while "
+                "adopting the structural update."
+            ),
+            "severity": "high",
+            "order": order,
+        }
+    )
+
+# Whole-manifest idempotency key: content-derived over the canonical entries, so
+# the same drift state always yields the same manifest_id.
+canon = json.dumps(entries, sort_keys=True, separators=(",", ":"))
+manifest_id = hashlib.sha256(canon.encode()).hexdigest()
+
+manifest = {
+    "schema_version": schema_version,
+    "generated_at": datetime.datetime.now(datetime.timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    ),
+    "generated_by": gen_by,
+    "source_version": src_ver,
+    "manifest_id": manifest_id,
+    "entries": entries,
+}
+
+os.makedirs(os.path.dirname(out), exist_ok=True)
+tmp = out + ".tmp"
+with open(tmp, "w") as fh:
+    json.dump(manifest, fh, indent=2, sort_keys=True)
+    fh.write("\n")
+    fh.flush()
+    os.fsync(fh.fileno())
+os.replace(tmp, out)  # same-dir atomic rename (crash-safe; BP-187 write-safety)
+PY
+}
+
 # Core engine. $1 = "deploy" (apply) | "check" (dry-run, report + exit code).
 # Uses globals INSTALL_DIR + PROJECT_PATH. Silent when everything is in-sync.
 _sync_oversight_templates() {
@@ -5715,7 +5855,12 @@ _sync_oversight_templates() {
     local oversight_dest="$PROJECT_PATH/oversight"
     local registry="$INSTALL_DIR/templates/known-oversight-template-versions.txt"
     local manifest="$PROJECT_PATH/.audit/state/oversight-templates.manifest"
+    local pending_manifest="$PROJECT_PATH/.audit/state/pending-updates.json"
     local n_new=0 n_sync=0 n_migrate=0 n_warn=0
+
+    # Collect both-changed entries for the pending-change manifest (deploy only).
+    local pending_tsv=""
+    [[ "$mode" == "deploy" ]] && pending_tsv="$(mktemp)"
 
     if [[ ! -d "$tmpl_source" ]]; then
         log_warning "Oversight templates not found at $tmpl_source"
@@ -5783,8 +5928,25 @@ _sync_oversight_templates() {
         # Otherwise the copy is locally modified → never clobber; warn loudly.
         n_warn=$((n_warn + 1))
         log_warning "template drifted + upstream changed; review + merge: oversight/$rel_path"
+        # Additionally record the three-state digest triple for the pending-change
+        # manifest so the in-project Parzival can reconcile it under review (P2/P3).
+        # old_shipped_hash (base B): recorded deploy hash, else last known prior-shipped
+        # hash for this path, else "" for a legacy pre-manifest file.
+        if [[ "$mode" == "deploy" ]]; then
+            local old_base="$h_recorded"
+            [[ -z "$old_base" ]] && old_base="$(_known_template_hashes "$rel_path" "$registry" | tail -n 1)"
+            printf '%s\t%s\t%s\t%s\n' "$rel_path" "$old_base" "$h_project" "$h_shipped" >> "$pending_tsv"
+        fi
         [[ "$mode" == "check" ]] && echo "  [warn]    oversight/$rel_path (locally-modified → needs-merge)"
     done < <(find "$tmpl_source" -type f)
+
+    # Emit/replace the pending-change manifest from the collected both-changed
+    # entries (empty => stale manifest removed). Additive; deploy path only.
+    if [[ "$mode" == "deploy" ]]; then
+        _write_pending_updates "$pending_manifest" "$pending_tsv" \
+            "install.sh@${INSTALLER_VERSION}" "$INSTALLER_VERSION"
+        rm -f "$pending_tsv"
+    fi
 
     if [[ "$mode" == "check" ]]; then
         if (( n_new + n_sync + n_migrate + n_warn == 0 )); then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3877,8 +3877,9 @@ detect_codex_cli() {
 # from being selected and then wholesale-overwritten by write_<ide>_config.
 detect_gemini_project() {
     local project_path="$1"
+    # Load-bearing detection marker: must stay in sync with the H1 in src/memory/adapters/templates/gemini/ai-memory.md — guarded by test_gemini_detection_marker_parity.
     { [[ -f "$project_path/.gemini/settings.json" ]] && grep -q "AI_MEMORY_INSTALL_DIR" "$project_path/.gemini/settings.json" 2>/dev/null; } \
-        || [[ -f "$project_path/AI-MEMORY.md" ]]
+        || { [[ -f "$project_path/AI-MEMORY.md" ]] && grep -q "# AI Memory — Agent Guidance" "$project_path/AI-MEMORY.md" 2>/dev/null; }
 }
 
 detect_cursor_project() {
@@ -3892,7 +3893,8 @@ detect_codex_project() {
     local project_path="$1"
     { [[ -f "$project_path/.codex/hooks.json" ]] && grep -q "AI_MEMORY_INSTALL_DIR" "$project_path/.codex/hooks.json" 2>/dev/null; } \
         || [[ -d "$project_path/.codex/skills/search-memory" ]] \
-        || [[ -d "$project_path/.agents/skills/search-memory" ]]
+        || [[ -d "$project_path/.agents/skills/search-memory" ]] \
+        || grep -q "BEGIN AI-MEMORY" "$project_path/AGENTS.md" 2>/dev/null
 }
 
 parse_ide_flag() {

--- a/templates/oversight/plans/PLAN_TEMPLATE.md
+++ b/templates/oversight/plans/PLAN_TEMPLATE.md
@@ -2,6 +2,9 @@
 plan_id: PLAN-<SLUG>-<YYYY-MM-DD>
 type: build | ops | maintenance | verification | research
 status: draft | approved | active | done | superseded | abandoned
+plan_role: standalone | master | session   # optional; default standalone
+master_plan: <path to MASTER plan | none>  # required when plan_role: session
+step_id: <ST-NN | ALL | none>              # required when plan_role: session (ALL = spine-wide verification/audit child)
 previous_plan: <PLAN-… filename | none>
 previous_completed: yes | no | n/a
 approved_by: <user> | pending

--- a/tests/test_install_bug529_adapter_refresh.py
+++ b/tests/test_install_bug529_adapter_refresh.py
@@ -67,20 +67,32 @@ parse_ide_flag "{flag}" "{project}"
     return result.stdout.split()
 
 
+# A hooks.json / settings.json counts as an ai-memory adapter only when it
+# CONTAINS the AI_MEMORY_INSTALL_DIR marker (mirrors the write_<ide>_config
+# force-gate grep). These helpers deploy a genuine, marked install.
+_MARKED_HOOKS = '{"env": {"AI_MEMORY_INSTALL_DIR": "/home/u/.ai-memory"}}'
+
+
 def _deploy_cursor(project: Path) -> None:
     (project / ".cursor").mkdir(parents=True, exist_ok=True)
-    (project / ".cursor" / "hooks.json").write_text("{}", encoding="utf-8")
+    (project / ".cursor" / "hooks.json").write_text(_MARKED_HOOKS, encoding="utf-8")
+    (project / ".cursor" / "skills" / "search-memory").mkdir(
+        parents=True, exist_ok=True
+    )
 
 
 def _deploy_codex(project: Path) -> None:
     (project / ".codex").mkdir(parents=True, exist_ok=True)
-    (project / ".codex" / "hooks.json").write_text("{}", encoding="utf-8")
-    (project / ".agents" / "skills").mkdir(parents=True, exist_ok=True)
+    (project / ".codex" / "hooks.json").write_text(_MARKED_HOOKS, encoding="utf-8")
+    (project / ".codex" / "skills" / "search-memory").mkdir(parents=True, exist_ok=True)
+    (project / ".agents" / "skills" / "search-memory").mkdir(
+        parents=True, exist_ok=True
+    )
 
 
 def _deploy_gemini(project: Path) -> None:
     (project / ".gemini").mkdir(parents=True, exist_ok=True)
-    (project / ".gemini" / "settings.json").write_text("{}", encoding="utf-8")
+    (project / ".gemini" / "settings.json").write_text(_MARKED_HOOKS, encoding="utf-8")
 
 
 class TestProjectAdapterPresenceSelectsIDE:
@@ -145,6 +157,95 @@ parse_ide_flag "" "{project}"
         )
         assert result.returncode == 0, result.stderr
         assert result.stdout.split() == ["gemini"]
+
+
+class TestOwnershipMarkerRequiredForNativeConfig:
+    """BUG-529 fix-r1 (HIGH clobber defect): a generic per-IDE native config
+    (.gemini/settings.json, .cursor/hooks.json, .codex/hooks.json) is
+    AI-Memory-owned — and therefore selectable/refreshable — ONLY when it
+    contains the AI_MEMORY_INSTALL_DIR marker. A user's unrelated hand-written
+    native config lacking the marker must NOT be selected, because
+    write_<ide>_config would otherwise wholesale-overwrite it (silent data loss).
+    Skill presence is scoped to the ai-memory-named subskill dir, not bare skills/.
+    """
+
+    def test_unmarked_gemini_settings_not_selected(self, install_sh_no_main, tmp_path):
+        # A user's own .gemini/settings.json (no AI_MEMORY_INSTALL_DIR marker),
+        # no AI-MEMORY.md, no CLI → gemini must NOT be selected.
+        project = tmp_path / "proj"
+        (project / ".gemini").mkdir(parents=True)
+        (project / ".gemini" / "settings.json").write_text(
+            '{"contextFileName": "GEMINI.md", "theme": "dark"}', encoding="utf-8"
+        )
+        assert _parse_ide(install_sh_no_main, "", project) == []
+
+    def test_unmarked_cursor_hooks_not_selected(self, install_sh_no_main, tmp_path):
+        # A user's own .cursor/hooks.json (no marker), no ai-memory skill subdir,
+        # no rules/ai-memory.mdc → cursor must NOT be selected.
+        project = tmp_path / "proj"
+        (project / ".cursor").mkdir(parents=True)
+        (project / ".cursor" / "hooks.json").write_text(
+            '{"hooks": {"beforeShellExecution": []}}', encoding="utf-8"
+        )
+        assert "cursor" not in _parse_ide(install_sh_no_main, "", project)
+
+    def test_unmarked_codex_hooks_not_selected(self, install_sh_no_main, tmp_path):
+        # A user's own .codex/hooks.json (no marker) + bare (non-ai-memory) skills
+        # dirs → codex must NOT be selected.
+        project = tmp_path / "proj"
+        (project / ".codex").mkdir(parents=True)
+        (project / ".codex" / "hooks.json").write_text(
+            '{"notify": ["say", "done"]}', encoding="utf-8"
+        )
+        (project / ".codex" / "skills" / "my-own-skill").mkdir(parents=True)
+        (project / ".agents" / "skills" / "unrelated").mkdir(parents=True)
+        assert "codex" not in _parse_ide(install_sh_no_main, "", project)
+
+    def test_marked_gemini_settings_selected(self, install_sh_no_main, tmp_path):
+        # Positive: a real ai-memory install's settings.json (contains the marker)
+        # IS selected even with no CLI on PATH.
+        project = tmp_path / "proj"
+        (project / ".gemini").mkdir(parents=True)
+        (project / ".gemini" / "settings.json").write_text(
+            '{"env": {"AI_MEMORY_INSTALL_DIR": "/home/u/.ai-memory"}}',
+            encoding="utf-8",
+        )
+        assert _parse_ide(install_sh_no_main, "", project) == ["gemini"]
+
+    def test_marked_hooks_select_cursor_and_codex(self, install_sh_no_main, tmp_path):
+        # Positive: real ai-memory install (marked hooks.json) selects both IDEs.
+        project = tmp_path / "proj"
+        (project / ".cursor").mkdir(parents=True)
+        (project / ".cursor" / "hooks.json").write_text(_MARKED_HOOKS, encoding="utf-8")
+        (project / ".codex").mkdir(parents=True)
+        (project / ".codex" / "hooks.json").write_text(_MARKED_HOOKS, encoding="utf-8")
+        selected = _parse_ide(install_sh_no_main, "", project)
+        assert "cursor" in selected
+        assert "codex" in selected
+
+    def test_ai_memory_skill_subdir_selects_ide(self, install_sh_no_main, tmp_path):
+        # Positive: the ai-memory-named skill subdir (search-memory) selects the
+        # IDE even when the hooks.json is absent/unmarked.
+        project = tmp_path / "proj"
+        (project / ".cursor" / "skills" / "search-memory").mkdir(parents=True)
+        (project / ".agents" / "skills" / "search-memory").mkdir(parents=True)
+        selected = _parse_ide(install_sh_no_main, "", project)
+        assert "cursor" in selected
+        assert "codex" in selected
+
+    def test_ai_memory_guidance_files_still_select(self, install_sh_no_main, tmp_path):
+        # The already-ai-memory-specific guidance markers are unchanged: bare
+        # existence of AI-MEMORY.md (gemini) / .cursor/rules/ai-memory.mdc still counts.
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / "AI-MEMORY.md").write_text("guidance", encoding="utf-8")
+        (project / ".cursor" / "rules").mkdir(parents=True)
+        (project / ".cursor" / "rules" / "ai-memory.mdc").write_text(
+            "---\nalwaysApply: true\n---\n", encoding="utf-8"
+        )
+        selected = _parse_ide(install_sh_no_main, "", project)
+        assert "gemini" in selected
+        assert "cursor" in selected
 
 
 class TestExplicitFlagSemanticsPreserved:

--- a/tests/test_install_bug529_adapter_refresh.py
+++ b/tests/test_install_bug529_adapter_refresh.py
@@ -1,0 +1,201 @@
+"""BUG-529: installer must refresh already-deployed IDE adapters on a normal update.
+
+Root cause: `parse_ide_flag` auto-detected IDEs ONLY by machine-CLI presence
+(`command -v gemini|agent|cursor-agent|codex`). On a machine without the cursor /
+codex CLIs, a normal update (no `--ide`) selected gemini only, so the already-
+deployed cursor / codex project adapters never re-processed → permanent drift.
+
+Fix (Option 1, DEC-PM401-D2): auto-detect now UNIONs machine-CLI presence with
+project-adapter-presence — an IDE is selected when its adapters already exist in
+the target project, even when its CLI is absent from PATH. Explicit `--ide <list>`
+and `--ide none` semantics are unchanged.
+
+These tests exercise the real `parse_ide_flag` by sourcing install.sh (minus
+`main "$@"`). The machine-CLI detectors are shadowed to return false so the tests
+deterministically prove selection driven by project-adapter-presence alone,
+independent of whatever CLIs happen to be on the test runner's PATH.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).parent.parent
+_SCRIPTS_DIR = _REPO / "scripts"
+_INSTALL_SH = _SCRIPTS_DIR / "install.sh"
+
+# Shadow the machine-CLI detectors to "absent" — simulates a machine without
+# gemini / cursor / codex CLIs on PATH (the BUG-529 P3 machine minus gemini).
+_NO_CLI = (
+    "detect_gemini_cli() { return 1; }\n"
+    "detect_cursor_ide() { return 1; }\n"
+    "detect_codex_cli() { return 1; }\n"
+)
+
+
+@pytest.fixture
+def install_sh_no_main(tmp_path) -> Path:
+    """install.sh minus final 'main \"$@\"' so it can be sourced for its funcs."""
+    lines = _INSTALL_SH.read_text(encoding="utf-8").splitlines(keepends=True)
+    assert lines[-1].strip() == 'main "$@"', (
+        f"Expected last line 'main \"$@\"', got: {lines[-1]!r}. "
+        "If install.sh structure changed, update this fixture."
+    )
+    copy = tmp_path / "install.sh"
+    copy.write_text("".join(lines[:-1]), encoding="utf-8")
+    copy.chmod(0o755)
+    # install.sh sources this helper at load time (before main).
+    shutil.copy(
+        _SCRIPTS_DIR / "_env_split_helpers.sh", tmp_path / "_env_split_helpers.sh"
+    )
+    return copy
+
+
+def _parse_ide(install_sh: Path, flag: str, project: Path, no_cli: bool = True) -> list:
+    """Call parse_ide_flag and return the selected IDE tokens as a list."""
+    shadow = _NO_CLI if no_cli else ""
+    bash_cmd = f"""
+set -euo pipefail
+source "{install_sh}"
+{shadow}
+parse_ide_flag "{flag}" "{project}"
+"""
+    result = subprocess.run(["bash", "-c", bash_cmd], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    return result.stdout.split()
+
+
+def _deploy_cursor(project: Path) -> None:
+    (project / ".cursor").mkdir(parents=True, exist_ok=True)
+    (project / ".cursor" / "hooks.json").write_text("{}", encoding="utf-8")
+
+
+def _deploy_codex(project: Path) -> None:
+    (project / ".codex").mkdir(parents=True, exist_ok=True)
+    (project / ".codex" / "hooks.json").write_text("{}", encoding="utf-8")
+    (project / ".agents" / "skills").mkdir(parents=True, exist_ok=True)
+
+
+def _deploy_gemini(project: Path) -> None:
+    (project / ".gemini").mkdir(parents=True, exist_ok=True)
+    (project / ".gemini" / "settings.json").write_text("{}", encoding="utf-8")
+
+
+class TestProjectAdapterPresenceSelectsIDE:
+    """Core BUG-529 regression: adapters present → IDE selected, CLI absent."""
+
+    def test_cursor_and_codex_selected_without_their_cli(
+        self, install_sh_no_main, tmp_path
+    ):
+        project = tmp_path / "proj"
+        project.mkdir()
+        _deploy_cursor(project)
+        _deploy_codex(project)
+        selected = _parse_ide(install_sh_no_main, "", project)
+        # Both refreshed on a normal update even though neither CLI is on PATH.
+        assert "cursor" in selected
+        assert "codex" in selected
+        # gemini has neither a CLI nor a deployed adapter → not selected.
+        assert "gemini" not in selected
+
+    def test_gemini_adapter_presence_selected_without_cli(
+        self, install_sh_no_main, tmp_path
+    ):
+        project = tmp_path / "proj"
+        project.mkdir()
+        _deploy_gemini(project)
+        selected = _parse_ide(install_sh_no_main, "", project)
+        assert selected == ["gemini"]
+
+    def test_cursor_rules_mdc_alone_selects_cursor(self, install_sh_no_main, tmp_path):
+        # A guidance-only cursor deploy (rules/ai-memory.mdc) still counts.
+        project = tmp_path / "proj"
+        (project / ".cursor" / "rules").mkdir(parents=True)
+        (project / ".cursor" / "rules" / "ai-memory.mdc").write_text(
+            "---\nalwaysApply: true\n---\n", encoding="utf-8"
+        )
+        selected = _parse_ide(install_sh_no_main, "", project)
+        assert "cursor" in selected
+
+    def test_no_adapters_no_cli_selects_nothing(self, install_sh_no_main, tmp_path):
+        # No false positives: empty project + no CLIs → no IDEs.
+        project = tmp_path / "proj"
+        project.mkdir()
+        assert _parse_ide(install_sh_no_main, "", project) == []
+
+    def test_cli_and_adapter_both_present_no_duplicate(
+        self, install_sh_no_main, tmp_path
+    ):
+        # gemini CLI present AND adapter deployed → selected exactly once.
+        project = tmp_path / "proj"
+        project.mkdir()
+        _deploy_gemini(project)
+        bash_cmd = f"""
+set -euo pipefail
+source "{install_sh_no_main}"
+detect_gemini_cli() {{ return 0; }}
+detect_cursor_ide() {{ return 1; }}
+detect_codex_cli() {{ return 1; }}
+parse_ide_flag "" "{project}"
+"""
+        result = subprocess.run(
+            ["bash", "-c", bash_cmd], capture_output=True, text=True
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.split() == ["gemini"]
+
+
+class TestExplicitFlagSemanticsPreserved:
+    """Explicit --ide wins; adapter-presence must not leak into it."""
+
+    def test_explicit_flag_wins_over_adapter_presence(
+        self, install_sh_no_main, tmp_path
+    ):
+        project = tmp_path / "proj"
+        project.mkdir()
+        # codex adapter deployed, but the user explicitly asked for cursor only.
+        _deploy_codex(project)
+        selected = _parse_ide(install_sh_no_main, "cursor", project)
+        assert selected == ["cursor"]
+
+    def test_explicit_comma_list_split(self, install_sh_no_main, tmp_path):
+        project = tmp_path / "proj"
+        project.mkdir()
+        selected = _parse_ide(install_sh_no_main, "cursor,codex", project)
+        assert selected == ["cursor", "codex"]
+
+    def test_none_selects_nothing_even_with_adapters(
+        self, install_sh_no_main, tmp_path
+    ):
+        project = tmp_path / "proj"
+        project.mkdir()
+        _deploy_cursor(project)
+        _deploy_codex(project)
+        _deploy_gemini(project)
+        assert _parse_ide(install_sh_no_main, "none", project) == []
+
+
+class TestSelectionIsReadOnly:
+    """The selection path must never mutate user-owned project files (the
+    write_<ide>_config force-gate that protects hooks.json/settings.json/GEMINI.md
+    is unchanged and out of scope). This asserts selection itself is read-only."""
+
+    def test_parse_ide_flag_does_not_modify_project(self, install_sh_no_main, tmp_path):
+        project = tmp_path / "proj"
+        project.mkdir()
+        _deploy_cursor(project)
+        _deploy_codex(project)
+        user_hooks = project / ".cursor" / "hooks.json"
+        user_hooks.write_text('{"user": "owned"}', encoding="utf-8")
+        before = {p: p.read_bytes() for p in project.rglob("*") if p.is_file()}
+        before_tree = sorted(p.relative_to(project) for p in project.rglob("*"))
+
+        _parse_ide(install_sh_no_main, "", project)
+
+        after = {p: p.read_bytes() for p in project.rglob("*") if p.is_file()}
+        after_tree = sorted(p.relative_to(project) for p in project.rglob("*"))
+        assert before == after, "selection mutated a project file"
+        assert before_tree == after_tree, "selection created/removed a path"
+        assert user_hooks.read_text(encoding="utf-8") == '{"user": "owned"}'

--- a/tests/test_install_bug529_adapter_refresh.py
+++ b/tests/test_install_bug529_adapter_refresh.py
@@ -16,6 +16,7 @@ deterministically prove selection driven by project-adapter-presence alone,
 independent of whatever CLIs happen to be on the test runner's PATH.
 """
 
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -234,11 +235,15 @@ class TestOwnershipMarkerRequiredForNativeConfig:
         assert "codex" in selected
 
     def test_ai_memory_guidance_files_still_select(self, install_sh_no_main, tmp_path):
-        # The already-ai-memory-specific guidance markers are unchanged: bare
-        # existence of AI-MEMORY.md (gemini) / .cursor/rules/ai-memory.mdc still counts.
+        # The already-ai-memory-specific guidance markers still count: an
+        # ownership-marked AI-MEMORY.md (gemini) / .cursor/rules/ai-memory.mdc.
+        # fix-r2 residual #1: AI-MEMORY.md is now ownership-gated (not bare
+        # existence) — the fixture must carry the real guidance header.
         project = tmp_path / "proj"
         project.mkdir()
-        (project / "AI-MEMORY.md").write_text("guidance", encoding="utf-8")
+        (project / "AI-MEMORY.md").write_text(
+            "# AI Memory — Agent Guidance\n\nguidance body", encoding="utf-8"
+        )
         (project / ".cursor" / "rules").mkdir(parents=True)
         (project / ".cursor" / "rules" / "ai-memory.mdc").write_text(
             "---\nalwaysApply: true\n---\n", encoding="utf-8"
@@ -246,6 +251,30 @@ class TestOwnershipMarkerRequiredForNativeConfig:
         selected = _parse_ide(install_sh_no_main, "", project)
         assert "gemini" in selected
         assert "cursor" in selected
+
+    def test_unmarked_ai_memory_md_not_selected(self, install_sh_no_main, tmp_path):
+        # fix-r2 residual #1: a user's own hand-written root AI-MEMORY.md (no
+        # ownership header), no marked settings.json, no CLI → gemini must NOT
+        # be selected (previously bare existence alone selected it, risking
+        # write_gemini_config clobbering the file + settings.json).
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / "AI-MEMORY.md").write_text(
+            "My own notes about AI and memory.", encoding="utf-8"
+        )
+        assert "gemini" not in _parse_ide(install_sh_no_main, "", project)
+
+    def test_agents_md_managed_block_selects_codex(self, install_sh_no_main, tmp_path):
+        # fix-r2 residual #2: an AGENTS.md containing the merge_agents_md.py
+        # managed-block marker selects codex, even with no codex CLI on PATH
+        # and no other codex adapter artifact present.
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / "AGENTS.md").write_text(
+            "<!-- BEGIN AI-MEMORY -->\nguidance\n<!-- END AI-MEMORY -->\n",
+            encoding="utf-8",
+        )
+        assert _parse_ide(install_sh_no_main, "", project) == ["codex"]
 
 
 class TestExplicitFlagSemanticsPreserved:
@@ -300,3 +329,42 @@ class TestSelectionIsReadOnly:
         assert before == after, "selection mutated a project file"
         assert before_tree == after_tree, "selection created/removed a path"
         assert user_hooks.read_text(encoding="utf-8") == '{"user": "owned"}'
+
+
+class TestGeminiDetectionMarkerParity:
+    """fix-r2 parity gate: detect_gemini_project's AI-MEMORY.md ownership grep
+    (install.sh) and the shipped gemini template's H1 (both reviewers flagged)
+    have nothing asserting they stay in sync. If a future edit changes one and
+    not the other, gemini detection silently breaks on existing installs, with
+    no failing test. install.sh is the single source of truth for the marker —
+    this test extracts it from there rather than hardcoding a third copy."""
+
+    def test_gemini_detection_marker_parity(self):
+        install_sh_text = _INSTALL_SH.read_text(encoding="utf-8")
+        match = re.search(
+            r'grep -q "([^"]+)" "\$project_path/AI-MEMORY\.md"', install_sh_text
+        )
+        assert match, (
+            "Could not find detect_gemini_project's AI-MEMORY.md grep pattern "
+            f"in {_INSTALL_SH}. If the grep line moved or changed shape, update "
+            "this test's extraction regex."
+        )
+        marker = match.group(1)
+
+        template_path = (
+            _REPO
+            / "src"
+            / "memory"
+            / "adapters"
+            / "templates"
+            / "gemini"
+            / "ai-memory.md"
+        )
+        template_text = template_path.read_text(encoding="utf-8")
+        assert marker in template_text, (
+            f"detect_gemini_project's ownership marker {marker!r} (extracted "
+            f"from install.sh) is absent from {template_path}. The install.sh "
+            "grep and the shipped template's H1 have drifted out of sync — "
+            "gemini detection will silently stop working on existing installs "
+            "whose AI-MEMORY.md was deployed from an older template."
+        )

--- a/tests/test_install_plan033_p1_pending_updates.py
+++ b/tests/test_install_plan033_p1_pending_updates.py
@@ -1,0 +1,292 @@
+"""PLAN-033 P1 — installer emits a pending-change manifest (BP-188).
+
+When ``_sync_oversight_templates`` (deploy mode) finds an oversight file that is
+BOTH user-modified AND changed upstream — the ``n_warn`` "needs-merge" branch —
+it additionally emits ``.audit/state/pending-updates.json`` carrying, per entry,
+the three-state digest triple ``{old_shipped_hash, deployed_hash,
+new_template_hash}`` plus classification / suggested_action / rationale /
+severity / order, and manifest-level ``schema_version`` + a content-derived
+``manifest_id`` (whole-manifest idempotency) + ``generated_at`` / ``generated_by``
+/ ``source_version``.
+
+This is PRODUCER-only and ADDITIVE: the existing loud ``log_warning`` stays, no
+user data is mutated, and no other deploy/sync/migrate/new/check behavior
+changes. These tests drive the same no-main sourcing harness the sibling
+``test_install_oversight_template_sync.py`` uses.
+"""
+
+import hashlib
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+_INSTALL_SH = _SCRIPTS_DIR / "install.sh"
+_HELPERS = _SCRIPTS_DIR / "_env_split_helpers.sh"
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+@pytest.fixture
+def install_sh_no_main(tmp_path) -> Path:
+    """Copy install.sh minus the final 'main "$@"' line into tmp_path for sourcing."""
+    content = _INSTALL_SH.read_text(encoding="utf-8")
+    lines = content.splitlines(keepends=True)
+    assert lines[-1].strip() == 'main "$@"', (
+        f"Expected last line 'main \"$@\"', got: {lines[-1]!r}. "
+        "If install.sh structure changed, update this fixture."
+    )
+    copy = tmp_path / "install.sh"
+    copy.write_text("".join(lines[:-1]), encoding="utf-8")
+    copy.chmod(0o755)
+    shutil.copy(_HELPERS, tmp_path / "_env_split_helpers.sh")
+    return copy
+
+
+@pytest.fixture
+def dirs(tmp_path):
+    install_dir = tmp_path / "install_dir"
+    project_dir = tmp_path / "project_dir"
+    install_dir.mkdir()
+    project_dir.mkdir()
+    return install_dir, project_dir
+
+
+def _mk_shipped_template(install_dir: Path, rel_path: str, body: str) -> None:
+    dest = install_dir / "templates" / "oversight" / rel_path
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(body, encoding="utf-8")
+
+
+def _mk_registry(install_dir: Path, rows: list[tuple[str, str]]) -> None:
+    reg = install_dir / "templates" / "known-oversight-template-versions.txt"
+    reg.parent.mkdir(parents=True, exist_ok=True)
+    lines = ["# test registry\n"] + [f"{rel}\t{h}\n" for rel, h in rows]
+    reg.write_text("".join(lines), encoding="utf-8")
+
+
+def _run(
+    install_sh_copy, install_dir, project_dir, func
+) -> subprocess.CompletedProcess:
+    bash_cmd = f"""
+set -euo pipefail
+export INSTALL_DIR="{install_dir}"
+export PROJECT_PATH="{project_dir}"
+source "{install_sh_copy}"
+INSTALL_DIR="{install_dir}"
+PROJECT_PATH="{project_dir}"
+{func}
+"""
+    return subprocess.run(["bash", "-c", bash_cmd], capture_output=True, text=True)
+
+
+def _deploy(install_sh_copy, install_dir, project_dir):
+    return _run(install_sh_copy, install_dir, project_dir, "deploy_oversight_templates")
+
+
+def _pending_path(project_dir: Path) -> Path:
+    return project_dir / ".audit" / "state" / "pending-updates.json"
+
+
+def _make_both_changed(
+    install_sh_no_main, install_dir, project_dir, rel="tracking/task-tracker.md"
+):
+    """Drive a project into the both-changed (n_warn) state and return the hashes.
+
+    v1 deployed + recorded (base B) -> user edits the copy -> upstream ships v2.
+    Returns (rel, base_hash, deployed_hash, new_template_hash).
+    """
+    _mk_shipped_template(install_dir, rel, "V1\n")
+    assert _deploy(install_sh_no_main, install_dir, project_dir).returncode == 0
+    base_hash = _sha256("V1\n")  # recorded in the manifest as the last-deployed base
+
+    copy = project_dir / "oversight" / rel
+    copy.write_text("MY LOCAL EDITS\n")
+    deployed_hash = _sha256("MY LOCAL EDITS\n")
+
+    _mk_shipped_template(install_dir, rel, "V2 STRUCTURAL UPDATE\n")
+    new_hash = _sha256("V2 STRUCTURAL UPDATE\n")
+    return rel, base_hash, deployed_hash, new_hash
+
+
+class TestEmitOnBothChanged:
+    def test_emit_contains_correct_digest_triple_and_classification(
+        self, install_sh_no_main, dirs
+    ):
+        install_dir, project_dir = dirs
+        rel, base, deployed, new = _make_both_changed(
+            install_sh_no_main, install_dir, project_dir
+        )
+
+        res = _deploy(install_sh_no_main, install_dir, project_dir)
+        assert res.returncode == 0, res.stderr
+
+        # Existing behavior preserved: never clobbered + loud warning still fires.
+        assert (project_dir / "oversight" / rel).read_text() == "MY LOCAL EDITS\n"
+        assert "review + merge" in res.stdout
+
+        manifest = _pending_path(project_dir)
+        assert manifest.exists(), "pending-updates.json must be emitted on both-changed"
+        doc = json.loads(manifest.read_text())
+
+        assert doc["schema_version"] == "1.0"
+        assert doc["generated_by"].startswith("install.sh@")
+        assert doc["source_version"]
+        assert doc["manifest_id"]
+        assert doc["generated_at"].endswith("Z")
+
+        assert len(doc["entries"]) == 1
+        e = doc["entries"][0]
+        # The three-state digest triple is the load-bearing discriminator.
+        assert e["old_shipped_hash"] == base
+        assert e["deployed_hash"] == deployed
+        assert e["new_template_hash"] == new
+        assert e["classification"] == "MANAGED_MERGE_REQUIRED"
+        assert e["suggested_action"] == "merge"
+        assert e["severity"] == "high"
+        assert e["rationale"]
+        assert e["id"] == rel
+        assert e["path"] == f"oversight/{rel}"
+        assert e["order"] == 0
+
+    def test_legacy_pre_manifest_file_yields_empty_old_shipped_hash(
+        self, install_sh_no_main, dirs
+    ):
+        """A file the operator had BEFORE we tracked it (no manifest record, no
+        matching registry hash) has no known base B -> old_shipped_hash == ""."""
+        install_dir, project_dir = dirs
+        rel = "decisions/decision-log.md"
+        # Project already carries a user-owned copy; no prior deploy => no manifest,
+        # no registry entry for this path.
+        copy = project_dir / "oversight" / rel
+        copy.parent.mkdir(parents=True)
+        copy.write_text("USER DECISIONS\n")
+        _mk_shipped_template(install_dir, rel, "SHIPPED STRUCTURE\n")
+
+        res = _deploy(install_sh_no_main, install_dir, project_dir)
+        assert res.returncode == 0, res.stderr
+
+        doc = json.loads(_pending_path(project_dir).read_text())
+        e = next(x for x in doc["entries"] if x["id"] == rel)
+        assert e["old_shipped_hash"] == ""
+        assert e["deployed_hash"] == _sha256("USER DECISIONS\n")
+        assert e["new_template_hash"] == _sha256("SHIPPED STRUCTURE\n")
+
+    def test_old_shipped_hash_falls_back_to_registry_known_hash(
+        self, install_sh_no_main, dirs
+    ):
+        """No manifest record, but a prior-shipped hash is registered for the path
+        -> old_shipped_hash uses that registry base rather than "" (best-effort B)."""
+        install_dir, project_dir = dirs
+        rel = "plans/PLAN_TEMPLATE.md"
+        prior_hash = _sha256("PRIOR SHIPPED\n")
+        _mk_registry(install_dir, [(rel, prior_hash)])
+        _mk_shipped_template(install_dir, rel, "CURRENT SHIPPED\n")
+
+        # User-modified copy that matches NEITHER shipped nor the known prior hash
+        # (so it is a warn, not a migrate) and has no manifest record.
+        copy = project_dir / "oversight" / rel
+        copy.parent.mkdir(parents=True)
+        copy.write_text("LOCALLY EDITED\n")
+
+        res = _deploy(install_sh_no_main, install_dir, project_dir)
+        assert res.returncode == 0, res.stderr
+
+        doc = json.loads(_pending_path(project_dir).read_text())
+        e = next(x for x in doc["entries"] if x["id"] == rel)
+        assert e["old_shipped_hash"] == prior_hash
+
+
+class TestIdempotency:
+    def test_rerun_replaces_never_appends_duplicates(self, install_sh_no_main, dirs):
+        install_dir, project_dir = dirs
+        _make_both_changed(install_sh_no_main, install_dir, project_dir)
+
+        assert _deploy(install_sh_no_main, install_dir, project_dir).returncode == 0
+        first = json.loads(_pending_path(project_dir).read_text())
+
+        # Same drift state on re-run: the whole manifest is REPLACED, not appended.
+        assert _deploy(install_sh_no_main, install_dir, project_dir).returncode == 0
+        second = json.loads(_pending_path(project_dir).read_text())
+
+        assert len(first["entries"]) == 1
+        assert len(second["entries"]) == 1  # no duplicate entry
+        assert first["manifest_id"] == second["manifest_id"]  # content-derived, stable
+        assert first["entries"] == second["entries"]
+
+    def test_resolved_drift_removes_stale_manifest(self, install_sh_no_main, dirs):
+        """Level-triggered: once the drift is gone, a re-run removes the manifest
+        so the consumer's presence-of-file discovery reads 'nothing pending'."""
+        install_dir, project_dir = dirs
+        rel, _, _, _ = _make_both_changed(install_sh_no_main, install_dir, project_dir)
+
+        assert _deploy(install_sh_no_main, install_dir, project_dir).returncode == 0
+        assert _pending_path(project_dir).exists()
+
+        # Operator resolves the conflict by taking the shipped version verbatim.
+        shipped = install_dir / "templates" / "oversight" / rel
+        (project_dir / "oversight" / rel).write_text(shipped.read_text())
+
+        assert _deploy(install_sh_no_main, install_dir, project_dir).returncode == 0
+        assert not _pending_path(project_dir).exists()
+
+
+class TestSchemaVersionGuard:
+    def test_reader_accepts_known_major(self, install_sh_no_main, dirs):
+        install_dir, project_dir = dirs
+        _make_both_changed(install_sh_no_main, install_dir, project_dir)
+        assert _deploy(install_sh_no_main, install_dir, project_dir).returncode == 0
+        manifest = _pending_path(project_dir)  # freshly emitted at schema 1.0
+
+        res = _run(
+            install_sh_no_main,
+            install_dir,
+            project_dir,
+            f'_pending_updates_schema_ok "{manifest}"',
+        )
+        assert res.returncode == 0, res.stderr
+
+    def test_reader_rejects_unknown_major(self, install_sh_no_main, dirs):
+        install_dir, project_dir = dirs
+        manifest = _pending_path(project_dir)
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        # A manifest written by a hypothetical future MAJOR the installer can't parse.
+        manifest.write_text(json.dumps({"schema_version": "99.0", "entries": []}))
+
+        res = _run(
+            install_sh_no_main,
+            install_dir,
+            project_dir,
+            f'_pending_updates_schema_ok "{manifest}"',
+        )
+        assert res.returncode != 0
+        assert "unsupported schema_version major 99" in res.stderr
+
+    def test_reader_absent_manifest_is_ok(self, install_sh_no_main, dirs):
+        install_dir, project_dir = dirs
+        missing = _pending_path(project_dir)
+        res = _run(
+            install_sh_no_main,
+            install_dir,
+            project_dir,
+            f'_pending_updates_schema_ok "{missing}"',
+        )
+        assert res.returncode == 0, res.stderr
+
+
+class TestAdditiveNoRegression:
+    def test_no_pending_manifest_when_no_both_changed(self, install_sh_no_main, dirs):
+        """A clean deploy (only a new file) emits no pending manifest — absence =
+        nothing pending; existing new-file deploy behavior is unchanged."""
+        install_dir, project_dir = dirs
+        _mk_shipped_template(install_dir, "tracking/task-tracker.md", "V1\n")
+
+        res = _deploy(install_sh_no_main, install_dir, project_dir)
+        assert res.returncode == 0, res.stderr
+        assert (project_dir / "oversight" / "tracking" / "task-tracker.md").exists()
+        assert not _pending_path(project_dir).exists()

--- a/tests/test_install_plan033_p1_pending_updates.py
+++ b/tests/test_install_plan033_p1_pending_updates.py
@@ -202,6 +202,71 @@ class TestEmitOnBothChanged:
         assert e["old_shipped_hash"] == prior_hash
 
 
+class TestBaseHashAmbiguity:
+    def test_multiple_registry_hashes_yield_empty_old_shipped_hash(
+        self, install_sh_no_main, dirs
+    ):
+        """The registry is built with ``sort -u`` (lexicographic, NOT chronological),
+        so when a legacy path has 2+ recorded prior-shipped hashes the latest-shipped
+        base is not identifiable -> old_shipped_hash must be "" (never a guessed base)
+        rather than the lexicographically-largest hash a ``tail -n 1`` would pick.
+
+        (The single-known-hash -> that-hash case is covered by
+        ``test_old_shipped_hash_falls_back_to_registry_known_hash``.)
+        """
+        install_dir, project_dir = dirs
+        rel = "plans/PLAN_TEMPLATE.md"
+        prior_a = _sha256("PRIOR SHIPPED A\n")
+        prior_b = _sha256("PRIOR SHIPPED B\n")
+        # Two prior-shipped hashes registered for the same path (2-entry legacy case).
+        _mk_registry(install_dir, [(rel, prior_a), (rel, prior_b)])
+        _mk_shipped_template(install_dir, rel, "CURRENT SHIPPED\n")
+
+        # User-modified copy matching neither shipped nor either prior hash, and with
+        # no manifest record -> warn path with an ambiguous base B.
+        copy = project_dir / "oversight" / rel
+        copy.parent.mkdir(parents=True)
+        copy.write_text("LOCALLY EDITED\n")
+
+        res = _deploy(install_sh_no_main, install_dir, project_dir)
+        assert res.returncode == 0, res.stderr
+
+        doc = json.loads(_pending_path(project_dir).read_text())
+        e = next(x for x in doc["entries"] if x["id"] == rel)
+        assert e["old_shipped_hash"] == ""
+        assert e["old_shipped_hash"] not in (prior_a, prior_b)
+
+
+class TestFailSafeEmit:
+    def test_unwritable_emit_target_does_not_abort_install(
+        self, install_sh_no_main, dirs
+    ):
+        """HIGH fail-safe: the producer-only emit MUST NOT break the install. When
+        the pending-updates.json target is unwritable, the deploy still returns 0
+        (with a non-fatal note) instead of aborting under ``set -euo pipefail`` and
+        skipping the rest of the Parzival-setup sequence.
+        """
+        install_dir, project_dir = dirs
+        _make_both_changed(install_sh_no_main, install_dir, project_dir)
+
+        # Sabotage the emit target: occupy the manifest path with a directory so the
+        # atomic write/replace fails (uid-independent stand-in for the read-only
+        # .audit/state / ENOSPC failure class the guard must swallow).
+        pending = _pending_path(project_dir)
+        pending.parent.mkdir(parents=True, exist_ok=True)
+        pending.mkdir()
+
+        res = _deploy(install_sh_no_main, install_dir, project_dir)
+
+        # Install NOT aborted: deploy returns 0 despite the emit failing...
+        assert res.returncode == 0, res.stderr
+        # ...with a non-fatal note surfaced, and the existing loud warning intact.
+        assert "non-fatal" in res.stderr or "non-fatal" in res.stdout
+        assert "review + merge" in res.stdout
+        # The manifest was NOT written over the sabotaged path.
+        assert pending.is_dir()
+
+
 class TestIdempotency:
     def test_rerun_replaces_never_appends_duplicates(self, install_sh_no_main, dirs):
         install_dir, project_dir = dirs

--- a/tests/test_install_plan033_p1_pending_updates.py
+++ b/tests/test_install_plan033_p1_pending_updates.py
@@ -310,6 +310,147 @@ class TestFailSafeEmit:
         # Emit was skipped (no temp file to collect into); no crash, no manifest.
         assert not _pending_path(project_dir).exists()
 
+    def test_temp_cleanup_failure_does_not_abort_oversight_deploy(
+        self, install_sh_no_main, dirs
+    ):
+        """HIGH fail-safe: a temp-CLEANUP failure — ``rm`` exiting non-zero on an
+        unremovable temp (read-only TMPDIR remounted mid-run / immutable bit / ACL) —
+        must NOT abort the oversight-template deploy under ``set -euo pipefail``.
+        Cleanup now runs in a RETURN trap (``rm -f "${pending_tsv:-}" … || true``)
+        whose ``|| true`` swallows the failure; before the fix the cleanup ``rm -f``
+        was a set-e-checked bare command, so an rm failure aborted the WHOLE deploy and
+        skipped the rest of the Parzival-setup sequence. The mktemp test covers the
+        PREP-alloc failure; this covers the CLEANUP failure.
+
+        We shadow ``rm`` with a function that exits 1 (uid-independent stand-in for the
+        unremovable-temp failure class; ``rm -f`` alone would succeed for root). Assert
+        the deploy still returns 0, the pending manifest was still emitted (the cleanup
+        trap fires AFTER the write, on return), and a fresh template in the same run
+        still deployed — proving the rm failure no longer aborts the deploy.
+        """
+        install_dir, project_dir = dirs
+        # Drive one file into the both-changed (n_warn) state so pending_tsv is
+        # populated and the cleanup rm is reached...
+        rel_warn, _, _, _ = _make_both_changed(
+            install_sh_no_main, install_dir, project_dir
+        )
+        # ...and add a fresh template so the same run must also do a [new] deploy.
+        _mk_shipped_template(install_dir, "conventions/new-conv.md", "NEW CONV\n")
+
+        # Sabotage the temp cleanup: shadow rm so it exits 1 for the deploy call.
+        res = _run(
+            install_sh_no_main,
+            install_dir,
+            project_dir,
+            "rm() { return 1; }\ndeploy_oversight_templates",
+        )
+
+        # Install NOT aborted: deploy returns 0 despite the cleanup rm failing...
+        assert res.returncode == 0, res.stderr
+        # ...the manifest was still emitted (the write precedes the cleanup rm)...
+        assert _pending_path(project_dir).exists()
+        # ...the deploy COMPLETED (the new file deployed, warn path intact, no clobber).
+        assert (project_dir / "oversight" / "conventions" / "new-conv.md").exists()
+        assert "review + merge" in res.stdout
+        assert (project_dir / "oversight" / rel_warn).read_text() == "MY LOCAL EDITS\n"
+
+    def test_printf_append_failure_does_not_abort_oversight_deploy(
+        self, install_sh_no_main, dirs
+    ):
+        """Producer-path op: the per-file TSV append ``printf … >> "$pending_tsv"``.
+        Shadow ``printf`` to exit 1 (its failure class: ENOSPC / read-only mid-write).
+        The append is guarded ``{ … || true; }``, so the deploy must still return 0 and
+        COMPLETE (a fresh [new] template deploys) rather than abort under set -e.
+        (log_* use ``echo``, not ``printf``, so shadowing printf touches only the
+        append + the base-B line-count, neither of which may abort.)
+        """
+        install_dir, project_dir = dirs
+        rel_warn, _, _, _ = _make_both_changed(
+            install_sh_no_main, install_dir, project_dir
+        )
+        _mk_shipped_template(install_dir, "conventions/new-conv.md", "NEW CONV\n")
+
+        res = _run(
+            install_sh_no_main,
+            install_dir,
+            project_dir,
+            "printf() { return 1; }\ndeploy_oversight_templates",
+        )
+
+        assert res.returncode == 0, res.stderr
+        assert (project_dir / "oversight" / "conventions" / "new-conv.md").exists()
+        assert "review + merge" in res.stdout
+        assert (project_dir / "oversight" / rel_warn).read_text() == "MY LOCAL EDITS\n"
+
+    def test_emit_writer_failure_does_not_abort_oversight_deploy(
+        self, install_sh_no_main, dirs
+    ):
+        """Producer-path op: the python emit ``_write_pending_updates``. Shadow it to
+        exit 1. The call sits under ``if !`` (set-e-exempt) which degrades to a
+        non-fatal warning, so the deploy must still return 0 and COMPLETE (a fresh
+        [new] template deploys). This is the direct shadow-the-op form of the
+        unwritable-target fail-safe test.
+        """
+        install_dir, project_dir = dirs
+        rel_warn, _, _, _ = _make_both_changed(
+            install_sh_no_main, install_dir, project_dir
+        )
+        _mk_shipped_template(install_dir, "conventions/new-conv.md", "NEW CONV\n")
+
+        res = _run(
+            install_sh_no_main,
+            install_dir,
+            project_dir,
+            "_write_pending_updates() { return 1; }\ndeploy_oversight_templates",
+        )
+
+        assert res.returncode == 0, res.stderr
+        assert "non-fatal" in res.stdout or "non-fatal" in res.stderr
+        assert (project_dir / "oversight" / "conventions" / "new-conv.md").exists()
+        assert "review + merge" in res.stdout
+        assert (project_dir / "oversight" / rel_warn).read_text() == "MY LOCAL EDITS\n"
+        # Emit failed => no manifest written this run.
+        assert not _pending_path(project_dir).exists()
+
+    def test_base_hash_lookup_failure_does_not_abort_oversight_deploy(
+        self, install_sh_no_main, dirs
+    ):
+        """Producer-path op: the base-B lookup
+        ``known_hashes="$(_known_template_hashes …)"`` — a bare (non-``local``)
+        assignment, so set-e-checked. Shadow ``_known_template_hashes`` to exit 1
+        (the unreadable-registry failure class). The ``|| true`` inside the
+        substitution degrades base-B to "" (never a guessed base), so the deploy must
+        still return 0 and COMPLETE (a fresh [new] template deploys).
+
+        Reaching this op requires the no-manifest-record path (old_base empty): a
+        user-modified copy with a registry entry but no prior deploy.
+        """
+        install_dir, project_dir = dirs
+        rel = "plans/PLAN_TEMPLATE.md"
+        _mk_registry(install_dir, [(rel, _sha256("PRIOR SHIPPED\n"))])
+        _mk_shipped_template(install_dir, rel, "CURRENT SHIPPED\n")
+        # User-modified copy, no prior deploy => no manifest record => old_base ""
+        # => the known_hashes lookup runs (and is the sabotaged op).
+        copy = project_dir / "oversight" / rel
+        copy.parent.mkdir(parents=True)
+        copy.write_text("LOCALLY EDITED\n")
+        # A fresh template so the same run must also do a [new] deploy.
+        _mk_shipped_template(install_dir, "conventions/new-conv.md", "NEW CONV\n")
+
+        res = _run(
+            install_sh_no_main,
+            install_dir,
+            project_dir,
+            "_known_template_hashes() { return 1; }\ndeploy_oversight_templates",
+        )
+
+        assert res.returncode == 0, res.stderr
+        assert (project_dir / "oversight" / "conventions" / "new-conv.md").exists()
+        # The warn entry still emits, with base-B degraded to "" (never guessed).
+        doc = json.loads(_pending_path(project_dir).read_text())
+        e = next(x for x in doc["entries"] if x["id"] == rel)
+        assert e["old_shipped_hash"] == ""
+
 
 class TestIdempotency:
     def test_rerun_replaces_never_appends_duplicates(self, install_sh_no_main, dirs):

--- a/tests/test_install_plan033_p1_pending_updates.py
+++ b/tests/test_install_plan033_p1_pending_updates.py
@@ -266,6 +266,50 @@ class TestFailSafeEmit:
         # The manifest was NOT written over the sabotaged path.
         assert pending.is_dir()
 
+    def test_temp_alloc_failure_does_not_abort_oversight_deploy(
+        self, install_sh_no_main, dirs
+    ):
+        """HIGH fail-safe (fix-r2): a temp-alloc failure in the PREP (mktemp) —
+        restricted/unwritable TMPDIR in a hardened container/CI — must NOT abort the
+        oversight-template deploy under ``set -euo pipefail``. Before the guard, the
+        ``pending_tsv="$(mktemp)"`` assignment was the command after the final ``&&``
+        (set-e-checked), so it aborted the WHOLE deploy: new/sync/migrate/warn all
+        skipped. The existing fail-safe test only covers the python-emit layer.
+
+        We shadow ``mktemp`` with a function that exits 1 (uid-independent stand-in
+        for the restricted-TMPDIR failure class; a chmod-000 TMPDIR would not fail
+        for root, as CI often runs). Assert the deploy still returns 0, surfaces the
+        non-fatal note, and COMPLETES — a new template deployed in the same run
+        proves the loop ran past the sabotaged prep.
+        """
+        install_dir, project_dir = dirs
+        # Drive one file into the both-changed (n_warn) state...
+        rel_warn, _, _, _ = _make_both_changed(
+            install_sh_no_main, install_dir, project_dir
+        )
+        # ...and add a fresh template so the same run must also do a [new] deploy.
+        _mk_shipped_template(install_dir, "conventions/new-conv.md", "NEW CONV\n")
+
+        # Sabotage the temp alloc: shadow mktemp so it exits 1 for the deploy call.
+        res = _run(
+            install_sh_no_main,
+            install_dir,
+            project_dir,
+            "mktemp() { return 1; }\ndeploy_oversight_templates",
+        )
+
+        # Install NOT aborted: deploy returns 0 despite the temp-alloc failure...
+        assert res.returncode == 0, res.stderr
+        # ...with the non-fatal temp-alloc note surfaced.
+        assert "temp alloc failed" in res.stdout or "temp alloc failed" in res.stderr
+        # The deploy COMPLETED past the sabotaged prep: the new file was deployed...
+        assert (project_dir / "oversight" / "conventions" / "new-conv.md").exists()
+        # ...and the warn path still ran (loud warning intact, copy never clobbered).
+        assert "review + merge" in res.stdout
+        assert (project_dir / "oversight" / rel_warn).read_text() == "MY LOCAL EDITS\n"
+        # Emit was skipped (no temp file to collect into); no crash, no manifest.
+        assert not _pending_path(project_dir).exists()
+
 
 class TestIdempotency:
     def test_rerun_replaces_never_appends_duplicates(self, install_sh_no_main, dirs):

--- a/tests/test_plan033_p2_reconcile_helper.py
+++ b/tests/test_plan033_p2_reconcile_helper.py
@@ -1,0 +1,453 @@
+"""Tests for the PLAN-033 P2 session-start reconciliation helper.
+
+The helper lives at
+``_ai-memory/pov/skills/aim-content-drift/scripts/reconcile_helper.py`` — a skill
+script invoked by path — so it is loaded here via ``importlib.util.spec_from_file_location``
+(same pattern as tests/test_plan033_p3_reconcile_engine.py). This file lives under
+``tests/`` so CI collects it (TD-812: CI only collects ``tests/``).
+
+Focus (the P2 helper DONE-WHEN): the ledger / hash-move re-nag behavior —
+  - effective_pending includes never-disposed entries.
+  - applied|dismissed at the SAME new_template_hash suppress re-surfacing.
+  - a MOVED new_template_hash re-surfaces a previously-disposed entry.
+  - deferred re-surfaces (recorded for audit, not suppressed).
+  - the one-line rollup format / silence when nothing is pending.
+  - `reconcile --disposition applied` invokes the engine and records action_taken+hash.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_HELPER_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "_ai-memory"
+    / "pov"
+    / "skills"
+    / "aim-content-drift"
+    / "scripts"
+    / "reconcile_helper.py"
+)
+_spec = importlib.util.spec_from_file_location("reconcile_helper", _HELPER_PATH)
+helper = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = helper
+_spec.loader.exec_module(helper)
+
+engine = helper.engine
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+def _sha(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+def _write_manifest(project_root: Path, entries: list[dict]) -> None:
+    state = project_root / ".audit" / "state"
+    state.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "schema_version": "1.0",
+        "generated_at": "2026-07-14T00:00:00Z",
+        "generated_by": "test",
+        "source_version": "2.8.3",
+        "manifest_id": "test-manifest",
+        "entries": entries,
+    }
+    (state / "pending-updates.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+
+def _entry(
+    id_: str, *, base="B", deployed="D", new="S", severity="high", order=0
+) -> dict:
+    return {
+        "id": id_,
+        "path": f"oversight/{id_}",
+        "classification": "MANAGED_MERGE_REQUIRED",
+        "old_shipped_hash": _sha(base),
+        "deployed_hash": _sha(deployed),
+        "new_template_hash": _sha(new),
+        "suggested_action": "merge",
+        "rationale": "local + upstream both changed",
+        "severity": severity,
+        "order": order,
+    }
+
+
+def _load_manifest(project_root: Path):
+    return engine.load_manifest(
+        project_root / ".audit" / "state" / "pending-updates.json"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# effective_pending — re-nag suppression core
+# --------------------------------------------------------------------------- #
+def test_never_disposed_entry_is_pending(tmp_path):
+    _write_manifest(tmp_path, [_entry("tracking/decision-log.md")])
+    manifest = _load_manifest(tmp_path)
+    pending = helper.effective_pending(manifest, {"dispositions": {}})
+    assert [e.id for e in pending] == ["tracking/decision-log.md"]
+
+
+def test_applied_at_same_hash_is_suppressed(tmp_path):
+    e = _entry("bugs/INDEX.md", new="S")
+    _write_manifest(tmp_path, [e])
+    manifest = _load_manifest(tmp_path)
+    ledger = {
+        "dispositions": {
+            "bugs/INDEX.md": {"disposition": "applied", "new_template_hash": _sha("S")}
+        }
+    }
+    assert helper.effective_pending(manifest, ledger) == []
+
+
+def test_dismissed_at_same_hash_is_suppressed(tmp_path):
+    e = _entry("bugs/INDEX.md", new="S")
+    _write_manifest(tmp_path, [e])
+    manifest = _load_manifest(tmp_path)
+    ledger = {
+        "dispositions": {
+            "bugs/INDEX.md": {
+                "disposition": "dismissed",
+                "new_template_hash": _sha("S"),
+            }
+        }
+    }
+    assert helper.effective_pending(manifest, ledger) == []
+
+
+def test_moved_hash_resurfaces_disposed_entry(tmp_path):
+    # Manifest now carries a NEW template hash (S2); the recorded disposition was at S1.
+    _write_manifest(tmp_path, [_entry("bugs/INDEX.md", new="S2")])
+    manifest = _load_manifest(tmp_path)
+    ledger = {
+        "dispositions": {
+            "bugs/INDEX.md": {"disposition": "applied", "new_template_hash": _sha("S1")}
+        }
+    }
+    pending = helper.effective_pending(manifest, ledger)
+    assert [e.id for e in pending] == ["bugs/INDEX.md"]
+
+
+def test_deferred_resurfaces(tmp_path):
+    _write_manifest(tmp_path, [_entry("bugs/INDEX.md", new="S")])
+    manifest = _load_manifest(tmp_path)
+    ledger = {
+        "dispositions": {
+            "bugs/INDEX.md": {"disposition": "deferred", "new_template_hash": _sha("S")}
+        }
+    }
+    pending = helper.effective_pending(manifest, ledger)
+    assert [e.id for e in pending] == ["bugs/INDEX.md"]
+
+
+def test_severity_ranking(tmp_path):
+    _write_manifest(
+        tmp_path,
+        [
+            _entry("a.md", severity="low", order=0),
+            _entry("b.md", severity="high", order=1),
+            _entry("c.md", severity="medium", order=2),
+        ],
+    )
+    manifest = _load_manifest(tmp_path)
+    pending = helper.effective_pending(manifest, {"dispositions": {}})
+    assert [e.id for e in pending] == ["b.md", "c.md", "a.md"]
+
+
+# --------------------------------------------------------------------------- #
+# rollup line
+# --------------------------------------------------------------------------- #
+def test_rollup_line_high_only(tmp_path):
+    _write_manifest(tmp_path, [_entry("a.md"), _entry("b.md", order=1)])
+    manifest = _load_manifest(tmp_path)
+    pending = helper.effective_pending(manifest, {"dispositions": {}})
+    assert helper._rollup_line(pending) == "Pending Updates: 2 pending (2 high)"
+
+
+def test_rollup_line_mixed_severity(tmp_path):
+    _write_manifest(
+        tmp_path,
+        [_entry("a.md", severity="high"), _entry("b.md", severity="medium", order=1)],
+    )
+    manifest = _load_manifest(tmp_path)
+    pending = helper.effective_pending(manifest, {"dispositions": {}})
+    assert (
+        helper._rollup_line(pending) == "Pending Updates: 2 pending (1 high, 1 medium)"
+    )
+
+
+def test_rollup_line_empty_is_silent():
+    assert helper._rollup_line([]) == ""
+
+
+# --------------------------------------------------------------------------- #
+# CLI: pending --format rollup is silent when manifest absent
+# --------------------------------------------------------------------------- #
+def test_cli_rollup_silent_when_no_manifest(tmp_path, capsys):
+    rc = helper.main(["pending", "--project-root", str(tmp_path), "--format", "rollup"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out == ""
+
+
+def test_cli_rollup_emits_line(tmp_path, capsys):
+    _write_manifest(tmp_path, [_entry("a.md")])
+    rc = helper.main(["pending", "--project-root", str(tmp_path), "--format", "rollup"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out.strip() == "Pending Updates: 1 pending (1 high)"
+
+
+def test_cli_pending_json_lists_entries(tmp_path, capsys):
+    _write_manifest(tmp_path, [_entry("a.md")])
+    rc = helper.main(["pending", "--project-root", str(tmp_path)])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["summary"]["total"] == 1
+    assert payload["summary"]["by_severity"] == {"high": 1}
+    assert payload["entries"][0]["id"] == "a.md"
+
+
+# --------------------------------------------------------------------------- #
+# CLI: reconcile applied invokes engine + records to ledger
+# --------------------------------------------------------------------------- #
+def _data_bearing_file(project_root: Path, rel: str, body: str) -> Path:
+    # A frontmatter-bearing oversight file (no format_version stamp yet) => the engine
+    # migrates it forward to v1 (adds the stamp) while preserving the body.
+    target = project_root / "oversight" / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    content = f"---\ntitle: Decision Log\n---\n{body}\n"
+    target.write_text(content, encoding="utf-8")
+    return target
+
+
+def test_reconcile_applied_migrates_and_records(tmp_path, capsys):
+    rel = "tracking/decision-log.md"
+    target = _data_bearing_file(tmp_path, rel, "DEC-1: keep my data")
+    deployed_hash = engine.compute_hash(target)
+    # base != deployed and base != new => CONFLICT (both-changed), the production case.
+    entry = {
+        "id": rel,
+        "path": f"oversight/{rel}",
+        "classification": "MANAGED_MERGE_REQUIRED",
+        "old_shipped_hash": _sha("pristine-base"),
+        "deployed_hash": deployed_hash,
+        "new_template_hash": _sha("new-template"),
+        "suggested_action": "merge",
+        "rationale": "both changed",
+        "severity": "high",
+        "order": 0,
+    }
+    _write_manifest(tmp_path, [entry])
+
+    rc = helper.main(
+        [
+            "reconcile",
+            "--project-root",
+            str(tmp_path),
+            "--id",
+            rel,
+            "--disposition",
+            "applied",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["status"] == "ok"
+    assert payload["decision"] == "conflict"
+    assert payload["action_taken"] == "migrated"
+
+    # Body preserved, structure migrated forward (stamp added).
+    migrated = target.read_text(encoding="utf-8")
+    assert "DEC-1: keep my data" in migrated
+    assert "format_version: 1" in migrated
+
+    # Ledger records the disposition at the entry's new_template_hash.
+    ledger = json.loads(
+        (tmp_path / ".audit" / "state" / "reconcile-dispositions.json").read_text()
+    )
+    rec = ledger["dispositions"][rel]
+    assert rec["disposition"] == "applied"
+    assert rec["new_template_hash"] == _sha("new-template")
+    assert rec["action_taken"] == "migrated"
+
+    # And now the entry is suppressed at that same hash (re-nag off).
+    manifest = _load_manifest(tmp_path)
+    assert (
+        helper.effective_pending(
+            manifest,
+            helper.load_ledger(
+                tmp_path / ".audit" / "state" / "reconcile-dispositions.json"
+            ),
+        )
+        == []
+    )
+
+
+def test_reconcile_dismiss_records_without_engine(tmp_path, capsys):
+    rel = "bugs/INDEX.md"
+    _write_manifest(tmp_path, [_entry(rel, new="S")])
+    rc = helper.main(
+        [
+            "reconcile",
+            "--project-root",
+            str(tmp_path),
+            "--id",
+            rel,
+            "--disposition",
+            "dismissed",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["disposition"] == "dismissed"
+    ledger = json.loads(
+        (tmp_path / ".audit" / "state" / "reconcile-dispositions.json").read_text()
+    )
+    assert ledger["dispositions"][rel]["disposition"] == "dismissed"
+    assert ledger["dispositions"][rel]["new_template_hash"] == _sha("S")
+
+
+def test_reconcile_unknown_id_errors(tmp_path, capsys):
+    _write_manifest(tmp_path, [_entry("a.md")])
+    rc = helper.main(
+        [
+            "reconcile",
+            "--project-root",
+            str(tmp_path),
+            "--id",
+            "nope.md",
+            "--disposition",
+            "applied",
+        ]
+    )
+    assert rc == 2
+
+
+# --------------------------------------------------------------------------- #
+# CLI: reconcile applied — engine failure must NOT record a false "applied"
+# --------------------------------------------------------------------------- #
+def test_reconcile_applied_engine_failure_records_no_ledger_entry(
+    tmp_path, capsys, monkeypatch
+):
+    rel = "tracking/decision-log.md"
+    target = _data_bearing_file(tmp_path, rel, "DEC-1: keep my data")
+    original_content = target.read_text(encoding="utf-8")
+    deployed_hash = engine.compute_hash(target)
+    entry = {
+        "id": rel,
+        "path": f"oversight/{rel}",
+        "classification": "MANAGED_MERGE_REQUIRED",
+        "old_shipped_hash": _sha("pristine-base"),
+        "deployed_hash": deployed_hash,
+        "new_template_hash": _sha("new-template"),
+        "suggested_action": "merge",
+        "rationale": "both changed",
+        "severity": "high",
+        "order": 0,
+    }
+    _write_manifest(tmp_path, [entry])
+
+    def _raise_stale(*_args, **_kwargs):
+        raise engine.StaleManifestError("forced failure for test")
+
+    monkeypatch.setattr(engine, "reconcile_entry", _raise_stale)
+
+    rc = helper.main(
+        [
+            "reconcile",
+            "--project-root",
+            str(tmp_path),
+            "--id",
+            rel,
+            "--disposition",
+            "applied",
+        ]
+    )
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().err)
+    assert payload["status"] == "error"
+    assert payload["error_type"] == "StaleManifestError"
+
+    # No ledger record was written for this entry — no false "applied".
+    ledger_path = tmp_path / ".audit" / "state" / "reconcile-dispositions.json"
+    assert not ledger_path.exists()
+
+    # The operator's file is untouched.
+    assert target.read_text(encoding="utf-8") == original_content
+
+
+# --------------------------------------------------------------------------- #
+# Fail-safe manifest loading — `pending --format rollup` never errors the
+# session-start rollup, regardless of what is on disk at the manifest path.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("raw_manifest", ["[]", "null", "42"])
+def test_pending_rollup_silent_on_non_object_manifest(tmp_path, capsys, raw_manifest):
+    state = tmp_path / ".audit" / "state"
+    state.mkdir(parents=True, exist_ok=True)
+    (state / "pending-updates.json").write_text(raw_manifest, encoding="utf-8")
+    rc = helper.main(["pending", "--project-root", str(tmp_path), "--format", "rollup"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out == ""
+
+
+def test_pending_rollup_silent_on_unreadable_manifest(tmp_path, capsys):
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        pytest.skip("chmod 000 has no effect when running as root")
+    state = tmp_path / ".audit" / "state"
+    state.mkdir(parents=True, exist_ok=True)
+    manifest_path = state / "pending-updates.json"
+    manifest_path.write_text(
+        json.dumps({"schema_version": "1.0", "entries": []}), encoding="utf-8"
+    )
+    manifest_path.chmod(0o000)
+    try:
+        rc = helper.main(
+            ["pending", "--project-root", str(tmp_path), "--format", "rollup"]
+        )
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert out == ""
+    finally:
+        manifest_path.chmod(0o644)
+
+
+def test_pending_rollup_silent_on_unreadable_ancestor_dir(tmp_path, capsys):
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        pytest.skip("chmod 000 has no effect when running as root")
+    state = tmp_path / ".audit" / "state"
+    state.mkdir(parents=True, exist_ok=True)
+    manifest_path = state / "pending-updates.json"
+    manifest_path.write_text(
+        json.dumps({"schema_version": "1.0", "entries": []}), encoding="utf-8"
+    )
+    state.chmod(0o000)
+    try:
+        rc = helper.main(
+            ["pending", "--project-root", str(tmp_path), "--format", "rollup"]
+        )
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert out == ""
+    finally:
+        state.chmod(0o755)
+
+
+def test_pending_rollup_silent_on_invalid_utf8_manifest(tmp_path, capsys):
+    state = tmp_path / ".audit" / "state"
+    state.mkdir(parents=True, exist_ok=True)
+    (state / "pending-updates.json").write_bytes(b"\xff\xfe\x00invalid")
+    rc = helper.main(["pending", "--project-root", str(tmp_path), "--format", "rollup"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out == ""

--- a/tests/test_plan033_p3_reconcile_engine.py
+++ b/tests/test_plan033_p3_reconcile_engine.py
@@ -1,0 +1,535 @@
+"""Tests for the PLAN-033 P3 template-drift reconciliation engine (BP-187).
+
+The engine lives at
+``_ai-memory/pov/skills/aim-content-drift/scripts/reconcile_engine.py`` — outside any
+importable package (a skill script invoked by path) — so it is loaded here via
+``importlib.util.spec_from_file_location`` (the established repo pattern, mirrors
+``tests/test_aim_doctor.py``). This test file lives under ``tests/`` so CI collects it
+(TD-812: CI only collects ``tests/``).
+
+Coverage (maps 1:1 to the P3 DONE-WHEN):
+  - decide(): all 4 BP-187 cells (§2.2 table).
+  - classify(): digest-triple -> decision, incl. the B="" fail-safe -> CONFLICT.
+  - load_manifest(): parse the frozen P1 schema; reject unknown MAJOR, accept MINOR.
+  - compute_hash(): == hashlib sha256 of raw bytes (installer parity).
+  - is_stale(): unchanged / deployed-mutated / template-moved / deployed-gone.
+  - format_version read/write: roundtrip, upsert, no-frontmatter raises.
+  - apply_migrations(): ordered chain, idempotent, gap fail-loud, N/A tolerance.
+  - atomic_write(): content + .bak + same-dir temp + no temp leak + crash cleanup.
+  - reconcile_entry(): all 4 decisions dispatched + staleness-skip + ZERO-DATA-LOSS
+    integration on a realistic bugs/INDEX.md-shaped fixture.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load the engine by file location (it is not part of the `memory` package).
+_ENGINE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "_ai-memory"
+    / "pov"
+    / "skills"
+    / "aim-content-drift"
+    / "scripts"
+    / "reconcile_engine.py"
+)
+_spec = importlib.util.spec_from_file_location("reconcile_engine", _ENGINE_PATH)
+engine = importlib.util.module_from_spec(_spec)
+# Register before exec: the module uses @dataclass, whose decorator looks up
+# sys.modules[cls.__module__] — exec_module() would fail without this.
+sys.modules[_spec.name] = engine
+_spec.loader.exec_module(engine)
+
+Decision = engine.Decision
+
+
+# --------------------------------------------------------------------------- #
+# Helpers / fixtures
+# --------------------------------------------------------------------------- #
+def _entry(*, base: str, deployed: str, new: str, path: str = "tracking/x.md"):
+    """Build a ReconcileEntry with just the digest triple that matters."""
+    return engine.ReconcileEntry(
+        id=path,
+        path=f"oversight/{path}",
+        classification="MANAGED_MERGE_REQUIRED",
+        old_shipped_hash=base,
+        deployed_hash=deployed,
+        new_template_hash=new,
+        suggested_action="merge",
+        rationale="test",
+        severity="high",
+        order=0,
+    )
+
+
+# A realistic data-bearing oversight file: YAML frontmatter (installer-owned
+# STRUCTURE) + a data body (operator-owned rows). Modeled on the real
+# oversight/bugs/INDEX.md shape. No format_version stamp yet (pre-P3 state).
+INDEX_FIXTURE = """\
+---
+class: register
+read_path: section-anchored
+owns: "generated bug-or-TD index + closed-history shard"
+cap_lines: 100
+---
+# Bug Tracker Index
+
+**Last Updated**: 2026-07-14
+
+## Quick Stats
+
+| Metric | Count |
+|--------|-------|
+| Open   | 12    |
+| Closed | 111   |
+
+## Records
+
+- BUG-527 — deploy parity — Closed
+- BUG-528 — marker asymmetry — Open
+- BUG-529 — adapter refresh — Open
+"""
+
+
+def _body_after_frontmatter(text: str) -> str:
+    """Return everything after the closing frontmatter fence (the DATA body)."""
+    lines = text.split("\n")
+    assert lines[0].strip() == "---"
+    close = next(i for i in range(1, len(lines)) if lines[i].strip() == "---")
+    return "\n".join(lines[close + 1 :])
+
+
+# --------------------------------------------------------------------------- #
+# decide() — the 4 BP-187 cells
+# --------------------------------------------------------------------------- #
+def test_decide_all_four_cells():
+    assert engine.decide(user_edited=False, template_changed=False) == Decision.NO_OP
+    assert engine.decide(user_edited=False, template_changed=True) == Decision.REFRESH
+    assert engine.decide(user_edited=True, template_changed=False) == Decision.PRESERVE
+    assert engine.decide(user_edited=True, template_changed=True) == Decision.CONFLICT
+
+
+# --------------------------------------------------------------------------- #
+# classify() — digest triple -> decision, incl. fail-safe
+# --------------------------------------------------------------------------- #
+def test_classify_no_op_when_all_equal():
+    e = _entry(base="a", deployed="a", new="a")
+    assert engine.classify(e) == Decision.NO_OP
+
+
+def test_classify_refresh_when_only_template_changed():
+    e = _entry(base="a", deployed="a", new="b")
+    assert engine.classify(e) == Decision.REFRESH
+
+
+def test_classify_preserve_when_only_user_edited():
+    e = _entry(base="a", deployed="b", new="a")
+    assert engine.classify(e) == Decision.PRESERVE
+
+
+def test_classify_conflict_when_both_changed():
+    e = _entry(base="a", deployed="b", new="c")
+    assert engine.classify(e) == Decision.CONFLICT
+
+
+def test_classify_empty_base_fails_safe_to_conflict():
+    # BP-187 §2.1: no pristine base => cannot prove unedited => never blind-refresh.
+    e = _entry(base="", deployed="b", new="c")
+    assert engine.classify(e) == Decision.CONFLICT
+    # Even when deployed == new (would look like NO_OP), an unknown base is CONFLICT.
+    e2 = _entry(base="", deployed="b", new="b")
+    assert engine.classify(e2) == Decision.CONFLICT
+
+
+# --------------------------------------------------------------------------- #
+# load_manifest() — frozen P1 schema; reject unknown MAJOR
+# --------------------------------------------------------------------------- #
+def _write_manifest(path: Path, schema_version: str) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": schema_version,
+                "generated_at": "2026-07-14T00:00:00Z",
+                "generated_by": "install.sh@2.8.3",
+                "source_version": "2.8.3",
+                "manifest_id": "deadbeef",
+                "entries": [
+                    {
+                        "id": "tracking/decision-log.md",
+                        "path": "oversight/tracking/decision-log.md",
+                        "classification": "MANAGED_MERGE_REQUIRED",
+                        "old_shipped_hash": "aaa",
+                        "deployed_hash": "bbb",
+                        "new_template_hash": "ccc",
+                        "suggested_action": "merge",
+                        "rationale": "both changed",
+                        "severity": "high",
+                        "order": 0,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_load_manifest_parses_frozen_schema(tmp_path):
+    m = tmp_path / "pending-updates.json"
+    _write_manifest(m, "1.0")
+    manifest = engine.load_manifest(m)
+    assert manifest.schema_version == "1.0"
+    assert manifest.manifest_id == "deadbeef"
+    assert len(manifest.entries) == 1
+    e = manifest.entries[0]
+    assert e.id == "tracking/decision-log.md"
+    assert e.old_shipped_hash == "aaa"
+    assert e.deployed_hash == "bbb"
+    assert e.new_template_hash == "ccc"
+    assert e.order == 0
+
+
+def test_load_manifest_accepts_higher_minor(tmp_path):
+    m = tmp_path / "pending-updates.json"
+    _write_manifest(m, "1.5")  # additive minor bump -> still supported
+    manifest = engine.load_manifest(m)
+    assert manifest.schema_version == "1.5"
+
+
+def test_load_manifest_rejects_unknown_major(tmp_path):
+    m = tmp_path / "pending-updates.json"
+    _write_manifest(m, "2.0")
+    with pytest.raises(engine.UnsupportedSchemaError):
+        engine.load_manifest(m)
+
+
+def test_load_manifest_rejects_garbage_schema(tmp_path):
+    m = tmp_path / "pending-updates.json"
+    _write_manifest(m, "not-a-version")
+    with pytest.raises(engine.UnsupportedSchemaError):
+        engine.load_manifest(m)
+
+
+# --------------------------------------------------------------------------- #
+# compute_hash() — installer parity
+# --------------------------------------------------------------------------- #
+def test_compute_hash_matches_sha256_of_bytes(tmp_path):
+    f = tmp_path / "f.md"
+    content = b"hello oversight\n"
+    f.write_bytes(content)
+    assert engine.compute_hash(f) == hashlib.sha256(content).hexdigest()
+
+
+# --------------------------------------------------------------------------- #
+# is_stale() — level-triggered re-check
+# --------------------------------------------------------------------------- #
+def test_is_stale_false_when_unchanged(tmp_path):
+    f = tmp_path / "d.md"
+    f.write_bytes(b"deployed\n")
+    e = _entry(base="a", deployed=engine.compute_hash(f), new="c")
+    assert engine.is_stale(e, deployed_path=f) is False
+
+
+def test_is_stale_true_when_deployed_mutated(tmp_path):
+    f = tmp_path / "d.md"
+    f.write_bytes(b"deployed\n")
+    e = _entry(base="a", deployed=engine.compute_hash(f), new="c")
+    f.write_bytes(b"deployed CHANGED\n")  # moved since manifest
+    assert engine.is_stale(e, deployed_path=f) is True
+
+
+def test_is_stale_true_when_deployed_gone(tmp_path):
+    e = _entry(base="a", deployed="whatever", new="c")
+    assert engine.is_stale(e, deployed_path=tmp_path / "missing.md") is True
+
+
+def test_is_stale_true_when_template_moved(tmp_path):
+    d = tmp_path / "d.md"
+    d.write_bytes(b"deployed\n")
+    t = tmp_path / "t.md"
+    t.write_bytes(b"template\n")
+    e = _entry(base="a", deployed=engine.compute_hash(d), new="STALEHASH")
+    assert engine.is_stale(e, deployed_path=d, new_template_path=t) is True
+
+
+# --------------------------------------------------------------------------- #
+# format_version read/write
+# --------------------------------------------------------------------------- #
+def test_read_format_version_absent_is_zero():
+    assert engine.read_format_version("# plain doc\n\nno frontmatter\n") == 0
+    assert engine.read_format_version(INDEX_FIXTURE) == 0  # frontmatter, no stamp
+
+
+def test_write_then_read_format_version_roundtrip():
+    stamped = engine.write_format_version(INDEX_FIXTURE, 3)
+    assert engine.read_format_version(stamped) == 3
+    # Idempotent upsert: re-stamping replaces, never duplicates.
+    stamped2 = engine.write_format_version(stamped, 4)
+    assert engine.read_format_version(stamped2) == 4
+    assert stamped2.count("format_version:") == 1
+
+
+def test_write_format_version_preserves_body_and_other_frontmatter():
+    stamped = engine.write_format_version(INDEX_FIXTURE, 1)
+    # Body (DATA) is byte-identical.
+    assert _body_after_frontmatter(stamped) == _body_after_frontmatter(INDEX_FIXTURE)
+    # Every original frontmatter key survives.
+    for key in ("class:", "read_path:", "owns:", "cap_lines:"):
+        assert key in stamped
+
+
+def test_write_format_version_no_frontmatter_raises():
+    with pytest.raises(engine.CannotStampError):
+        engine.write_format_version("# plain\n\nbody\n", 1)
+
+
+# --------------------------------------------------------------------------- #
+# apply_migrations() — ordered / idempotent / gap / N/A
+# --------------------------------------------------------------------------- #
+def _synthetic_chain():
+    """Two structural migrations that each append a marker line (frontmatter file)."""
+
+    def to_v1(text: str) -> str:
+        return text.rstrip("\n") + "\nMARK_V1\n"
+
+    def to_v2(text: str) -> str:
+        return text.rstrip("\n") + "\nMARK_V2\n"
+
+    return (
+        engine.Migration(0, 1, to_v1, "s0001"),
+        engine.Migration(1, 2, to_v2, "s0002"),
+    )
+
+
+def test_apply_migrations_runs_ordered_chain():
+    out = engine.apply_migrations(INDEX_FIXTURE, 2, _synthetic_chain())
+    assert engine.read_format_version(out) == 2
+    # Both structural markers applied, in order.
+    v1_pos = out.index("MARK_V1")
+    v2_pos = out.index("MARK_V2")
+    assert v1_pos < v2_pos
+    # Original DATA body still present (zero-loss through the chain).
+    assert "BUG-529 — adapter refresh — Open" in out
+
+
+def test_apply_migrations_is_idempotent():
+    once = engine.apply_migrations(INDEX_FIXTURE, 2, _synthetic_chain())
+    twice = engine.apply_migrations(once, 2, _synthetic_chain())
+    assert once == twice  # already at target -> unchanged
+
+
+def test_apply_migrations_partial_then_resume():
+    partial = engine.apply_migrations(INDEX_FIXTURE, 1, _synthetic_chain())
+    assert engine.read_format_version(partial) == 1
+    assert "MARK_V1" in partial and "MARK_V2" not in partial
+    full = engine.apply_migrations(partial, 2, _synthetic_chain())
+    assert engine.read_format_version(full) == 2
+    assert full.count("MARK_V1") == 1  # not re-applied
+
+
+def test_apply_migrations_gap_fails_loud():
+    # Only a 1->2 migration exists; a v0 file has no way to reach it.
+    only_v1_v2 = (engine.Migration(1, 2, lambda t: t, "s0002"),)
+    with pytest.raises(engine.MigrationChainError):
+        engine.apply_migrations(INDEX_FIXTURE, 2, only_v1_v2)
+
+
+def test_apply_migrations_baseline_stamp_on_real_fixture():
+    # The shipped MIGRATIONS registry (0001 baseline) on a real frontmatter file.
+    out = engine.apply_migrations(
+        INDEX_FIXTURE, engine.CURRENT_FORMAT_VERSION, engine.MIGRATIONS
+    )
+    assert engine.read_format_version(out) == 1
+    assert _body_after_frontmatter(out) == _body_after_frontmatter(INDEX_FIXTURE)
+
+
+def test_apply_migrations_no_frontmatter_is_na_terminal():
+    plain = "# plain doc\n\n- data row 1\n- data row 2\n"
+    out = engine.apply_migrations(plain, 1, engine.MIGRATIONS)
+    # No frontmatter to stamp: baseline transform is identity -> file byte-identical,
+    # a clean terminal (data preserved), never a dead-end or error.
+    assert out == plain
+
+
+# --------------------------------------------------------------------------- #
+# atomic_write() — crash-safe, backup-first (BP-187 §4)
+# --------------------------------------------------------------------------- #
+def test_atomic_write_writes_content_and_backs_up(tmp_path):
+    f = tmp_path / "sub" / "f.md"
+    f.parent.mkdir()
+    f.write_text("ORIGINAL\n", encoding="utf-8")
+    backup = engine.atomic_write(f, "NEW CONTENT\n")
+    assert f.read_text(encoding="utf-8") == "NEW CONTENT\n"
+    assert backup == str(f) + ".bak"
+    assert Path(backup).read_text(encoding="utf-8") == "ORIGINAL\n"
+
+
+def test_atomic_write_no_backup_when_target_absent(tmp_path):
+    f = tmp_path / "new.md"
+    backup = engine.atomic_write(f, "FRESH\n")
+    assert backup is None
+    assert f.read_text(encoding="utf-8") == "FRESH\n"
+
+
+def test_atomic_write_accepts_bytes(tmp_path):
+    f = tmp_path / "b.md"
+    engine.atomic_write(f, b"\x00\x01raw\n")
+    assert f.read_bytes() == b"\x00\x01raw\n"
+
+
+def test_atomic_write_leaves_no_temp_files(tmp_path):
+    f = tmp_path / "f.md"
+    engine.atomic_write(f, "content\n")
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+    assert leftovers == []
+
+
+def test_atomic_write_cleans_temp_on_crash(tmp_path, monkeypatch):
+    f = tmp_path / "f.md"
+    f.write_text("SAFE ORIGINAL\n", encoding="utf-8")
+
+    def boom(*a, **k):
+        raise RuntimeError("simulated crash mid-write")
+
+    # Crash at the atomic rename step, after the temp has been written.
+    monkeypatch.setattr(engine.os, "replace", boom)
+    with pytest.raises(RuntimeError):
+        engine.atomic_write(f, "NEW\n")
+    # Original intact (atomic: never a truncated hybrid); no temp left behind.
+    assert f.read_text(encoding="utf-8") == "SAFE ORIGINAL\n"
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+    assert leftovers == []
+
+
+# --------------------------------------------------------------------------- #
+# reconcile_entry() — dispatch, staleness, and the ZERO-DATA-LOSS proof
+# --------------------------------------------------------------------------- #
+def _deploy(project_root: Path, rel: str, content: str) -> Path:
+    p = project_root / "oversight" / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def test_reconcile_no_op_makes_no_write(tmp_path):
+    dep = _deploy(tmp_path, "tracking/x.md", "same\n")
+    e = _entry(base="h", deployed="h", new="h", path="tracking/x.md")
+    res = engine.reconcile_entry(e, project_root=tmp_path)
+    assert res.decision == Decision.NO_OP
+    assert res.action_taken == "no-op"
+    assert not (dep.parent / (dep.name + ".bak")).exists()
+
+
+def test_reconcile_preserve_keeps_deployed(tmp_path):
+    dep = _deploy(tmp_path, "tracking/x.md", "user edited\n")
+    e = _entry(
+        base="base", deployed="edited", new="base", path="tracking/x.md"
+    )  # user_edited, template unchanged
+    res = engine.reconcile_entry(e, project_root=tmp_path)
+    assert res.decision == Decision.PRESERVE
+    assert dep.read_text(encoding="utf-8") == "user edited\n"
+
+
+def test_reconcile_refresh_overwrites_with_template(tmp_path):
+    dep = _deploy(tmp_path, "tracking/x.md", "old deployed\n")
+    template = tmp_path / "new_template.md"
+    template.write_text("NEW TEMPLATE\n", encoding="utf-8")
+    e = _entry(
+        base=engine.compute_hash(dep),  # deployed == base -> user NOT edited
+        deployed=engine.compute_hash(dep),
+        new=engine.compute_hash(template),  # template changed
+        path="tracking/x.md",
+    )
+    res = engine.reconcile_entry(e, project_root=tmp_path, new_template_path=template)
+    assert res.decision == Decision.REFRESH
+    assert dep.read_text(encoding="utf-8") == "NEW TEMPLATE\n"
+    assert Path(res.backup_path).read_text(encoding="utf-8") == "old deployed\n"
+
+
+def test_reconcile_conflict_migrates_structure_preserves_data(tmp_path):
+    # THE ZERO-DATA-LOSS PROOF: a both-changed data-bearing file reconciles by
+    # migrating STRUCTURE (frontmatter format_version stamp) forward while every
+    # operator DATA row survives byte-for-byte.
+    dep = _deploy(tmp_path, "bugs/INDEX.md", INDEX_FIXTURE)
+    e = _entry(
+        base="last_shipped",  # non-empty base
+        deployed=engine.compute_hash(dep),  # != base -> user edited
+        new="new_template",  # != base -> template changed  => CONFLICT
+        path="bugs/INDEX.md",
+    )
+    before_body = _body_after_frontmatter(dep.read_text(encoding="utf-8"))
+
+    res = engine.reconcile_entry(e, project_root=tmp_path)
+
+    assert res.decision == Decision.CONFLICT
+    assert res.action_taken == "migrated"
+    after = dep.read_text(encoding="utf-8")
+    # STRUCTURE advanced: format_version stamped.
+    assert engine.read_format_version(after) == 1
+    # DATA preserved: body byte-identical (ZERO data loss).
+    assert _body_after_frontmatter(after) == before_body
+    # Every operator data row survives verbatim.
+    for row in (
+        "BUG-527 — deploy parity — Closed",
+        "BUG-528 — marker asymmetry — Open",
+        "BUG-529 — adapter refresh — Open",
+        "| Open   | 12    |",
+        "| Closed | 111   |",
+    ):
+        assert row in after
+    # Backup captured the pre-migration original exactly.
+    assert Path(res.backup_path).read_text(encoding="utf-8") == INDEX_FIXTURE
+
+
+def test_reconcile_conflict_no_frontmatter_preserves_as_terminal(tmp_path):
+    # A both-changed file with no frontmatter: baseline stamp is N/A -> data
+    # preserved, clean "preserved" terminal (note 2: not a dead-end).
+    plain = "# Decision Log\n\n### DEC-1\nbody\n"
+    dep = _deploy(tmp_path, "tracking/decision-log.md", plain)
+    e = _entry(
+        base="base",
+        deployed=engine.compute_hash(dep),
+        new="new",
+        path="tracking/decision-log.md",
+    )
+    res = engine.reconcile_entry(e, project_root=tmp_path)
+    assert res.decision == Decision.CONFLICT
+    assert res.action_taken == "preserved"
+    assert dep.read_text(encoding="utf-8") == plain  # byte-identical
+    assert res.backup_path is None
+
+
+def test_reconcile_conflict_idempotent_second_run_is_preserved(tmp_path):
+    dep = _deploy(tmp_path, "bugs/INDEX.md", INDEX_FIXTURE)
+    e1 = _entry(
+        base="b", deployed=engine.compute_hash(dep), new="n", path="bugs/INDEX.md"
+    )
+    first = engine.reconcile_entry(e1, project_root=tmp_path)
+    assert first.action_taken == "migrated"
+    # Second pass: file now stamped; a fresh manifest reflects the new deployed hash.
+    e2 = _entry(
+        base="b", deployed=engine.compute_hash(dep), new="n", path="bugs/INDEX.md"
+    )
+    second = engine.reconcile_entry(e2, project_root=tmp_path)
+    assert second.action_taken == "preserved"  # already current, no re-write
+
+
+def test_reconcile_refuses_stale_manifest(tmp_path):
+    dep = _deploy(tmp_path, "bugs/INDEX.md", INDEX_FIXTURE)
+    e = _entry(
+        base="b",
+        deployed="STALE_HASH_FROM_OLD_MANIFEST",  # != current on-disk hash
+        new="n",
+        path="bugs/INDEX.md",
+    )
+    with pytest.raises(engine.StaleManifestError):
+        engine.reconcile_entry(e, project_root=tmp_path)
+    # Refused before any write: file untouched, no backup created.
+    assert dep.read_text(encoding="utf-8") == INDEX_FIXTURE
+    assert not (dep.parent / (dep.name + ".bak")).exists()

--- a/tests/test_plan033_p3_reconcile_engine.py
+++ b/tests/test_plan033_p3_reconcile_engine.py
@@ -53,12 +53,19 @@ Decision = engine.Decision
 # --------------------------------------------------------------------------- #
 # Helpers / fixtures
 # --------------------------------------------------------------------------- #
-def _entry(*, base: str, deployed: str, new: str, path: str = "tracking/x.md"):
+def _entry(
+    *,
+    base: str,
+    deployed: str,
+    new: str,
+    path: str = "tracking/x.md",
+    classification: str = "MANAGED_MERGE_REQUIRED",
+):
     """Build a ReconcileEntry with just the digest triple that matters."""
     return engine.ReconcileEntry(
         id=path,
         path=f"oversight/{path}",
-        classification="MANAGED_MERGE_REQUIRED",
+        classification=classification,
         old_shipped_hash=base,
         deployed_hash=deployed,
         new_template_hash=new,
@@ -437,6 +444,10 @@ def test_reconcile_preserve_keeps_deployed(tmp_path):
 
 
 def test_reconcile_refresh_overwrites_with_template(tmp_path):
+    # A raw refresh is only for a NON-data-bearing (fully installer-owned) file.
+    # "INSTALLER_OWNED" is a PLACEHOLDER token: P1's classification taxonomy is not
+    # yet formally defined (today P1 emits only MANAGED_MERGE_REQUIRED), so this
+    # exercises the defense-in-depth safe-refresh extension point, not a live path.
     dep = _deploy(tmp_path, "tracking/x.md", "old deployed\n")
     template = tmp_path / "new_template.md"
     template.write_text("NEW TEMPLATE\n", encoding="utf-8")
@@ -445,11 +456,50 @@ def test_reconcile_refresh_overwrites_with_template(tmp_path):
         deployed=engine.compute_hash(dep),
         new=engine.compute_hash(template),  # template changed
         path="tracking/x.md",
+        classification="INSTALLER_OWNED",  # placeholder overwrite-safe token
     )
     res = engine.reconcile_entry(e, project_root=tmp_path, new_template_path=template)
     assert res.decision == Decision.REFRESH
+    assert res.action_taken == "refreshed"
     assert dep.read_text(encoding="utf-8") == "NEW TEMPLATE\n"
     assert Path(res.backup_path).read_text(encoding="utf-8") == "old deployed\n"
+
+
+def test_reconcile_refresh_data_bearing_migrates_not_overwrites(tmp_path):
+    # F1 defense-in-depth: even in the REFRESH quadrant (deployed == base, template
+    # changed), a data-bearing/managed file must migrate STRUCTURE forward and
+    # preserve every operator DATA row — NOT be raw-overwritten with the new template.
+    dep = _deploy(tmp_path, "bugs/INDEX.md", INDEX_FIXTURE)
+    template = tmp_path / "new_template.md"
+    template.write_text("BRAND NEW EMPTY TEMPLATE\n", encoding="utf-8")
+    e = _entry(
+        base=engine.compute_hash(dep),  # deployed == base -> user NOT edited
+        deployed=engine.compute_hash(dep),
+        new=engine.compute_hash(template),  # template changed -> REFRESH quadrant
+        path="bugs/INDEX.md",
+        classification="MANAGED_MERGE_REQUIRED",  # data-bearing
+    )
+    assert engine.classify(e) == Decision.REFRESH  # genuinely the REFRESH quadrant
+
+    res = engine.reconcile_entry(e, project_root=tmp_path, new_template_path=template)
+
+    # Routed to the migrate path: template content is NOT written in.
+    assert res.decision == Decision.REFRESH
+    assert res.action_taken == "migrated"
+    after = dep.read_text(encoding="utf-8")
+    assert "BRAND NEW EMPTY TEMPLATE" not in after
+    # STRUCTURE advanced; every operator DATA row survives byte-for-byte.
+    assert engine.read_format_version(after) == 1
+    for row in (
+        "BUG-527 — deploy parity — Closed",
+        "BUG-528 — marker asymmetry — Open",
+        "BUG-529 — adapter refresh — Open",
+        "| Open   | 12    |",
+        "| Closed | 111   |",
+    ):
+        assert row in after
+    # Backup captured the pre-migration original exactly.
+    assert Path(res.backup_path).read_text(encoding="utf-8") == INDEX_FIXTURE
 
 
 def test_reconcile_conflict_migrates_structure_preserves_data(tmp_path):
@@ -533,3 +583,136 @@ def test_reconcile_refuses_stale_manifest(tmp_path):
     # Refused before any write: file untouched, no backup created.
     assert dep.read_text(encoding="utf-8") == INDEX_FIXTURE
     assert not (dep.parent / (dep.name + ".bak")).exists()
+
+
+# --------------------------------------------------------------------------- #
+# F2 — backup must NOT follow a symlink at <path>.bak (clobbers an unrelated
+# file the operator owns). BP-187 §4: backup-before-write is a safety net, never
+# a foot-gun that destroys data elsewhere.
+# --------------------------------------------------------------------------- #
+def test_atomic_write_backup_does_not_follow_symlink(tmp_path):
+    victim = tmp_path / "unrelated_precious.txt"
+    victim.write_text("PRECIOUS — MUST SURVIVE\n", encoding="utf-8")
+    f = tmp_path / "f.md"
+    f.write_text("ORIGINAL\n", encoding="utf-8")
+    # A pre-existing symlink sits where the backup would be written.
+    bak = Path(str(f) + ".bak")
+    bak.symlink_to(victim)
+
+    engine.atomic_write(f, "NEW CONTENT\n")
+
+    # The symlink's target (an unrelated file) is untouched — copy2 default
+    # follow_symlinks=True would have clobbered it with f.md's old bytes.
+    assert victim.read_text(encoding="utf-8") == "PRECIOUS — MUST SURVIVE\n"
+    # The write itself still succeeded.
+    assert f.read_text(encoding="utf-8") == "NEW CONTENT\n"
+
+
+# --------------------------------------------------------------------------- #
+# F3 — single-slot .bak must not silently clobber (a) an operator's pre-existing
+# sibling .bak or (b) an earlier backup on a 2nd write. BP-187 §4.5.
+# --------------------------------------------------------------------------- #
+def test_atomic_write_does_not_clobber_preexisting_bak(tmp_path):
+    f = tmp_path / "f.md"
+    f.write_text("V1\n", encoding="utf-8")
+    operator_bak = Path(str(f) + ".bak")
+    operator_bak.write_text("OPERATOR'S OWN BACKUP — KEEP\n", encoding="utf-8")
+
+    backup = engine.atomic_write(f, "V2\n")
+
+    # The operator's pre-existing .bak survives untouched.
+    assert operator_bak.read_text(encoding="utf-8") == "OPERATOR'S OWN BACKUP — KEEP\n"
+    # Our backup went to a collision-safe name (not the operator's .bak).
+    assert backup != str(operator_bak)
+    assert Path(backup).read_text(encoding="utf-8") == "V1\n"
+
+
+def test_atomic_write_second_write_does_not_selfclobber_backup(tmp_path):
+    f = tmp_path / "f.md"
+    f.write_text("V1\n", encoding="utf-8")
+    b1 = engine.atomic_write(f, "V2\n")  # backs up V1
+    b2 = engine.atomic_write(f, "V3\n")  # backs up V2 — must NOT overwrite b1
+    assert b1 != b2
+    assert Path(b1).read_text(encoding="utf-8") == "V1\n"
+    assert Path(b2).read_text(encoding="utf-8") == "V2\n"
+
+
+# --------------------------------------------------------------------------- #
+# F4 — a leading `---…---` markdown thematic break is NOT YAML frontmatter and
+# must never get a format_version stamp injected into operator content.
+# --------------------------------------------------------------------------- #
+def test_write_format_version_thematic_break_is_not_frontmatter():
+    # Opens with a thematic break; the block between the rules is prose, not
+    # key: value YAML.
+    doc = (
+        "---\n"
+        "A horizontal rule opens this note, not YAML frontmatter.\n"
+        "Just prose describing a decision.\n"
+        "---\n"
+        "Body content.\n"
+    )
+    with pytest.raises(engine.CannotStampError):
+        engine.write_format_version(doc, 1)
+
+
+def test_read_format_version_thematic_break_is_zero():
+    doc = "---\nnarrative prose, no keys here\n---\nbody\n"
+    assert engine.read_format_version(doc) == 0
+
+
+def test_apply_migrations_thematic_break_not_stamped(tmp_path):
+    # Through the real registry: a thematic-break doc is an N/A terminal — it
+    # comes out byte-identical, never with format_version injected.
+    doc = "---\nHorizontal rule, not frontmatter.\n---\n\nOperator body row.\n"
+    out = engine.apply_migrations(doc, engine.CURRENT_FORMAT_VERSION, engine.MIGRATIONS)
+    assert out == doc
+
+
+# --------------------------------------------------------------------------- #
+# F5 — the inserted stamp line must match the file's dominant newline; a CRLF
+# file must not gain a bare-LF line (mixed endings).
+# --------------------------------------------------------------------------- #
+def test_write_format_version_preserves_crlf_line_endings():
+    crlf = INDEX_FIXTURE.replace("\n", "\r\n")
+    stamped = engine.write_format_version(crlf, 1)
+    assert engine.read_format_version(stamped) == 1
+    # The inserted stamp line carries the file's CRLF ending.
+    assert "format_version: 1\r\n" in stamped
+    # No lone LF anywhere: every newline is a CRLF pair.
+    assert "\n" not in stamped.replace("\r\n", "")
+    # Re-stamp (the replace branch) must also keep CRLF.
+    restamped = engine.write_format_version(stamped, 2)
+    assert "\n" not in restamped.replace("\r\n", "")
+
+
+# --------------------------------------------------------------------------- #
+# F6 — load_manifest wraps parse/entry errors in ReconcileError so callers catch
+# one uniform type (fail-loud, no write — just a catchable type).
+# --------------------------------------------------------------------------- #
+def test_load_manifest_wraps_json_decode_error(tmp_path):
+    m = tmp_path / "pending-updates.json"
+    m.write_text("{ this is not valid json", encoding="utf-8")
+    with pytest.raises(engine.ReconcileError):
+        engine.load_manifest(m)
+
+
+def test_load_manifest_wraps_missing_entry_id(tmp_path):
+    m = tmp_path / "pending-updates.json"
+    m.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "entries": [
+                    {  # no "id" key
+                        "path": "oversight/tracking/decision-log.md",
+                        "old_shipped_hash": "a",
+                        "deployed_hash": "b",
+                        "new_template_hash": "c",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(engine.ReconcileError):
+        engine.load_manifest(m)


### PR DESCRIPTION
## Summary

Completes the managed-file deployment path so a normal update reaches existing
installs, and makes both-changed oversight-template drift reconcilable under
human review instead of an inert, recurring warning. Two problems are addressed:
adapter guidance that never refreshed on existing installs, and oversight
templates that drift and then only warn without any way to reconcile.

## Changes

**IDE-adapter project detection (BUG-529).** Installer IDE auto-detection keyed
off machine-CLI presence, so an existing install never refreshed adapters for a
CLI that wasn't on the current machine's PATH. Detection now also considers
adapters already deployed in the project, gated on AI-Memory ownership markers:

- `detect_gemini_project` requires the ownership header in `AI-MEMORY.md` rather
  than bare file existence, so a user's hand-written file is neither selected nor
  overwritten.
- `detect_codex_project` recognises the `AGENTS.md` managed-block marker.
- A parity test asserts the gemini detection marker stays in sync with the
  shipped guidance template's heading, so a future edit to either side fails
  loudly instead of silently dropping detection.

**Pending-change manifest (producer).** When an update finds an oversight file
that is both user-modified and changed upstream, the installer now emits a
structured `pending-updates.json` (three-state digest triple, schema-versioned,
content-addressed, atomically written) instead of only logging a warning.

**Reconciliation engine.** A standalone engine consumes the manifest and, per
entry, preserves user data while migrating structure forward: backup, atomic
temp-write-and-rename, staleness re-check, and an Alembic-style stamped migration
chain. Data-bearing files are never raw-overwritten.

**Session-start reconciliation surface.** The in-project agent discovers the
manifest at session start: a one-line ambient rollup, and an on-request flow that
lists pending entries (count and pointer, never inline diffs) and reconciles each
under explicit approve/defer/dismiss review. Dispositions are recorded and do not
re-surface unless the upstream template hash moves.

## Testing

- Adapter detection, deploy-parity, manifest producer, reconciliation engine, and
  the session-start helper are covered by unit tests; the full changed surface is
  green (207 tests).
- Data-safety paths (correct target resolution, apply-before-record ordering,
  zero-data-loss on migrate, fail-safe on an unreadable or malformed manifest)
  are exercised directly.

## Notes

Follow-up items are tracked separately and are not required for this change. A
concrete before/after content diff of the real drifted files on a live install
is the remaining verification before release.
