### PR TITLE
Fix RUF036: place None last in trace_buffer type union

### DIFF
--- a/src/memory/trace_buffer.py
+++ b/src/memory/trace_buffer.py
@@ -46,7 +46,7 @@ def emit_trace_event(
     data: dict,
     trace_id: str | None = None,
     span_id: str | None = None,
-    parent_span_id: str | None | object = _UNSET,
+    parent_span_id: str | object | None = _UNSET,
     session_id: str | None = None,
     project_id: str | None = None,
     start_time: datetime | None = None,


### PR DESCRIPTION
A newly-active ruff rule (RUF036) flagged a type union where None was not in last position, failing the Lint job on main and blocking PR merges. Reorders the single parameter annotation so None comes last. Semantically identical (union member order is irrelevant in Python typing). Local lint gate (ruff, black, isort) passes clean; scoped to one line.