### PR TITLE
docs: reposition README intro as an AI development harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,28 @@
   <img src="https://img.shields.io/badge/Gemini_CLI-Supported-4285F4?style=flat-square&logo=google" alt="Gemini CLI">
   <img src="https://img.shields.io/badge/Cursor-Supported-00D4AA?style=flat-square" alt="Cursor">
   <img src="https://img.shields.io/badge/Codex_CLI-Supported-412991?style=flat-square&logo=openai" alt="Codex CLI">
+  <a href="https://github.com/bmad-code-org/BMAD-METHOD"><img src="https://img.shields.io/badge/BMad_Method-Powered-blue?style=flat-square" alt="BMad Method"></a>
 </p>
 
 ---
 
-**AI-Memory** is a persistent context layer that gives AI coding agents institutional memory across sessions — storing architectural decisions, code patterns, conventions, and project history in a vector database (Qdrant), and surfacing the right context automatically when you need it.
+**AI-Memory** is a long-lived **AI development harness**: persistent project memory, a built-in AI project manager, and a [BMad Method](https://github.com/bmad-code-org/BMAD-METHOD)–driven agent team that carry a project from its first commit through every release to long-term maintenance.
+
+It gives AI-assisted development the three things a real project needs that a chat window doesn't:
+
+- **Memory that persists** — decisions, code patterns, and conventions are captured as you work and resurfaced automatically at session start and per turn, so you never re-explain past work. *(Project-scoped, backed by a Qdrant vector store.)*
+- **A project manager** — **Parzival**, a Technical PM & Quality Gatekeeper, plans the work, dispatches parallel agent teams, reviews their output adversarially, and holds quality gates across sessions. *He recommends; you decide.*
+- **A real team** — Parzival runs a [BMad Method](https://github.com/bmad-code-org/BMAD-METHOD) roster — developer, reviewer, tech-writer, analyst, architect, UX — so build, review, and docs each get the right specialist.
+
+**Built for the whole arc of a project, not a single prompt:**
+```mermaid
+flowchart LR
+  new[new project] --> disc[discovery] --> arch[architecture] --> plan[planning]
+  plan --> exec[execution] --> intg[integration] --> rel[release] --> maint[maintenance]
+```
+Parzival routes each session to the right phase, loads only that phase's context, and — with the memory layer, source-of-truth drift detection, and a self-maintaining wiki — keeps a months-long project coherent as it grows through updates and new features.
+
+**Who it's for:** developers and small teams doing AI-assisted development who want continuity, oversight, and quality gates across long-lived projects — not just autocomplete.
 
 [**Report a Bug**](https://github.com/Hidden-History/ai-memory/issues) | [**Request a Feature**](https://github.com/Hidden-History/ai-memory/issues) | [**CHANGELOG**](CHANGELOG.md)
 
@@ -154,7 +171,7 @@ See [docs/AIM-SOT.md](docs/AIM-SOT.md) for the Source-of-Truth subsystem — reg
 
 ## Parzival: AI Project Manager
 
-Parzival is an AI project manager for Claude Code. He manages the full project lifecycle — planning work, activating parallel agent teams, reviewing output adversarially, and maintaining cross-session continuity. You talk to Parzival; he manages everything else.
+Parzival is an AI project manager for Claude Code. He manages the full project lifecycle — planning work, activating parallel agent teams, reviewing output adversarially, and maintaining cross-session continuity. His agent team runs on the [BMad Method](https://github.com/bmad-code-org/BMAD-METHOD), so build, review, and docs work each get a dedicated specialist persona. You talk to Parzival; he manages everything else.
 
 **Session commands:**
 

--- a/docs/DISPATCH-SKILLS.md
+++ b/docs/DISPATCH-SKILLS.md
@@ -22,7 +22,7 @@ Multi-LLM agent dispatch for Claude Code -- design teams, activate agents across
 The Parzival dispatch skill suite is a set of 7 skills that enable multi-agent orchestration within Claude Code. Together, they allow Parzival to:
 
 - **Design parallel agent teams** with file ownership isolation and conflict avoidance
-- **Activate agents** using either generic or BMAD (Build Measure Analyze Design) personas
+- **Activate agents** using either generic or BMAD personas
 - **Route tasks to different LLM providers** -- Claude (native), Ollama, OpenRouter, and 8 additional backends
 - **Manage the full agent lifecycle** -- instruction delivery, progress monitoring, output review, correction loops, and shutdown
 

--- a/docs/parzival/README-POV.md
+++ b/docs/parzival/README-POV.md
@@ -852,7 +852,7 @@ MIT License - See BMAD Method for full license terms.
 ## 🙏 Acknowledgments
 
 Parzival is built on:
-- **[BMAD Method](https://github.com/bmad-method/bmad-method)** - AI-powered development methodology
+- **[BMAD Method](https://github.com/bmad-code-org/BMAD-METHOD)** - AI-powered development methodology
 - **[Claude Code](https://claude.ai/code)** - AI pair programming environment
 
 ---


### PR DESCRIPTION
## What

Repositions the README's opening so a first-time reader sees what AI-Memory actually is — a long-term **AI development harness** (persistent memory + a built-in AI project manager + a BMad Method agent team) across the full project lifecycle — rather than a memory-layer-only description.

## Changes

- **Intro rewrite** — a harness hero line, three pillars (memory / project manager / team), a mermaid lifecycle flow (new project → discovery → … → maintenance), and a "who it's for" line.
- **BMad Method linkage** — a BMad Method badge in the header row and a framework link in the Parzival section (the framework was previously unlinked in the README).
- **Two small doc fixes** — correct the BMAD acronym gloss in `docs/DISPATCH-SKILLS.md`, and a stale framework URL in `docs/parzival/README-POV.md`.

Docs-only — no code or behavior changes. Diff touches `README.md` and the two docs files.
