### PR TITLE
Correct POV dispatch guidance and stop mocked config leaking a queue tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,9 @@ scripts/_migration_state.json
 # Backup/verification directories (user-local, not for repo)
 _ai-memory/_ai-memory.restructred/
 _ai-memory/pov.v1.bak/
+
+# Stray tree from a test that mocks get_config() and reaches the enqueue path.
+# _resolve_queue_dir() now rejects non-path config (TD-798), so nothing should
+# create this. Kept as a backstop so a future unhardened path cannot dirty a
+# diff -- this masks the symptom and is NOT a substitute for the guard.
+MagicMock/

--- a/_ai-memory/pov/skills/aim-agent-dispatch/SKILL.md
+++ b/_ai-memory/pov/skills/aim-agent-dispatch/SKILL.md
@@ -174,6 +174,8 @@ MUST spawn fresh agent for every task -- never reuse across roles or stories.
 
 MUST use `/bmad-agent-tech-writer` for ALL documentation tasks (writing, updating, reviewing docs). MUST use `/bmad-code-review` for ALL review agents (never `/bmad-agent-dev`). MUST use `/bmad-help` whenever unsure which agent or workflow to use -- the tables above are NOT exhaustive.
 
+**Activation form — the leading `/` is required.** Activate BMAD personas as `/bmad-<name>`, not a bare name. **If a `/bmad-*` activation fails, the cause is CWD drift — the teammate was spawned from the wrong directory.** Correct response: shut it down and respawn from the sentinel-verified workspace root (Step 0). Do NOT conclude the skill is unavailable, do NOT substitute a general-purpose agent, and do NOT have the teammate file-read the persona — those are the substitute anti-patterns BOND forbids. (PM #415: a misdiagnosis of this failure as "skill unavailable from a subagent context" cost two sessions and produced a standing instruction telling reviewers not to attempt a tool that worked.)
+
 MUST route ALL best-practice / conventions / coding-standard research through `/aim-best-practices-researcher` -- never hand-run web searches for this. The skill saves the finding to a BP file and stores it to the project-scoped conventions collection, so hand-rolling the research loses it to future sessions.
 
 **Workflow commands by phase** (sent AFTER activation, when in planning mode):
@@ -182,8 +184,8 @@ MUST route ALL best-practice / conventions / coding-standard research through `/
 |-------|-------|-----------------|
 | Research | Analyst | `/bmad-market-research`, `/bmad-domain-research`, `/bmad-technical-research` |
 | Discovery | Analyst | `/bmad-product-brief` |
-| Discovery (or any phase) | PM | `/bmad-create-prd`, `/bmad-validate-prd`, `/bmad-edit-prd` |
-| Architecture | Architect | `/bmad-create-architecture` |
+| Discovery (or any phase) | PM | `/bmad-prd` (create / update / validate intent) |
+| Architecture | Architect | `/bmad-architecture` (create intent) |
 | Architecture | PM | `/bmad-create-epics-and-stories` |
 | Architecture | Architect | `/bmad-check-implementation-readiness` |
 | Architecture | UX Designer | `/bmad-ux` |
@@ -195,16 +197,19 @@ MUST route ALL best-practice / conventions / coding-standard research through `/
 
 Set `AI_MEMORY_AGENT_ID` environment variable when spawning.
 
-> **Maintenance check:** `scripts/check_bmad_commands.sh` verifies every `/bmad-*` command in the tables above resolves to an installed skill under `.claude/skills/` (fire-only-if-missing: silent when all resolve, non-zero listing any that don't; degrades gracefully when BMAD is not installed). Run it after editing these tables or updating the BMAD module.
+> **Maintenance check:** `scripts/check_bmad_commands.sh` verifies every `/bmad-*` command in the tables above resolves to an installed skill under `.claude/skills/` (fire-only-if-missing: silent when all resolve, non-zero listing any that don't; degrades gracefully when BMAD is not installed). Run it after editing these tables or updating the BMAD module. Pass `--check-deprecated` to ALSO fail on a command that resolves but is a deprecated back-compat shim — resolution alone cannot catch one (TD-971: `/bmad-create-prd` passed a green check for exactly this reason).
 
 #### B4. Verify Activation (MANDATORY — two-phase)
 
 **Sentinel (CLAUDE.md workspace-root):** before every spawn, as its own Bash step, assert workspace root:
 `test -d _ai-memory && test -d _bmad && test -d oversight`. FAIL → ABORT.
 
-**Spawn (two-phase, GC-20):** the spawn prompt loads the BMAD persona via the Skill tool (e.g.
-`Use the Skill tool to load bmad-agent-dev` — likewise `bmad-create-story`, `bmad-code-review`; a bare
-`/bmad-*` at spawn activates the lead, not the persona) + one line — "You're activated as a teammate
+**Spawn (two-phase, GC-20):** the spawn prompt loads the BMAD persona via the Skill tool, using the
+**slash form** — e.g. `Use the Skill tool to load /bmad-agent-dev` — likewise `/bmad-create-story`,
+`/bmad-code-review`. The leading `/` is required. **If a `/bmad-*` activation fails, the teammate was
+spawned from the WRONG DIRECTORY** — shut it down and respawn from the sentinel-verified workspace root
+(Step 0). Never conclude the skill is unavailable, never fall back to a bare name, never file-read the
+persona. + one line — "You're activated as a teammate
 under Parzival (team-lead). Once activated, SendMessage your activation reply (greeting + menu, and
 anything the agent asks) to team-lead, then wait for my instructions before doing any work." Never the
 task. `mode: auto`.

--- a/_ai-memory/pov/skills/aim-agent-dispatch/scripts/check_bmad_commands.sh
+++ b/_ai-memory/pov/skills/aim-agent-dispatch/scripts/check_bmad_commands.sh
@@ -12,6 +12,7 @@
 # flag every command as broken.
 #
 # Usage: check_bmad_commands.sh [--skill-md <file>] [--skills-dir <dir>]
+#                               [--check-deprecated]
 #
 # --skill-md <file>
 #     SKILL.md whose tables are scanned for /bmad-* tokens.
@@ -19,9 +20,17 @@
 # --skills-dir <dir>
 #     Directory where installed skills live (one subdir per skill).
 #     Default: ./.claude/skills (relative to CWD — the project/workspace root).
+# --check-deprecated
+#     ALSO fail when a referenced command resolves to a skill whose frontmatter
+#     `description:` marks it DEPRECATED (a back-compat shim forwarding to a
+#     successor). Resolution alone cannot catch this: a shim resolves perfectly,
+#     which is why TD-971 (/bmad-create-prd) survived a green check. Deprecation
+#     is judged ONLY on the `description:` field — a body mention of the word
+#     "deprecation" is prose, not a shim marker.
 #
-# Exit codes: 0 = all referenced commands resolve, or BMAD not installed (skip)
-#             1 = one or more referenced commands do not resolve
+# Exit codes: 0 = all referenced commands resolve (and, with --check-deprecated,
+#                 none is a deprecated shim), or BMAD not installed (skip)
+#             1 = one or more referenced commands do not resolve, or are shims
 #             2 = bad argument / missing input file
 #
 # Output routing: all output is net-new -> stderr; stdout stays empty.
@@ -33,6 +42,7 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 skill_md="${SCRIPT_DIR}/../SKILL.md"
 skills_dir="./.claude/skills"
+check_deprecated=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -42,9 +52,11 @@ while [[ $# -gt 0 ]]; do
         --skills-dir)
             [[ $# -ge 2 ]] || { echo "check_bmad_commands: --skills-dir requires a dir" >&2; exit 2; }
             skills_dir="$2"; shift 2 ;;
+        --check-deprecated)
+            check_deprecated=1; shift ;;
         *)
             echo "check_bmad_commands: unknown argument: $1" >&2
-            echo "Usage: check_bmad_commands.sh [--skill-md <file>] [--skills-dir <dir>]" >&2
+            echo "Usage: check_bmad_commands.sh [--skill-md <file>] [--skills-dir <dir>] [--check-deprecated]" >&2
             exit 2 ;;
     esac
 done
@@ -90,6 +102,31 @@ if [[ ${#unresolved[@]} -gt 0 ]]; then
     done
     echo "Fix the table row(s) in ${skill_md} or install the missing skill(s)." >&2
     exit 1
+fi
+
+# Deprecation pass: a shim RESOLVES, so this cannot be folded into the loop
+# above. Judged only on the frontmatter `description:` line, which is where the
+# BMAD deprecation scheme records it; a body mention of "deprecation" is prose.
+if [[ $check_deprecated -eq 1 ]]; then
+    deprecated=()
+    for cmd in "${commands[@]}"; do
+        name="${cmd#/}"
+        skill_file="${skills_dir}/${name}/SKILL.md"
+        [[ -f "$skill_file" ]] || continue
+        desc="$(grep -m1 '^description:' "$skill_file" || true)"
+        if [[ "$desc" == *DEPRECATED* ]]; then
+            deprecated+=("$cmd")
+        fi
+    done
+
+    if [[ ${#deprecated[@]} -gt 0 ]]; then
+        echo "check_bmad_commands: ${#deprecated[@]} referenced BMAD command(s) resolve but are DEPRECATED shims:" >&2
+        for cmd in "${deprecated[@]}"; do
+            echo "  deprecated: ${cmd}  (${skills_dir}/${cmd#/}/SKILL.md declares it a shim)" >&2
+        done
+        echo "Point the table row(s) in ${skill_md} at the successor skill named in each shim's description." >&2
+        exit 1
+    fi
 fi
 
 exit 0

--- a/_ai-memory/pov/skills/aim-parzival-team-builder/SKILL.md
+++ b/_ai-memory/pov/skills/aim-parzival-team-builder/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aim-parzival-team-builder
 description: Design agent team structure for parallel work execution
-allowed-tools: Read
+allowed-tools: Read, Grep, Bash
 context: fork
 ---
 
@@ -49,7 +49,7 @@ The fast path should read like a form, not a conversation.
 ```yaml
 # Dispatch Plan v1
 provider: claude
-model: claude-sonnet-4-6
+model: sonnet
 agent: dev
 agent_id: dev-auth
 bmad_agent_type: dev
@@ -61,7 +61,7 @@ workspace_root: /mnt/e/projects/dev-ai-memory
 complexity: moderate
 reviewer_plan:
   mode: single
-  models: [claude-sonnet-4-6]
+  models: [sonnet]
 route: aim-agent-dispatch
 # Approve?
 ```
@@ -84,7 +84,7 @@ not collapse to prose.
 ```yaml
 # Dispatch Plan v1
 provider: claude | openrouter | ollama | gemini | deepseek | groq | cerebras | mistral | openai | vertex-ai | siliconflow
-model: <exact-model-id-string>       # verbatim, e.g., "glm-5.1:cloud", "claude-sonnet-4-6"
+model: <exact-model-id-string>       # verbatim, e.g., "glm-5.1:cloud". Anthropic models by TIER ALIAS: "opus", "sonnet", "haiku" -- never a pinned ID
 agent: <role-name>                   # dev | pm | architect | analyst | ux-designer | tech-writer | code-reviewer | <generic>
 agent_id: <AI_MEMORY_AGENT_ID>       # e.g., "dev-auth", "review-opus", "architect-design"
 bmad_agent_type: <type> | null       # null ONLY for genuine non-BMAD work (code-reviewer, verify). If a BMAD role fits, null is a FAIL — assign the persona.
@@ -274,7 +274,7 @@ Before executing, verify:
 - [ ] No file ownership conflicts
 - [ ] Each agent has clear DONE WHEN criteria
 - [ ] Each agent has a unique AI_MEMORY_AGENT_ID assigned
-- [ ] Team size is 3-5 (split if larger)
+- [ ] Team size is 3-5 (split if larger) — **exception: a dual-review pair (2) is sanctioned**
 - [ ] Conflict avoidance strategy selected and documented
 - [ ] Context blocks are complete (no placeholders or TBDs)
 - [ ] No two parallel workspace-writing Validate skills share a `doc_workspace` (each validator in a separate git worktree — #284)
@@ -308,9 +308,10 @@ The team design document (Steps 1-6) is the deliverable. It feeds into the agent
 placeholder families that are NOT Step-4 context-block content — the dispatch-time assembler fills them
 from each agent's BMAD role so no raw placeholder survives into a rendered prompt:
 - `{*_activation}` (`{teammate_N_activation}`, `{manager_N_activation}`, `{worker_N_activation}`) =
-  the Skill-tool-load activation string for that agent's BMAD role — e.g. `Use the Skill tool to load
-  bmad-dev (the BMAD dev persona).` A bare `/bmad-*` at spawn activates the lead, not the persona, so
-  the persona MUST be loaded via the Skill tool.
+  the Skill-tool-load activation string for that agent's BMAD role, using the **slash form** — e.g.
+  `Use the Skill tool to load /bmad-agent-dev (the BMAD dev persona).` The leading `/` is required.
+  **If activation fails, the teammate was spawned from the wrong directory** — respawn from the
+  sentinel-verified workspace root rather than treating the skill as unavailable.
 - `{*_subagent_type}` (`{teammate_N_subagent_type}` / `{teammate_subagent_type}`,
   `{manager_N_subagent_type}` / `{manager_subagent_type}`) = `general-purpose` — the BMAD persona
   activates via the in-prompt Skill-load, not a native `subagent_type`. (Workers spawn via tmux

--- a/src/memory/classifier/queue.py
+++ b/src/memory/classifier/queue.py
@@ -15,7 +15,7 @@ import logging
 import os
 import time
 from dataclasses import asdict, dataclass
-from pathlib import Path
+from pathlib import Path, PurePath
 
 logger = logging.getLogger("ai_memory.classifier.queue")
 
@@ -30,7 +30,15 @@ def _resolve_queue_dir() -> Path:
     try:
         from ..config import get_config
 
-        return Path(get_config().queue_dir)
+        raw = get_config().queue_dir
+        # Reject anything that is not genuinely a path. A test double such as
+        # MagicMock implements __fspath__, so Path() would SUCCEED and yield the
+        # relative path "MagicMock/<name>/<id>" -- which enqueue then mkdir()s
+        # into the CWD (the repo root). os.PathLike cannot be used to
+        # discriminate here: MagicMock satisfies it and a plain str does not.
+        if not isinstance(raw, (str, PurePath)):
+            raise TypeError(f"queue_dir is not a path: {type(raw).__name__}")
+        return Path(raw)
     except Exception as e:
         logger.debug("config_not_available_using_fallback", extra={"error": str(e)})
         return Path(

--- a/tests/test_check_bmad_commands.py
+++ b/tests/test_check_bmad_commands.py
@@ -69,10 +69,20 @@ def _make_skills(base: Path, names: tuple[str, ...]) -> Path:
     return d
 
 
+def _write_skill_frontmatter(skills_dir: Path, name: str, description: str) -> None:
+    """Give an installed skill a SKILL.md carrying *description* in frontmatter."""
+    (skills_dir / name).mkdir(exist_ok=True)
+    (skills_dir / name / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\n# {name}\n",
+        encoding="utf-8",
+    )
+
+
 def _run(
     helper: Path,
     skill_md: Path,
     skills_dir: Path,
+    *extra: str,
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [
@@ -82,6 +92,7 @@ def _run(
             str(skill_md),
             "--skills-dir",
             str(skills_dir),
+            *extra,
         ],
         capture_output=True,
         text=True,
@@ -193,3 +204,77 @@ def test_missing_skill_md_exits_two(helper: Path, tmp_path: Path) -> None:
     assert r.returncode == 2
     assert r.stdout == ""
     assert "not found" in r.stderr
+
+
+# ---------------------------------------------------------------------------
+# --check-deprecated: a shim RESOLVES, so only this mode can catch it (TD-971)
+# ---------------------------------------------------------------------------
+
+
+def test_deprecated_shim_ignored_without_flag(helper: Path, tmp_path: Path) -> None:
+    """Default mode is resolution-only: a shim resolves, so it passes silently.
+
+    This pins the exact gap that let TD-971 survive a green check.
+    """
+    skill_md = _write_skill_md(tmp_path, "`/bmad-create-prd`")
+    skills = _make_skills(tmp_path, ())
+    _write_skill_frontmatter(
+        skills, "bmad-create-prd", "'DEPRECATED — consolidated into bmad-prd.'"
+    )
+    r = _run(helper, skill_md, skills)
+    assert r.returncode == 0
+    assert r.stderr == ""
+
+
+def test_deprecated_shim_fires_with_flag(helper: Path, tmp_path: Path) -> None:
+    skill_md = _write_skill_md(tmp_path, "`/bmad-create-prd`, `/bmad-agent-dev`")
+    skills = _make_skills(tmp_path, ())
+    _write_skill_frontmatter(
+        skills, "bmad-create-prd", "'DEPRECATED — consolidated into bmad-prd.'"
+    )
+    _write_skill_frontmatter(skills, "bmad-agent-dev", "Senior software engineer.")
+    r = _run(helper, skill_md, skills, "--check-deprecated")
+    assert r.returncode == 1
+    assert r.stdout == ""
+    assert "/bmad-create-prd" in r.stderr
+    assert "/bmad-agent-dev" not in r.stderr
+
+
+def test_live_skill_is_silent_with_flag(helper: Path, tmp_path: Path) -> None:
+    skill_md = _write_skill_md(tmp_path, "`/bmad-agent-dev`")
+    skills = _make_skills(tmp_path, ())
+    _write_skill_frontmatter(skills, "bmad-agent-dev", "Senior software engineer.")
+    r = _run(helper, skill_md, skills, "--check-deprecated")
+    assert r.returncode == 0
+    assert r.stdout == ""
+    assert r.stderr == ""
+
+
+def test_body_mention_of_deprecation_not_flagged(helper: Path, tmp_path: Path) -> None:
+    """Only the frontmatter `description:` marks a shim; body prose does not.
+
+    /bmad-create-story says "Performance improvements or deprecations" in its
+    body and is NOT a shim — a body-wide grep would false-positive on it.
+    """
+    skill_md = _write_skill_md(tmp_path, "`/bmad-create-story`")
+    skills = _make_skills(tmp_path, ())
+    (skills / "bmad-create-story").mkdir(exist_ok=True)
+    (skills / "bmad-create-story" / "SKILL.md").write_text(
+        "---\nname: bmad-create-story\ndescription: Creates a story file.\n---\n\n"
+        "# Create Story\n\n- Performance improvements or deprecations\n",
+        encoding="utf-8",
+    )
+    r = _run(helper, skill_md, skills, "--check-deprecated")
+    assert r.returncode == 0
+    assert r.stderr == ""
+
+
+def test_deprecated_flag_degrades_when_bmad_absent(
+    helper: Path, tmp_path: Path
+) -> None:
+    """Graceful degrade still wins over the deprecation pass."""
+    skill_md = _write_skill_md(tmp_path, "`/bmad-agent-dev`")
+    skills = _make_skills(tmp_path, ())
+    r = _run(helper, skill_md, skills, "--check-deprecated")
+    assert r.returncode == 0
+    assert "BMAD not installed" in r.stderr

--- a/tests/test_classifier/test_queue.py
+++ b/tests/test_classifier/test_queue.py
@@ -185,3 +185,31 @@ def test_resolve_queue_dir_uses_config(monkeypatch):
     result = _real_resolve_queue_dir()
 
     assert result == Path("/tmp/test-queue-config-path")
+
+
+@pytest.mark.timeout(10)
+def test_resolve_queue_dir_rejects_non_path_config(monkeypatch, tmp_path):
+    """A mocked config must not steer the queue into a repo-relative MagicMock/ tree.
+
+    MagicMock implements __fspath__, so Path(get_config().queue_dir) SUCCEEDS and
+    yields the relative path "MagicMock/<name>/<id>" rather than raising. The
+    pre-fix except-branch therefore never fired, and enqueue's
+    mkdir(parents=True) wrote that tree into the CWD -- the repo root. A fresh
+    object id per run meant it never collided and grew monotonically
+    (TD-798; duplicates TD-821 / TD-872 / TD-902).
+    """
+    from unittest.mock import MagicMock
+
+    import src.memory.config as config_module
+
+    fallback = tmp_path / "queue"
+    monkeypatch.setenv("AI_MEMORY_QUEUE_DIR", str(fallback))
+    monkeypatch.setattr(config_module, "get_config", lambda: MagicMock())
+
+    result = _real_resolve_queue_dir()
+
+    assert (
+        "MagicMock" not in result.parts
+    ), f"mocked config leaked into the queue path: {result}"
+    assert result.is_absolute(), f"queue dir must be absolute, got {result}"
+    assert result == fallback

--- a/tests/test_pov_skill_activation_truth.py
+++ b/tests/test_pov_skill_activation_truth.py
@@ -1,0 +1,143 @@
+"""Content invariants for the two POV dispatch skills.
+
+These assert against repo-resident SKILL.md files only, so they run everywhere.
+That is deliberate: the repo's .claude/skills/ ships 22 aim-* skills and ZERO
+bmad-*, so any check requiring live BMAD resolution would skip in CI and report
+green while asserting nothing. The live-resolution counterpart lives in
+check_bmad_commands.sh --check-deprecated, which graceful-degrades by design.
+
+Covers:
+  TD-911 -- the slash form is REQUIRED, and the retired "bare /bmad-* activates
+            the lead" theory must not return. A /bmad-* activation failure means
+            CWD drift (PM #415 measured this; the theory was retired).
+  TD-971 -- no deprecated BMAD shim may be referenced by the dispatch tables.
+  TD-890 defect 4 -- Anthropic models are dispatched by TIER ALIAS, never a
+            pinned ID (which has rotted twice). The non-Anthropic verbatim
+            example must survive so the rule's exception stays illustrated.
+
+Scope/blindness, stated: SKILL.md only. These do not read scripts/, workflows/,
+templates/ or references/ in either skill directory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_POV = Path(__file__).resolve().parent.parent / "_ai-memory/pov/skills"
+DISPATCH = _POV / "aim-agent-dispatch/SKILL.md"
+TEAM_BUILDER = _POV / "aim-parzival-team-builder/SKILL.md"
+
+# Shims confirmed against their own frontmatter. A body mention of the word
+# "deprecation" is prose, not a shim marker -- /bmad-create-story says
+# "Performance improvements or deprecations" and is NOT a shim.
+DEPRECATED_SHIMS = (
+    "/bmad-create-prd",
+    "/bmad-validate-prd",
+    "/bmad-edit-prd",
+    "/bmad-create-architecture",
+)
+
+# The theory PM #415 measured as false and retired.
+RETIRED_THEORY = "activates the lead, not the persona"
+
+
+@pytest.fixture(scope="module")
+def dispatch_text() -> str:
+    assert DISPATCH.exists(), f"missing: {DISPATCH}"
+    return DISPATCH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def team_builder_text() -> str:
+    assert TEAM_BUILDER.exists(), f"missing: {TEAM_BUILDER}"
+    return TEAM_BUILDER.read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# TD-911 -- activation truth
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["dispatch", "team_builder"])
+def test_retired_activation_theory_absent(name, request) -> None:
+    text = request.getfixturevalue(f"{name}_text")
+    assert RETIRED_THEORY not in text, (
+        f"{name}: the retired bare-name activation theory has returned. "
+        "PM #415 measured the slash as REQUIRED; an activation failure means "
+        "CWD drift, not an unavailable skill."
+    )
+
+
+def test_dispatch_teaches_slash_form(dispatch_text: str) -> None:
+    assert "the leading `/` is required" in dispatch_text.lower()
+    assert "Use the Skill tool to load /bmad-agent-dev" in dispatch_text
+
+
+def test_team_builder_teaches_slash_form(team_builder_text: str) -> None:
+    assert "The leading `/` is required." in team_builder_text
+    assert "Use the Skill tool to load /bmad-agent-dev" in team_builder_text
+
+
+def test_team_builder_does_not_name_a_nonexistent_skill(
+    team_builder_text: str,
+) -> None:
+    """`bmad-dev` does not exist; the real persona skill is `bmad-agent-dev`."""
+    assert "load bmad-dev" not in team_builder_text
+    assert "`bmad-dev`" not in team_builder_text
+
+
+def test_team_builder_allows_grep_and_bash(team_builder_text: str) -> None:
+    """Frontmatter must not under-declare the tools the skill actually uses."""
+    assert "allowed-tools: Read, Grep, Bash" in team_builder_text
+
+
+def test_dual_review_pair_exception_documented(team_builder_text: str) -> None:
+    assert "dual-review pair (2) is sanctioned" in team_builder_text
+
+
+# --------------------------------------------------------------------------
+# TD-971 -- no deprecated shim referenced
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shim", DEPRECATED_SHIMS)
+def test_no_deprecated_shim_dispatched(dispatch_text: str, shim: str) -> None:
+    """No TABLE ROW may dispatch a shim.
+
+    Scoped to markdown table rows on purpose. A file-wide match would also fire
+    on prose that names a shim in order to explain why it is forbidden -- which
+    would make documenting the rule impossible. The invariant is about what gets
+    dispatched, not about which names may be written down.
+    """
+    rows = [ln for ln in dispatch_text.splitlines() if ln.lstrip().startswith("|")]
+    offenders = [ln for ln in rows if f"`{shim}`" in ln]
+    assert not offenders, (
+        f"{shim} is a deprecated back-compat shim and must not be dispatched. "
+        f"Point the row at the successor named in the shim's description. "
+        f"Offending row(s): {offenders}"
+    )
+
+
+def test_successor_commands_present(dispatch_text: str) -> None:
+    assert "`/bmad-prd`" in dispatch_text
+    assert "`/bmad-architecture`" in dispatch_text
+
+
+# --------------------------------------------------------------------------
+# TD-890 defect 4 -- tier alias, not pinned ID
+# --------------------------------------------------------------------------
+
+
+def test_no_pinned_anthropic_model_id(team_builder_text: str) -> None:
+    assert "claude-sonnet-4-6" not in team_builder_text, (
+        "Anthropic models are dispatched by tier alias (opus/sonnet/haiku). "
+        "A pinned ID has rotted twice, once running both Opus reviewers two "
+        "generations behind on a gate."
+    )
+
+
+def test_non_anthropic_verbatim_example_retained(team_builder_text: str) -> None:
+    """The exception must stay illustrated: non-Anthropic IDs ARE verbatim."""
+    assert "glm-5.1:cloud" in team_builder_text

--- a/tests/test_pov_skill_activation_truth.py
+++ b/tests/test_pov_skill_activation_truth.py
@@ -83,9 +83,15 @@ def test_team_builder_teaches_slash_form(team_builder_text: str) -> None:
 def test_team_builder_does_not_name_a_nonexistent_skill(
     team_builder_text: str,
 ) -> None:
-    """`bmad-dev` does not exist; the real persona skill is `bmad-agent-dev`."""
-    assert "load bmad-dev" not in team_builder_text
-    assert "`bmad-dev`" not in team_builder_text
+    """`bmad-dev` does not exist; the real persona skill is `bmad-agent-dev`.
+
+    Whitespace is normalised first. The defect being pinned was line-wrapped as
+    "load\\n  bmad-dev", so a contiguous "load bmad-dev" match passes vacuously
+    against the very text it is meant to catch.
+    """
+    flat = " ".join(team_builder_text.split())
+    assert "load bmad-dev" not in flat
+    assert "load /bmad-dev" not in flat
 
 
 def test_team_builder_allows_grep_and_bash(team_builder_text: str) -> None:


### PR DESCRIPTION
## Summary

Four fixes across the two POV dispatch skills and the classification queue.

- **TD-911** — both dispatch skills taught a retired activation rule
- **TD-971** — both command tables dispatched deprecated BMAD shims
- **TD-890 (defect 4)** — the dispatch plan schema pinned an Anthropic model ID
- **TD-798** — a mocked config wrote a directory tree into the repository root

---

## TD-911 — activation form

`aim-agent-dispatch` and `aim-parzival-team-builder` both instructed callers to
activate BMAD personas by bare name, on the theory that the slash form
"activates the lead, not the persona". That theory was measured false and
retired. The slash form is required; an activation failure means the teammate
was spawned from the wrong directory, and the correct response is to shut it
down and respawn from the sentinel-verified workspace root — not to conclude
the skill is unavailable, substitute a general-purpose agent, or file-read the
persona.

Two further defects in the same region of `aim-parzival-team-builder`:

- it named `bmad-dev`, which resolves to no installed skill (the persona is
  `bmad-agent-dev`);
- its frontmatter declared `allowed-tools: Read` while the skill also uses Grep
  and Bash, and its pre-dispatch checklist omitted the sanctioned two-agent
  dual-review exception.

## TD-971 — deprecated command references

Both command tables were tested across all 24 referenced commands for
resolution **and** deprecation. All 24 resolve. Four are back-compat shims
whose own frontmatter marks them `DEPRECATED`:

| Referenced command | Successor |
|---|---|
| `/bmad-create-prd` | `/bmad-prd` (create intent) |
| `/bmad-validate-prd` | `/bmad-prd` (validate intent) |
| `/bmad-edit-prd` | `/bmad-prd` (update intent) |
| `/bmad-create-architecture` | `/bmad-architecture` (create intent) |

The rows now name the successor skills. No override files exist for any of the
four (`_bmad/custom/` holds only `config.toml` and `config.user.toml`), so
nothing depended on the shims' back-compat behaviour.

Deprecation is judged only on the frontmatter `description:` field. A body
mention of the word is prose: `/bmad-create-story` contains "Performance
improvements or deprecations" and is **not** a shim.

`check_bmad_commands.sh` tested only whether a command *resolves*. A shim
resolves perfectly, which is why one passed a green check. It gains
`--check-deprecated`, which reads each resolved skill's frontmatter and
degrades gracefully when BMAD is not installed, matching the existing mode.

## TD-890 defect 4 — model identifiers

The dispatch plan schema pinned `claude-sonnet-4-6` in three places, including
the comment that teaches the verbatim-identifier rule. Anthropic models are now
given by tier alias (`opus` / `sonnet` / `haiku`). A pinned identifier has gone
stale twice, once running both reviewers two generations behind on a gate.

The non-Anthropic example `glm-5.1:cloud` is deliberately retained: identifiers
for those providers genuinely must survive verbatim, and the rule's exception
needs to stay illustrated.

## TD-798 — queue directory resolution

`_resolve_queue_dir()` passed the configured value straight to `Path()` inside
a `try/except`. The guard never fired, because nothing raised:

```
MagicMock().queue_dir.__fspath__()  ->  'MagicMock/mock.queue_dir/126278042022256'
```

`MagicMock` implements `__fspath__`, so `Path()` **succeeded** and returned a
*relative* path. `enqueue_for_classification()` then called
`mkdir(parents=True)` on it, creating the tree under the working directory —
the repository root. A fresh object id per run meant it never collided, so it
grew monotonically and always looked freshly introduced.

The resolver now requires a real path type and otherwise falls through to the
existing environment/default branch:

```python
if not isinstance(raw, (str, PurePath)):
    raise TypeError(f"queue_dir is not a path: {type(raw).__name__}")
```

`os.PathLike` cannot be used to discriminate here. It fails in both directions
at once — admitting the mock while rejecting the real production value, which
`config.py` declares as `str`:

| value | `isinstance(str, PurePath)` | `isinstance(os.PathLike)` |
|---|---|---|
| `'~/.ai-memory/queue'` (production) | accept | **False — would reject** |
| `Path('/tmp/q')` | accept | True |
| `MagicMock().queue_dir` | **reject** | **True — would admit** |

Behaviour for real configuration is unchanged: `queue_dir` is a pydantic
`str` field, so it is always accepted.

A `.gitignore` entry for `MagicMock/` is added as a backstop only. The resolver
guard is the fix; the ignore rule exists so a future unhardened path cannot
quietly dirty a diff.

---

## Tests

`tests/test_classifier/test_queue.py` gains a regression test that fails before
the resolver change and passes after. Before:

```
AssertionError: mocked config leaked into the queue path: MagicMock/mock.queue_dir/137502624192496
assert 'MagicMock' not in ('MagicMock', 'mock.queue_dir', '137502624192496')
```

`tests/test_check_bmad_commands.py` gains five cases covering
`--check-deprecated`, including that the default mode stays silent on a shim
(the gap that let this survive) and that a body mention of "deprecation" is not
flagged.

`tests/test_pov_skill_activation_truth.py` is new: content invariants over both
SKILL.md files. 13 of its 14 cases fail against the pre-change files. The
fourteenth asserts the `glm-5.1:cloud` example is retained and holds in both
directions by design.

These assert over repository-resident files rather than live skill resolution.
The repository ships 22 `aim-*` skills and no `bmad-*` ones, so a
resolution-based check would skip in CI and report green while asserting
nothing. Live resolution is covered by `--check-deprecated`, which is run
against an installed BMAD tree.

Run against the pre-change command tables, the new detector independently
rediscovers all four shims:

```
check_bmad_commands: 4 referenced BMAD command(s) resolve but are DEPRECATED shims:
  deprecated: /bmad-create-architecture
  deprecated: /bmad-create-prd
  deprecated: /bmad-edit-prd
  deprecated: /bmad-validate-prd
```

## Scope and known gaps

- The source-versus-reference comparison covered **`SKILL.md` only**. It is
  blind to `scripts/`, `workflows/`, `templates/` and `references/` in those
  two skill directories; divergence there is not ruled out.
- `aim-tracking-rotate/SKILL.md` also diverges, but in the other direction —
  the source is ahead. It is deliberately untouched.
- `shellcheck` reports SC2016 (informational) on `check_bmad_commands.sh`. It
  is pre-existing and unrelated, and the single quotes there are correct.
